### PR TITLE
fix webpack assets handling in docker

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -163,7 +163,7 @@ TEMPLATES_AUTO_RELOAD = True
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'
 
-WEBPACK_ASSETS_URL = os.environ.get('ASSETS_URL')
+WEBPACK_ASSETS_URL = os.environ.get('WEBPACK_ASSETS_URL')
 WEBPACK_SERVER_URL = os.environ.get('WEBPACK_SERVER_URL')
 
 # How many days a new account can stay active before it is approved by admin

--- a/newsroom/webpack.py
+++ b/newsroom/webpack.py
@@ -58,7 +58,6 @@ class NewsroomWebpack(Webpack):
         if app.config.get('WEBPACK_SERVER_URL'):
             try:
                 self.assets = session.get(urljoin(app.config['WEBPACK_SERVER_URL'], 'manifest.json'), timeout=5).json()
-                self.assets_url = app.config['WEBPACK_SERVER_URL']
                 return
             except requests.exceptions.ConnectionError:
                 raise RuntimeError(


### PR DESCRIPTION
use assets url for client and server url when fetching manifest file on the server