### PR TITLE
handle theme folder in newsroom-app/server

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -161,7 +161,6 @@ TEMPLATES_AUTO_RELOAD = True
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'
 
-WEBPACK_MANIFEST_PATH = os.path.join(os.path.dirname(__file__), '..', 'static', 'dist', 'manifest.json')
 WEBPACK_ASSETS_URL = os.environ.get('ASSETS_URL')
 WEBPACK_SERVER_URL = os.environ.get('WEBPACK_SERVER_URL')
 

--- a/newsroom/web/factory.py
+++ b/newsroom/web/factory.py
@@ -35,9 +35,12 @@ class NewsroomWebApp(BaseNewsroomApp):
         self.sidenavs = []
         self.settings_apps = []
         self.dashboards = []
-        self.theme_folder = 'theme'
-
         super(NewsroomWebApp, self).__init__(import_name=import_name, config=config, **kwargs)
+
+        self.theme_folder = self.config.get(
+            "THEME_PATH",
+            os.path.join(self.config["ABS_PATH"], 'theme') if self.config.get("ABS_PATH") else 'theme'
+        )
 
         self._setup_jinja()
         self._setup_limiter()
@@ -84,7 +87,10 @@ class NewsroomWebApp(BaseNewsroomApp):
         self.add_template_global(self.settings_apps, 'settings_apps')
         self.add_template_global(get_multi_line_message)
 
-        jinja2_loaders = []
+        jinja2_loaders = [
+            jinja2.FileSystemLoader(self.theme_folder),
+        ]
+
         # ABS_PATH is set only for the instance settings and not set for a test app instance
         if 'ABS_PATH' in self.config:
             jinja2_loaders.append(
@@ -111,7 +117,7 @@ class NewsroomWebApp(BaseNewsroomApp):
             self.static_url_path.replace('static', 'theme') + '/<path:filename>',
             endpoint='theme',
             host=self.static_host,
-            view_func=self.send_theme_file
+            view_func=self.send_theme_file,
         )
 
     def download_formatter(self, _format, formatter, name, types, assets=None):

--- a/newsroom/webpack.py
+++ b/newsroom/webpack.py
@@ -25,9 +25,21 @@ session = requests.Session()
 class NewsroomWebpack(Webpack):
 
     def init_app(self, app):
+        app.config.setdefault(
+            "WEBPACK_MANIFEST_PATH",
+            os.path.join(
+                app.config["ABS_PATH"].parent,
+                "client",
+                "dist",
+                "manifest.json",
+            ) if app.config.get("ABS_PATH") else None,
+        )
+
         super(NewsroomWebpack, self).init_app(app)
+
         if not app.config.get('DEBUG'):  # let us change debug flag later
             app.before_request(self._refresh_webpack_stats_if_debug)
+
         app.add_url_rule('/static/dist/<path:filename>', 'asset', send_asset)
 
     def _refresh_webpack_stats_if_debug(self):


### PR DESCRIPTION
and set default for webpack manifest path
so we don't have to put this in each app settings

SDESK-6200