### PR TITLE
[NHUB-22] Show list of Authors in Wire Preview

### DIFF
--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -389,7 +389,7 @@ article.list {
         height: 45px;
     }
     &:focus {
-        outline: 0;       
+        outline: 0;
     }
     &:focus-visible {
         box-shadow: inset 0 0 0 1px rgba(0, 172, 236, .6), inset 0 0 3px 4px rgba(0, 172, 236, .4);
@@ -667,7 +667,7 @@ article.list {
         &:focus {
             background: #fff;
             //box-shadow: inset 0 0 0 1px rgba(61,143,177,0.5), inset 0 0 0 6px rgba(61,143,177,0.15);
-            box-shadow: inset 0 0 0 1px rgba(0, 172, 236, .5), inset 0 0 0 6px rgba(0, 172, 236, .2);        
+            box-shadow: inset 0 0 0 1px rgba(0, 172, 236, .5), inset 0 0 0 6px rgba(0, 172, 236, .2);
         }
     }
     @include sm {
@@ -1078,7 +1078,7 @@ article.list {
             border-bottom: 3px solid $main-blue;
         }
         &:focus {
-            outline: 0;       
+            outline: 0;
         }
         &:focus-visible {
             box-shadow: 0 0 0 1px rgba(0, 172, 236, .6), 0 0 3px 4px rgba(0, 172, 236, .4);
@@ -2657,7 +2657,7 @@ a.wire-articles__versions {
         text-decoration: none;
     }
     &:focus {
-        outline: 0;       
+        outline: 0;
     }
     &:focus-visible {
         box-shadow: 0 0 0 1px rgba(0, 172, 236, .6), 0 0 3px 4px rgba(0, 172, 236, .4);
@@ -2724,6 +2724,33 @@ a.wire-articles__versions {
     line-height: 1.3;
     margin-top: 5px;
     margin-bottom: 0px;
+}
+
+.wire-column__preview__item__author {
+    display: flex;
+    flex-direction: column;
+
+    h5 {
+        font-size: 0.6875rem;
+        color: $body-text;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        margin-bottom: 5px;
+        display: block;
+    }
+
+    h6 {
+        color: $body-text;
+        font-weight: $font-weight-medium;
+    }
+
+    p {
+        color: $gray-dark;
+        font-size: 0.8125rem;
+        line-height: 1.4;
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 }
 
 .content--item-detail {

--- a/assets/wire/components/ItemDetails.jsx
+++ b/assets/wire/components/ItemDetails.jsx
@@ -34,6 +34,7 @@ import ArticleBody from 'ui/components/ArticleBody';
 import ArticleAuthor from 'ui/components/ArticleAuthor';
 import ArticleEmbargoed from 'ui/components/ArticleEmbargoed';
 import PreviewEdnote from './PreviewEdnote';
+import {Authors} from './fields/Authors';
 
 
 function ItemDetails({
@@ -91,6 +92,10 @@ function ItemDetails({
                         <ArticleContentInfoWrapper>
                             {isDisplayed('tags_section', detailsConfig) &&
                                 <PreviewTags item={item} isItemDetail={true} displayConfig={detailsConfig}/>}
+
+                            {!isDisplayed('authors', detailsConfig) ? null : (
+                                <Authors item={item} />
+                            )}
 
                             {isDisplayed('ednotes_section', detailsConfig) &&
                                 <PreviewEdnote item={item} />}

--- a/assets/wire/components/ItemDetails.jsx
+++ b/assets/wire/components/ItemDetails.jsx
@@ -93,7 +93,7 @@ function ItemDetails({
                             {isDisplayed('tags_section', detailsConfig) &&
                                 <PreviewTags item={item} isItemDetail={true} displayConfig={detailsConfig}/>}
 
-                            {!isDisplayed('authors', detailsConfig) ? null : (
+                            {isDisplayed('authors', detailsConfig) && (
                                 <Authors item={item} />
                             )}
 

--- a/assets/wire/components/WirePreview.jsx
+++ b/assets/wire/components/WirePreview.jsx
@@ -97,7 +97,7 @@ class WirePreview extends React.PureComponent {
                     {isDisplayed('tags_section', previewConfig) &&
                         <PreviewTags item={item} isItemDetail={false} displayConfig={previewConfig}/>}
 
-                    {!isDisplayed('authors', previewConfig) ? null : (
+                    {isDisplayed('authors', previewConfig) && (
                         <Authors item={item} />
                     )}
 

--- a/assets/wire/components/WirePreview.jsx
+++ b/assets/wire/components/WirePreview.jsx
@@ -31,6 +31,7 @@ import PreviewTags from './PreviewTags';
 import PreviewMeta from './PreviewMeta';
 import AgendaLinks from './AgendaLinks';
 import PreviewEdnote from './PreviewEdnote';
+import {Authors} from './fields/Authors';
 
 
 class WirePreview extends React.PureComponent {
@@ -95,6 +96,10 @@ class WirePreview extends React.PureComponent {
 
                     {isDisplayed('tags_section', previewConfig) &&
                         <PreviewTags item={item} isItemDetail={false} displayConfig={previewConfig}/>}
+
+                    {!isDisplayed('authors', previewConfig) ? null : (
+                        <Authors item={item} />
+                    )}
 
                     {isDisplayed('ednotes_section', previewConfig) &&
                                 <PreviewEdnote item={item} />}

--- a/assets/wire/components/fields/Authors.jsx
+++ b/assets/wire/components/fields/Authors.jsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import {gettext} from 'utils';
+
+import InfoBox from '../InfoBox';
+
+export function Authors({item}) {
+    if (!item || !item.authors || !item.authors.length) {
+        return null;
+    }
+
+    return (
+        <InfoBox label={gettext('Authors')}>
+            {item.authors.map((author) => (
+                <div key={author.code + '/' + author.role} className="wire-column__preview__item__author">
+                    <h5>{author.role}</h5>
+                    <h6>{author.name}</h6>
+                    {(!author.biography || !author.biography.length) ? null : (
+                        <p>{author.biography.split('\n').map((item, key) => (
+                            <span key={key}>{item}<br/></span>
+                        ))}</p>
+                    )}
+                </div>
+            ))}
+        </InfoBox>
+    );
+}
+
+Authors.propTypes = {
+    item: PropTypes.shape({
+        authors: PropTypes.arrayOf(PropTypes.shape({
+            code: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+            role: PropTypes.string.isRequired,
+            biography: PropTypes.string,
+        })),
+    }),
+};


### PR DESCRIPTION
On by default, if the list of Authors is not empty for the item.

Can be turned off with the following `ui_config`

```json
[{
    "_id": "wire",
    "preview": {
        "authors": {"displayed": false}
    }
}]
```