### PR TITLE
[NHUB-96] Improve notifications to handle more message types

### DIFF
--- a/assets/components/NotificationListItem.jsx
+++ b/assets/components/NotificationListItem.jsx
@@ -1,36 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {gettext, shortDate} from 'utils';
 import CloseButton from './CloseButton';
+import {renderNotificationComponent} from 'notifications/components/notificationItems';
 
-
-const getAgendaNotification = (item) => [
-    <div key='message' className="notif__list__info">{gettext('An event you are watching has been updated')}</div>,
-    <div key='name' className="notif__list__headline">
-        <a href={`/agenda?item=${item._id}`} >{item.name}</a>
-    </div>];
-
-const getWireNotification = (item) => [
-    <div key='message' className="notif__list__info">{gettext('A story you downloaded has been updated')}</div>,
-    <div key='name' className="notif__list__headline">
-        <a href={`/wire?item=${item._id}`} >{item.headline}</a>
-    </div>];
-
-function NotificationListItem({item, clearNotification}) {
-    
+function NotificationListItem({notification, item, clearNotification}) {
     return (
         <div key={item._id} className='notif__list__item'>
             <CloseButton onClick={() => clearNotification(item._id)}/>
-            {item.type === 'text' ? getWireNotification(item) : getAgendaNotification(item)}
-            <div className='wire-articles__item__meta-info'>
-                {gettext('Created on')} {shortDate(item.versioncreated)}
-            </div>
+            {renderNotificationComponent(notification, item)}
         </div>);
-   
+
 }
 
 NotificationListItem.propTypes = {
+    notification: PropTypes.object,
     item: PropTypes.object,
     clearNotification: PropTypes.func,
 };

--- a/assets/notifications/components/BasicNotificationItem.jsx
+++ b/assets/notifications/components/BasicNotificationItem.jsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+export function BasicNotificationItem({header, body, url, footer}) {
+    return (
+        <React.Fragment>
+            {header == null ? null : (
+                <div className="notif__list__info">{header}</div>
+            )}
+            {body == null ? null : (
+                <div className="notif__list__headline">
+                    {url != null ? (<a href={url}>{body}</a>) : body}
+                </div>
+            )}
+            {footer == null ? null : (
+                <div className='wire-articles__item__meta-info'>
+                    {footer}
+                </div>
+            )}
+        </React.Fragment>
+    );
+}
+
+BasicNotificationItem.propTypes = {
+    header: PropTypes.string,
+    body: PropTypes.string,
+    url: PropTypes.string,
+    footer: PropTypes.string,
+};

--- a/assets/notifications/components/NotificationsApp.jsx
+++ b/assets/notifications/components/NotificationsApp.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {
     deleteNotification,
-    deleteAllNotifications
+    deleteAllNotifications,
+    loadNotifications,
 } from '../actions';
 
 import NotificationList from 'components/NotificationList';
@@ -15,10 +16,15 @@ class NotificationsApp extends React.Component {
 
     render() {
         return [
-            <NotificationList key="notifications"
+            <NotificationList
+                key="notifications"
                 notifications={this.props.notifications}
+                items={this.props.items}
+                count={this.props.count}
                 clearNotification={this.props.clearNotification}
                 clearAll={this.props.clearAll}
+                loadNotifications={this.props.loadNotifications}
+                loading={this.props.loading}
             />,
         ];
     }
@@ -26,19 +32,27 @@ class NotificationsApp extends React.Component {
 
 NotificationsApp.propTypes = {
     user: PropTypes.string,
+    items: PropTypes.object,
     notifications: PropTypes.arrayOf(PropTypes.object),
+    count: PropTypes.number,
     clearNotification: PropTypes.func,
     clearAll: PropTypes.func,
+    loadNotifications: PropTypes.func,
+    loading: PropTypes.bool,
 };
 
 const mapStateToProps = (state) => ({
     user: state.user,
+    items: state.items,
     notifications: state.notifications,
+    count: state.notificationCount,
+    loading: state.loading,
 });
 
 const mapDispatchToProps = (dispatch) => ({
     clearNotification: (id) => dispatch(deleteNotification(id)),
     clearAll: () => dispatch(deleteAllNotifications()),
+    loadNotifications: () => dispatch(loadNotifications()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NotificationsApp);

--- a/assets/notifications/components/notificationItems.jsx
+++ b/assets/notifications/components/notificationItems.jsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+import {get} from 'lodash';
+
+import {gettext, shortDate} from 'utils';
+import {BasicNotificationItem} from './BasicNotificationItem';
+
+export const registeredNotifications = [];
+
+export function registerNotification(condition, component) {
+    registeredNotifications.unshift({condition, component});
+}
+
+export function renderNotificationComponent(notification, item) {
+    let notificationEntry = registeredNotifications.find(
+        (entry) => entry.condition(notification, item)
+    );
+
+    if (notificationEntry == null || notificationEntry.component == null) {
+        console.error('Unable to find Notification Item component', notification, item);
+
+        return null;
+    }
+
+    return notificationEntry.component(notification, item);
+}
+
+function getNotificationFooterText(notification) {
+    switch (notification.action) {
+    case 'share':
+        return gettext('Shared by {{ first_name }} {{ last_name }} on {{ datetime }}', {
+            first_name: get(notification, 'data.shared_by.first_name'),
+            last_name: get(notification, 'data.shared_by.last_name'),
+            datetime: shortDate(notification.created),
+        });
+    case 'topic_matches':
+        return gettext('Created on {{ datetime }}', {datetime: shortDate(notification.created)});
+    case 'history_match':
+    default:
+        return gettext('Updated on {{ datetime }}', {datetime: shortDate(notification.created)});
+    }
+}
+
+function getNotificationUrl(notification, item) {
+    if (get(notification, 'data.url')) {
+        return notification.data.url;
+    }
+
+    return notification.resource === 'agenda' ?
+        `/wire?item=${item._id}` :
+        `/agenda?item=${item._id}`;
+}
+
+function getNotificationName(item) {
+    return item.label || item.name || item.headline || item.slugline;
+}
+
+// New Wire item that matches action history (such as item Downloaded)
+registerNotification(
+    (notification, item) => (
+        (get(notification, 'action') === 'history_match' && get(notification, 'resource') === 'text') ||
+        // Fallback Wire notification (legacy functionality)
+        get(notification, 'resource') === 'text' || item.type === 'text'
+    ),
+    (notification, item) => (
+        <BasicNotificationItem
+            header={gettext('A story you downloaded has been updated')}
+            body={getNotificationName(item)}
+            url={getNotificationUrl(notification, item)}
+            footer={getNotificationFooterText(notification)}
+        />
+    )
+);
+
+// New Agenda item that matches action history (such as item Downloaded)
+registerNotification(
+    (notification, item) => (
+        (get(notification, 'action') === 'history_match' && get(notification, 'resource') === 'agenda') ||
+        (get(notification, 'action') === 'watched_agenda_updated') ||
+        // Fallback Agenda notification (legacy functionality)
+        get(notification, 'resource') === 'agenda' || item.type === 'agenda'
+    ),
+    (notification, item) => (
+        <BasicNotificationItem
+            header={gettext('An event you are watching has been updated')}
+            body={getNotificationName(item)}
+            url={getNotificationUrl(notification, item)}
+            footer={getNotificationFooterText(notification)}
+        />
+    )
+);
+
+// New Wire/Agenda item matches a subscribed topic
+registerNotification(
+    (notification) => (
+        get(notification, 'action') === 'topic_matches' &&
+        ['text', 'wire', 'items', 'agenda'].includes(get(notification, 'resource'))
+    ),
+    (notification, item) => (
+        <BasicNotificationItem
+            header={notification.resource === 'agenda' ?
+                gettext('An Agenda item has arrived that matches a subscribed topic') :
+                gettext('A story has arrived that matches a subscribed topic')
+            }
+            body={getNotificationName(item)}
+            url={getNotificationUrl(notification, item)}
+            footer={getNotificationFooterText(notification)}
+        />
+    )
+);
+
+// A Topic was shared with this User
+registerNotification(
+    (notification) => (
+        notification &&
+        notification.action === 'share' &&
+        notification.resource === 'topic'
+    ),
+    (notification, item) => (
+        <BasicNotificationItem
+            header={item.topic_type === 'agenda' ?
+                gettext('An Agenda Topic has been shared with you') :
+                gettext('A Wire Topic has been shared with you')
+            }
+            body={getNotificationName(item)}
+            url={getNotificationUrl(notification, item)}
+            footer={getNotificationFooterText(notification)}
+        />
+    )
+);
+
+// A Wire/Agenda item was shared with this user
+registerNotification(
+    (notification) => (
+        get(notification, 'action') === 'share' &&
+        ['text', 'wire', 'items', 'agenda'].includes(get(notification, 'resource'))
+    ),
+    (notification, item) => (
+        <BasicNotificationItem
+            header={notification.resource === 'agenda' ?
+                gettext('An Agenda item was shared with you') :
+                gettext('A Wire item was shared with you')
+            }
+            body={getNotificationName(item)}
+            url={getNotificationUrl(notification, item)}
+            footer={getNotificationFooterText(notification)}
+        />
+    )
+);

--- a/assets/notifications/components/notificationItems.jsx
+++ b/assets/notifications/components/notificationItems.jsx
@@ -46,8 +46,8 @@ function getNotificationUrl(notification, item) {
     }
 
     return notification.resource === 'agenda' ?
-        `/wire?item=${item._id}` :
-        `/agenda?item=${item._id}`;
+        `/agenda?item=${item._id}` :
+        `/wire?item=${item._id}`;
 }
 
 function getNotificationName(item) {

--- a/assets/notifications/reducers.js
+++ b/assets/notifications/reducers.js
@@ -1,6 +1,7 @@
-
 import {
-    NEW_NOTIFICATION,
+    UPDATE_NOTIFICATION_COUNT,
+    SET_NOTIFICATIONS,
+    SET_NOTIFICATIONS_LOADING,
     INIT_DATA,
     CLEAR_NOTIFICATION,
     CLEAR_ALL_NOTIFICATIONS,
@@ -8,18 +9,36 @@ import {
 
 const initialState = {
     user: null,
+    items: {},
     notifications: [],
+    notificationCount: 0,
+    loading: false,
 };
 
 export default function notificationReducer(state = initialState, action) {
     switch (action.type) {
-
-    case NEW_NOTIFICATION: {
-        const notifications = state.notifications.concat([action.notification.item]);
-
+    case SET_NOTIFICATIONS:
         return {
             ...state,
-            notifications,
+            notifications: action.notifications,
+            notificationCount: action.notifications.length,
+            items: action.items.reduce((itemMap, item) => {
+                itemMap[item._id] = item;
+
+                return itemMap;
+            }, {}),
+        };
+
+    case SET_NOTIFICATIONS_LOADING:
+        return {
+            ...state,
+            loading: action.loading,
+        };
+
+    case UPDATE_NOTIFICATION_COUNT: {
+        return {
+            ...state,
+            notificationCount: state.notificationCount + action.count,
         };
     }
 
@@ -27,14 +46,16 @@ export default function notificationReducer(state = initialState, action) {
         return {
             ...state,
             notifications: [],
+            notificationCount: 0,
         };
 
 
     case CLEAR_NOTIFICATION:{
-        const notifications = state.notifications.filter((n) => n._id !== action.id);
+        const notifications = state.notifications.filter((n) => n.item !== action.id);
         return {
             ...state,
-            notifications,
+            notifications: notifications,
+            notificationCount: notifications.length,
         };
     }
 
@@ -42,7 +63,10 @@ export default function notificationReducer(state = initialState, action) {
         return {
             ...state,
             user: action.data.user || null,
-            notifications: action.data.notifications || [],
+            items: {},
+            notifications: [],
+            notificationCount: action.data.notificationCount,
+            loading: false,
         };
     }
 

--- a/assets/styles/navbar.scss
+++ b/assets/styles/navbar.scss
@@ -78,6 +78,10 @@
         color: $body-text;
         font-weight: 700;
     }
+    .notif__list__message {
+        padding: 10px 12px;
+        margin: 10px;
+    }
     .notif__list__item {
         background: #fff;
         box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.2);

--- a/newsroom/notifications/__init__.py
+++ b/newsroom/notifications/__init__.py
@@ -1,4 +1,8 @@
+from typing import List, Dict, Any, Optional
+from typing_extensions import TypedDict
+
 import flask
+from bson import ObjectId
 import superdesk
 
 from superdesk.notification import push_notification  # noqa
@@ -14,6 +18,32 @@ def push_user_notification(name, **kwargs):
 def push_company_notification(name, **kwargs):
     company_id = get_user().get('company')
     push_notification(f'{name}:company-{company_id}', **kwargs)
+
+
+class UserNotification(TypedDict):
+    resource: str
+    action: str
+    user: ObjectId
+    item: str
+    data: Optional[Dict[str, Any]]
+
+
+def save_user_notifications(entries: List[UserNotification]):
+    service = superdesk.get_resource_service("notifications")
+    notification_ids = service.post(entries)
+    new_notifications = service.get_items(notification_ids)
+
+    # Iterate over the new notifications and collect the number
+    # of new notifications per user
+    notification_counts: Dict[str, int] = {}
+    for entry in new_notifications:
+        user_id = str(entry["user"])
+        notification_counts.setdefault(user_id, 0)
+        notification_counts[user_id] += 1
+
+    # We only send the additional notification counts, and leave it up to the client
+    # to request the list of notifications, when required
+    push_notification("new_notifications", counts=notification_counts)
 
 
 from .notifications import NotificationsResource, NotificationsService, get_user_notifications  # noqa

--- a/newsroom/notifications/notifications.py
+++ b/newsroom/notifications/notifications.py
@@ -17,10 +17,13 @@ class NotificationsResource(newsroom.Resource):
     item_methods = ['GET', 'PATCH', 'DELETE']
 
     schema = {
-        '_id': {'type': 'string', 'unique': True},
-        'item': newsroom.Resource.rel('items'),
-        'user': newsroom.Resource.rel('users'),
-        'created': {'type': 'dict', 'nullable': True},
+        "_id": {"type": "string", "unique": True},
+        "item": newsroom.Resource.rel("items"),
+        "user": newsroom.Resource.rel("users"),
+        "created": {"type": "datetime", "nullable": True},
+        "resource": {"type": "string"},
+        "action": {"type": "string"},
+        "data": {"type": "dict", "schema": {}, "allow_unknown": True},
     }
 
     datasource = {
@@ -33,19 +36,39 @@ class NotificationsResource(newsroom.Resource):
 
 
 class NotificationsService(newsroom.Service):
-    def create(self, docs):
+    def create(self, docs, **kwargs):
         now = utcnow()
+        ids = []
 
         for doc in docs:
-            id = '_'.join(map(str, [doc['user'], doc['item']]))
+            notification_id = "_".join(map(str, [doc["user"], doc["item"]]))
+            ids.append(notification_id)
             try:
                 super().create([{
-                    '_id': id,
-                    'created': now, 'user': ObjectId(doc['user']), 'item': doc['item']
+                    "_id": notification_id,
+                    "created": now,
+                    "user": ObjectId(doc["user"]),
+                    "item": doc["item"],
+                    "resource": doc.get("resource"),
+                    "action": doc.get("action"),
+                    "data": doc.get("data"),
                 }])
             except (werkzeug.exceptions.Conflict, pymongo.errors.BulkWriteError):
-                original = super().find_one(req=None, _id=id)
-                super().update(id=id, updates={'created': now}, original=original)
+                original = super().find_one(req=None, _id=notification_id)
+                super().update(
+                    id=notification_id,
+                    updates={
+                        "created": now,
+                        "action": doc.get("action") or original.get("action"),
+                        "data": doc.get("data") or original.get("data"),
+                    },
+                    original=original
+                )
+
+        return ids
+
+    def get_items(self, item_ids):
+        return self.get(req=None, lookup={"_id": {"$in": item_ids}})
 
 
 def get_user_notifications(user_id):
@@ -63,21 +86,42 @@ def get_initial_notifications():
     Returns the stories that user has notifications for
     :return: List of stories
     """
-    if not session.get('user'):
+    if not session.get("user"):
         return None
 
-    saved_notifications = get_user_notifications(session['user'])
-    item_ids = [n['item'] for n in saved_notifications]
+    saved_notifications = get_user_notifications(session["user"])
+
+    return {
+        "user": str(session["user"]) if session["user"] else None,
+        "notificationCount": len(list(saved_notifications))
+    }
+
+
+def get_notifications_with_items():
+    """
+    Returns the stories that user has notifications for
+    :return: List of stories
+    """
+    if not session.get("user"):
+        return None
+
+    saved_notifications = get_user_notifications(session["user"])
+    item_ids = [n["item"] for n in saved_notifications]
     items = []
     try:
-        items.extend(superdesk.get_resource_service('wire_search').get_items(item_ids))
+        items.extend(superdesk.get_resource_service("wire_search").get_items(item_ids))
     except (KeyError, TypeError):  # wire disabled
         pass
     try:
-        items.extend(superdesk.get_resource_service('agenda').get_items(item_ids))
+        items.extend(superdesk.get_resource_service("agenda").get_items(item_ids))
     except (KeyError, TypeError):  # agenda disabled
         pass
+    try:
+        items.extend(superdesk.get_resource_service("topics").get_items(item_ids))
+    except (KeyError, TypeError):  # topics disabled
+        pass
     return {
-        'user': str(session['user']) if session['user'] else None,
-        'notifications': list(items),
+        "user": str(session["user"]) if session["user"] else None,
+        "items": list(items),
+        "notifications": saved_notifications,
     }

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -11,7 +11,7 @@ from superdesk.text_utils import get_word_count, get_char_count
 from superdesk.utc import utcnow
 from planning.common import WORKFLOW_STATE
 
-from newsroom.notifications import push_notification
+from newsroom.notifications import push_notification, save_user_notifications, UserNotification
 from newsroom.topics.topics import get_agenda_notification_topics_for_query_by_id, get_topics_with_subscribers
 from newsroom.utils import parse_dates, get_user_dict, get_company_dict, parse_date_str
 from newsroom.email import send_new_item_notification_email, \
@@ -670,17 +670,17 @@ def notify_user_matches(item, users_dict, companies_dict, user_ids, company_ids)
         if not users_ids:
             return
 
-        app.data.insert('notifications', [
-            {'item': item['_id'], 'user': user}
+        save_user_notifications([
+            UserNotification(
+                user=user,
+                item=item["_id"],
+                resource=item.get("type"),
+                action="history_match",
+                data=None,
+            )
             for user in users_ids
         ])
 
-        push_notification(
-            'history_matches',
-            item=item,
-            users=users_ids,
-            section=section
-        )
         send_user_notification_emails(
             item,
             users_ids,
@@ -753,11 +753,19 @@ def send_topic_notification_emails(item, topics, topic_matches, users):
             user = users.get(str(user_id))
 
             if user and user.get('receive_email'):
+                section = topic.get("topic_type") or "wire"
+                save_user_notifications([UserNotification(
+                    user=user["_id"],
+                    item=item["_id"],
+                    resource=section,
+                    action="topic_matches",
+                    data=None,
+                )])
                 send_new_item_notification_email(
                     user,
                     topic['label'],
                     item=item,
-                    section=topic.get('topic_type') or 'wire'
+                    section=section,
                 )
 
 

--- a/newsroom/topics/topics.py
+++ b/newsroom/topics/topics.py
@@ -49,6 +49,9 @@ class TopicsService(newsroom.Service):
         if original.get('is_global') and 'is_global' in updates and not updates.get('is_global'):
             updates['subscribers'] = [original['user']] if original['user'] in original['subscribers'] else []
 
+    def get_items(self, item_ids):
+        return self.get(req=None, lookup={"_id": {"$in": item_ids}})
+
 
 def get_user_topics(user_id):
     user = superdesk.get_resource_service('users').find_one(req=None, _id=ObjectId(user_id))

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -12,7 +12,7 @@ from newsroom.auth.views import send_token, add_token_data, \
     is_current_user_admin, is_current_user, is_current_user_account_mgr
 from newsroom.decorator import admin_only, login_required, account_manager_only
 from newsroom.companies import get_user_company_name, get_company_sections_monitoring_data
-from newsroom.notifications.notifications import get_user_notifications
+from newsroom.notifications.notifications import get_notifications_with_items
 from newsroom.notifications import push_user_notification, push_company_notification
 from newsroom.topics import get_user_topics
 from newsroom.users import blueprint
@@ -209,7 +209,8 @@ def post_topic(_id):
 def get_notifications(user_id):
     if flask.session['user'] != str(user_id):
         flask.abort(403)
-    return jsonify({'_items': get_user_notifications(user_id)}), 200
+
+    return jsonify(get_notifications_with_items()), 200
 
 
 @blueprint.route('/users/<user_id>/notifications', methods=['DELETE'])

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -26,7 +26,7 @@ from newsroom.email import send_template_email
 from newsroom.companies import get_user_company
 from newsroom.utils import get_entity_or_404, get_json_or_400, parse_dates, get_type, is_json_request, query_resource, \
     get_agenda_dates, get_location_string, get_public_contacts, get_links, get_items_for_user_action
-from newsroom.notifications import push_user_notification, push_notification
+from newsroom.notifications import push_user_notification, push_notification, save_user_notifications, UserNotification
 from newsroom.companies import section
 from newsroom.template_filters import is_admin_or_internal
 
@@ -283,6 +283,21 @@ def share():
             template_kwargs['contactList'] = [get_public_contacts(item) for item in items]
             template_kwargs['linkList'] = [get_links(item) for item in items]
             template_kwargs['is_admin'] = is_admin_or_internal(user)
+
+        save_user_notifications([UserNotification(
+            resource=item_type,
+            action="share",
+            user=user["_id"],
+            item=items[0]["_id"],
+            data=dict(
+                shared_by=dict(
+                    _id=current_user["_id"],
+                    first_name=current_user["first_name"],
+                    last_name=current_user["last_name"],
+                ),
+                items=[i["_id"] for i in items]
+            ),
+        )])
 
         send_template_email(
             to=[user["email"]],

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,11 @@ honcho>=1.0.1
 gunicorn>=20.0.4,<20.1
 PyRTF3>=0.47.5
 xhtml2pdf>=0.2.4
+
+# Fix an issue between xhtml2pdf v0.2.4 and reportlab v3.6.7
+# https://github.com/xhtml2pdf/xhtml2pdf/issues/589
+reportlab==3.6.6
+
 elastic-apm[flask]>=6.7,<6.8
 
 

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -67,14 +67,14 @@ def test_delete_notification(client):
 
     resp = client.get(notifications_url)
     data = json.loads(resp.get_data())
-    id = data['_items'][0]['_id']
+    notify_id = data['notifications'][0]['_id']
 
-    resp = client.delete('/users/{}/notifications/{}'.format(user, id))
+    resp = client.delete('/users/{}/notifications/{}'.format(user, notify_id))
     assert 200 == resp.status_code
 
     resp = client.get(notifications_url)
     data = json.loads(resp.get_data())
-    assert 0 == len(data['_items'])
+    assert 0 == len(data['notifications'])
 
 
 def test_delete_all_notifications(client):
@@ -92,11 +92,11 @@ def test_delete_all_notifications(client):
 
     resp = client.get(notifications_url)
     data = json.loads(resp.get_data())
-    assert 2 == len(data['_items'])
+    assert 2 == len(data['notifications'])
 
     resp = client.delete('/users/{}/notifications'.format(user))
     assert 200 == resp.status_code
 
     resp = client.get(notifications_url)
     data = json.loads(resp.get_data())
-    assert 0 == len(data['_items'])
+    assert 0 == len(data['notifications'])


### PR DESCRIPTION
Improves notifications by:
* Only sending `count` with websocket notifications, and not the `notification` or `content item`
* Only loading notifications and their associated items if notification bar is open
* Adding the ability to register new notification message types
* Add new notifications for shared Wire, Agenda and Topics, as well as when new content arrives that matches a Topic