### PR TITLE
[CPNHUB-10] fix: Use ObjectId for Navigation Company IDs

### DIFF
--- a/data_updates/00006_20220223-155546_products.py
+++ b/data_updates/00006_20220223-155546_products.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Mark Pittaway
+# Creation: 2022-02-23 15:55
+
+from bson import ObjectId
+from eve.utils import config
+from superdesk.commands.data_updates import DataUpdate as _DataUpdate
+
+
+class DataUpdate(_DataUpdate):
+
+    resource = 'products'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        for product in mongodb_collection.find({}):
+            if not product.get("companies"):
+                continue
+
+            print(mongodb_collection.update(
+                {config.ID_FIELD: product.get(config.ID_FIELD)},
+                {
+                    "$set": {
+                        "companies": [
+                            ObjectId(company_id)
+                            for company_id in product.get("companies")
+                        ]
+                    }
+                }
+            ))
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        raise NotImplementedError()

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -147,9 +147,9 @@ def update_products(updates, company_id):
     db = app.data.get_mongo_collection('products')
     for product in products:
         if updates.get(str(product['_id'])):
-            db.update_one({'_id': product['_id']}, {'$addToSet': {'companies': company_id}})
+            db.update_one({'_id': product['_id']}, {'$addToSet': {'companies': ObjectId(company_id)}})
         else:
-            db.update_one({'_id': product['_id']}, {'$pull': {'companies': company_id}})
+            db.update_one({'_id': product['_id']}, {'$pull': {'companies': ObjectId(company_id)}})
 
 
 def update_company(data, _id):

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -122,7 +122,7 @@ class NewsAPINewsService(BaseSearchService):
         if search.args.get('products'):
             search.products = list(get_resource_service('products').get(req=None, lookup={
                 'is_enabled': True,
-                'companies': str(search.company['_id']),
+                'companies': ObjectId(search.company['_id']),
                 '_id': {
                     '$in': [
                         ObjectId(pid)

--- a/newsroom/news_api/products/resource.py
+++ b/newsroom/news_api/products/resource.py
@@ -24,7 +24,7 @@ class NewsAPIProductsService(ProductsService):
         req.projection = self.allowed_fields
         if '_id' in lookup and isinstance(lookup['_id'], str):
             lookup['_id'] = ObjectId(lookup.get('_id'))
-        lookup['companies'] = str(g.user)
+        lookup['companies'] = ObjectId(g.user)
         item = super().find_one(req, **lookup)
         return item
 
@@ -34,7 +34,7 @@ class NewsAPIProductsService(ProductsService):
         if not req:
             req = ParsedRequest()
         req.projection = self.allowed_fields
-        lookup['companies'] = str(company_id)
+        lookup['companies'] = ObjectId(company_id)
         lookup['product_type'] = 'news_api'
         return super().get(req=req, lookup=lookup)
 

--- a/newsroom/products/products.py
+++ b/newsroom/products/products.py
@@ -36,6 +36,7 @@ class ProductsResource(newsroom.Resource):
         },
         'companies': {
             'type': 'list',
+            "schema": newsroom.Resource.rel("companies"),
             'nullable': True,
         },
         'product_type': {
@@ -84,7 +85,7 @@ def get_product_by_id(product_id, product_type=None, company_id=None):
     }
 
     if company_id is not None:
-        lookup['companies'] = str(company_id)
+        lookup['companies'] = ObjectId(company_id)
 
     if product_type is not None:
         lookup['product_type'] = product_type
@@ -99,7 +100,7 @@ def get_products_by_company(company_id, navigation_id=None, product_type=None):
     :param navigation_id: Navigation Id
     :param product_type: Type of the product
     """
-    lookup = {'is_enabled': True, 'companies': str(company_id)}
+    lookup = {'is_enabled': True, 'companies': ObjectId(company_id)}
     if navigation_id:
         lookup['navigations'] = _get_navigation_query(navigation_id)
     if product_type:
@@ -110,5 +111,5 @@ def get_products_by_company(company_id, navigation_id=None, product_type=None):
 
 
 def get_products_dict_by_company(company_id):
-    lookup = {'is_enabled': True, 'companies': str(company_id)}
+    lookup = {'is_enabled': True, 'companies': ObjectId(company_id)}
     return list(superdesk.get_resource_service('products').get(req=None, lookup=lookup))

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -92,6 +92,11 @@ def edit(id):
 @account_manager_only
 def update_companies(id):
     updates = flask.request.get_json()
+    if updates.get("companies"):
+        updates["companies"] = [
+            ObjectId(company_id)
+            for company_id in updates["companies"]
+        ]
     get_resource_service('products').patch(id=ObjectId(id), updates=updates)
     return jsonify({'success': True}), 200
 

--- a/newsroom/reports/reports.py
+++ b/newsroom/reports/reports.py
@@ -80,19 +80,19 @@ def get_company_products():
     products = query_resource('products')
 
     for product in products:
-        for company in product.get('companies', []):
-            company_product = company_products.get(company, {})
+        for company_id in product.get('companies', []):
+            company_product = company_products.get(company_id, {})
             products = company_product.get('products', [])
             products.append(product)
             company_product['products'] = products
-            company_products[company] = company_product
+            company_products[company_id] = company_product
 
     for _id, details in company_products.items():
-        if companies.get(ObjectId(_id)):
+        if companies.get(_id):
             results.append({
-                '_id': _id,
-                'name': companies[ObjectId(_id)]['name'],
-                'is_enabled': companies[ObjectId(_id)]['is_enabled'],
+                '_id': str(_id),
+                'name': companies[_id]['name'],
+                'is_enabled': companies[_id]['is_enabled'],
                 'products': details.get('products', [])
             })
 
@@ -131,19 +131,19 @@ def get_company_report():
     products = query_resource('products')
 
     for product in products:
-        for company in product.get('companies', []):
-            company_product = company_products.get(company, {})
+        for company_id in product.get('companies', []):
+            company_product = company_products.get(company_id, {})
             products = company_product.get('products', [])
             products.append(product)
             company_product['products'] = products
-            company_products[company] = company_product
+            company_products[company_id] = company_product
 
     for _id, details in company_products.items():
-        users = list(query_resource('users', lookup={'company': ObjectId(_id)}))
-        if companies.get(ObjectId(_id)):
-            company = companies[ObjectId(_id)]
+        users = list(query_resource('users', lookup={'company': _id}))
+        if companies.get(_id):
+            company = companies[_id]
             results.append({
-                '_id': _id,
+                '_id': str(_id),
                 'name': company['name'],
                 'is_enabled': company['is_enabled'],
                 'products': details.get('products', []),
@@ -326,12 +326,12 @@ def get_company_api_usage():
     return results
 
 
-def get_company_names(companies):
+def get_company_names(company_ids):
     service = superdesk.get_resource_service('companies')
     enabled_companies = []
     disabled_companies = []
-    for company in companies:
-        company = service.find_one(req=None, _id=company)
+    for company_id in company_ids:
+        company = service.find_one(req=None, _id=company_id)
         if company:
             if not company.get('is_enabled'):
                 disabled_companies.append(company.get('name'))
@@ -345,8 +345,14 @@ def get_product_company():
     lookup = {'_id': ObjectId(args.get('product'))} if args.get('product') else None
     products = query_resource('products', lookup=lookup)
 
-    res = [{'_id': product.get('_id'), 'product': product.get('name'), 'companies': product.get('companies', [])} for
-           product in products]
+    res = [
+        {
+            '_id': product.get('_id'),
+            'product': product.get('name'),
+            'companies': product.get('companies', [])
+        }
+        for product in products
+    ]
 
     for r in res:
         r.update(get_company_names(r.get('companies', [])))

--- a/newsroom/search.py
+++ b/newsroom/search.py
@@ -668,7 +668,7 @@ class BaseSearchService(Service):
 
             search.user = user
             search.is_admin = is_admin(user)
-            search.company = companies.get(str(user.get('company', '')))
+            search.company = companies.get(user.get('company', ''))
 
             search.query = deepcopy(query)
             search.section = topic.get('topic_type')

--- a/newsroom/tests/fixtures.py
+++ b/newsroom/tests/fixtures.py
@@ -10,6 +10,8 @@ PUBLIC_USER_FIRSTNAME = 'Foo'
 PUBLIC_USER_LASTNAME = 'Bar'
 PUBLIC_USER_NAME = '{} {}'.format(PUBLIC_USER_FIRSTNAME, PUBLIC_USER_LASTNAME)
 TEST_USER_ID = ObjectId('5cc94454bc43165c045ffec9')
+COMPANY_1_ID = ObjectId("6215cbf55fc14ebe18e175a5")
+COMPANY_2_ID = ObjectId("6215ce6ed2943dec3725afde")
 
 items = [
     {
@@ -190,7 +192,7 @@ def init_auth(app, client):
 
 def setup_user_company(app):
     app.data.insert('companies', [{
-        '_id': 1,
+        '_id': COMPANY_1_ID,
         'name': 'Grain Corp',
         'is_enabled': True
     }])
@@ -200,7 +202,7 @@ def setup_user_company(app):
         'email': 'foo@bar.com',
         'first_name': PUBLIC_USER_FIRSTNAME,
         'last_name': PUBLIC_USER_LASTNAME,
-        'company': 1,
+        'company': COMPANY_1_ID,
         'is_enabled': True,
         'is_approved': True,
         '_created': utcnow()
@@ -209,7 +211,7 @@ def setup_user_company(app):
         'email': 'test@bar.com',
         'first_name': 'Test',
         'last_name': 'Bar',
-        'company': 1,
+        'company': COMPANY_1_ID,
         'is_enabled': True,
         'is_approved': True,
         '_created': utcnow()

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -7,7 +7,8 @@ from unittest import mock
 import newsroom.auth  # noqa - Fix cyclic import when running single test file
 from newsroom.utils import get_location_string, get_agenda_dates, get_public_contacts, get_entity_or_404, \
     get_local_date, get_end_date
-from tests.fixtures import items, init_items, agenda_items, init_agenda_items, init_auth, init_company, PUBLIC_USER_ID  # noqa
+from tests.fixtures import items, init_items, agenda_items, init_agenda_items, init_auth, init_company, \
+    PUBLIC_USER_ID, COMPANY_1_ID  # noqa
 from tests.utils import post_json, delete_json, get_json, get_admin_user_id, mock_send_email
 from copy import deepcopy
 from bson import ObjectId
@@ -199,7 +200,7 @@ def test_agenda_search_filtered_by_query_product(client, app):
         '_id': 12,
         'name': 'product test',
         'query': 'headline:test',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['51'],
         'is_enabled': True,
         'product_type': 'agenda'
@@ -207,7 +208,7 @@ def test_agenda_search_filtered_by_query_product(client, app):
         '_id': 13,
         'name': 'product test 2',
         'query': 'slugline:prime',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['52'],
         'is_enabled': True,
         'product_type': 'agenda'

--- a/tests/core/test_agenda_events_only.py
+++ b/tests/core/test_agenda_events_only.py
@@ -2,7 +2,8 @@ from flask import json
 from pytest import fixture
 from copy import deepcopy
 from newsroom.notifications import get_user_notifications
-from tests.fixtures import items, init_items, agenda_items, init_agenda_items, init_auth, setup_user_company, PUBLIC_USER_ID  # noqa
+from tests.fixtures import items, init_items, agenda_items, init_agenda_items, init_auth, setup_user_company, \
+    PUBLIC_USER_ID, COMPANY_1_ID  # noqa
 from tests.utils import post_json, mock_send_email
 from .test_push_events import test_event, test_planning
 from unittest import mock
@@ -11,11 +12,11 @@ from unittest import mock
 @fixture(autouse=True)
 def set_events_only_company(app):
     setup_user_company(app)
-    company = app.data.find_one('companies', None, _id=1)
+    company = app.data.find_one('companies', None, _id=COMPANY_1_ID)
     assert company is not None
     updates = {'events_only': True, 'section': {'wire': True, 'agenda': True}, 'is_enabled': True}
-    app.data.update('companies', 1, updates, company)
-    company = app.data.find_one('companies', None, _id=1)
+    app.data.update('companies', COMPANY_1_ID, updates, company)
+    company = app.data.find_one('companies', None, _id=COMPANY_1_ID)
     assert company.get('events_only') is True
     user = app.data.find_one('users', None, _id=PUBLIC_USER_ID)
     assert user is not None
@@ -39,7 +40,7 @@ def set_products(app):
         '_id': 12,
         'name': 'product test',
         'query': 'headline:test',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['51'],
         'is_enabled': True,
         'product_type': 'agenda'
@@ -47,7 +48,7 @@ def set_products(app):
         '_id': 13,
         'name': 'product test 2',
         'query': 'slugline:prime',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['52'],
         'is_enabled': True,
         'product_type': 'agenda'
@@ -107,7 +108,7 @@ def set_watch_products(app):
         '_id': 12,
         'name': 'product test',
         'query': 'press',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['51'],
         'is_enabled': True,
         'product_type': 'agenda'

--- a/tests/core/test_navigations.py
+++ b/tests/core/test_navigations.py
@@ -3,6 +3,7 @@ from flask import json
 from pytest import fixture
 
 from newsroom.tests.users import test_login_succeeds_for_admin, init as user_init  # noqa
+from newsroom.tests.fixtures import COMPANY_1_ID
 from newsroom.navigations.navigations import get_navigations_by_company
 
 
@@ -151,7 +152,7 @@ def test_get_agenda_navigations_by_company_returns_ordered(client, app):
     }])
 
     app.data.insert('companies', [{
-        '_id': 'c-1',
+        '_id': COMPANY_1_ID,
         'phone': '2132132134',
         'sd_subscriber_id': '12345',
         'name': 'Press Co.',
@@ -163,7 +164,7 @@ def test_get_agenda_navigations_by_company_returns_ordered(client, app):
         '_id': 'p-1',
         'name': 'Top Things',
         'navigations': ['n-1'],
-        'companies': ['c-1'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
         'query': '_featured',
         'product_type': 'agenda'
@@ -171,7 +172,7 @@ def test_get_agenda_navigations_by_company_returns_ordered(client, app):
         '_id': 'p-2',
         'name': 'A News',
         'navigations': ['59b4c5c61d41c8d736852fbf'],
-        'companies': ['c-1'],
+        'companies': [COMPANY_1_ID],
         'description': 'news product',
         'is_enabled': True,
         'product_type': 'wire',
@@ -179,7 +180,7 @@ def test_get_agenda_navigations_by_company_returns_ordered(client, app):
     }])
 
     test_login_succeeds_for_admin(client)
-    navigations = get_navigations_by_company('c-1', 'agenda')
+    navigations = get_navigations_by_company(COMPANY_1_ID, 'agenda')
     assert navigations[0].get('name') == 'Uber'
-    navigations = get_navigations_by_company('c-1', 'wire')
+    navigations = get_navigations_by_company(COMPANY_1_ID, 'wire')
     assert navigations[0].get('name') == 'Sport'

--- a/tests/core/test_push.py
+++ b/tests/core/test_push.py
@@ -10,7 +10,7 @@ import newsroom.auth  # noqa - Fix cyclic import when running single test file
 from superdesk import get_resource_service
 import newsroom.auth  # noqa - Fix cyclic import when running single test file
 from newsroom.utils import get_entity_or_404
-from ..fixtures import init_auth  # noqa
+from ..fixtures import init_auth, COMPANY_1_ID, COMPANY_2_ID  # noqa
 from ..utils import mock_send_email
 from unittest import mock
 
@@ -401,7 +401,7 @@ def test_notify_user_matches_for_killed_item_in_history(client, app, mocker):
 @mock.patch('newsroom.email.send_email', mock_send_email)
 def test_notify_user_matches_for_new_item_in_bookmarks(client, app, mocker):
     app.data.insert('companies', [{
-        '_id': '2',
+        '_id': COMPANY_1_ID,
         'name': 'Press co.',
         'is_enabled': True,
     }])
@@ -412,7 +412,7 @@ def test_notify_user_matches_for_new_item_in_bookmarks(client, app, mocker):
         'is_enabled': True,
         'is_approved': True,
         'receive_email': True,
-        'company': '2',
+        'company': COMPANY_1_ID,
     }
 
     user_ids = app.data.insert('users', [user])
@@ -424,7 +424,7 @@ def test_notify_user_matches_for_new_item_in_bookmarks(client, app, mocker):
         "query": "service.code: a",
         "is_enabled": True,
         "description": "Service A",
-        "companies": ['2'],
+        "companies": [COMPANY_1_ID],
         "sd_product_id": None,
         "product_type": "wire",
     }])
@@ -626,7 +626,7 @@ def test_matching_topics_for_public_user(client, app):
         'description': 'Top level sport product',
         'sd_product_id': 'p-1',
         'is_enabled': True,
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'product_type': 'wire'
     }])
 
@@ -634,8 +634,8 @@ def test_matching_topics_for_public_user(client, app):
     client.post('/push', json=item)
     search = get_resource_service('wire_search')
 
-    users = {'foo': {'company': '1', 'user_type': 'public'}}
-    companies = {'1': {'_id': '1', 'name': 'test-comp'}}
+    users = {'foo': {'company': COMPANY_1_ID, 'user_type': 'public'}}
+    companies = {COMPANY_1_ID: {'_id': COMPANY_1_ID, 'name': 'test-comp'}}
     topics = [
         {'_id': 'created_to_old', 'created': {'to': '2017-01-01'}, 'user': 'foo'},
         {'_id': 'created_from_future', 'created': {'from': 'now/d'}, 'user': 'foo', 'timezone_offset': 60 * 28},
@@ -654,7 +654,7 @@ def test_matching_topics_for_user_with_inactive_company(client, app):
         'description': 'Top level sport product',
         'sd_product_id': 'p-1',
         'is_enabled': True,
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'product_type': 'wire'
     }])
 
@@ -662,8 +662,8 @@ def test_matching_topics_for_user_with_inactive_company(client, app):
     client.post('/push', json=item)
     search = get_resource_service('wire_search')
 
-    users = {'foo': {'company': '1', 'user_type': 'public'}, 'bar': {'company': '2', 'user_type': 'public'}}
-    companies = {'1': {'_id': '1', 'name': 'test-comp'}}
+    users = {'foo': {'company': COMPANY_1_ID, 'user_type': 'public'}, 'bar': {'company': COMPANY_2_ID, 'user_type': 'public'}}
+    companies = {COMPANY_1_ID: {'_id': COMPANY_1_ID, 'name': 'test-comp'}}
     topics = [
         {'_id': 'created_to_old', 'created': {'to': '2017-01-01'}, 'user': 'bar'},
         {'_id': 'created_from_future', 'created': {'from': 'now/d'}, 'user': 'foo', 'timezone_offset': 60 * 28},

--- a/tests/core/test_push.py
+++ b/tests/core/test_push.py
@@ -662,7 +662,10 @@ def test_matching_topics_for_user_with_inactive_company(client, app):
     client.post('/push', json=item)
     search = get_resource_service('wire_search')
 
-    users = {'foo': {'company': COMPANY_1_ID, 'user_type': 'public'}, 'bar': {'company': COMPANY_2_ID, 'user_type': 'public'}}
+    users = {
+        'foo': {'company': COMPANY_1_ID, 'user_type': 'public'},
+        'bar': {'company': COMPANY_2_ID, 'user_type': 'public'},
+    }
     companies = {COMPANY_1_ID: {'_id': COMPANY_1_ID, 'name': 'test-comp'}}
     topics = [
         {'_id': 'created_to_old', 'created': {'to': '2017-01-01'}, 'user': 'bar'},

--- a/tests/core/test_reports.py
+++ b/tests/core/test_reports.py
@@ -3,16 +3,17 @@ from pytest import fixture
 from bson import ObjectId
 from datetime import datetime, timedelta
 from newsroom.tests.users import test_login_succeeds_for_admin, init as user_init  # noqa
+from newsroom.tests.fixtures import COMPANY_1_ID, COMPANY_2_ID
 
 
 @fixture(autouse=True)
 def init(app):
     app.data.insert('companies', [{
-        '_id': ObjectId('59bc460f1d41c8fa815cc2c2'),
+        '_id': COMPANY_1_ID,
         'name': 'Press Co.',
         'is_enabled': True,
     }, {
-        '_id': ObjectId('59c38b965057fb87d7eda9ab'),
+        '_id': COMPANY_2_ID,
         'name': 'Paper Co.',
         'is_enabled': True,
     }])
@@ -22,7 +23,7 @@ def init(app):
         'first_name': 'Foo',
         'last_name': 'Smith',
         'is_enabled': True,
-        'company': ObjectId('59bc460f1d41c8fa815cc2c2'),
+        'company': COMPANY_1_ID,
     }, {
         '_id': 'u-2',
         'email': 'bar@bar.com',
@@ -35,7 +36,7 @@ def init(app):
         'first_name': 'Bar',
         'last_name': 'Brown',
         'is_enabled': True,
-        'company': ObjectId('59bc460f1d41c8fa815cc2c2'),
+        'company': COMPANY_1_ID,
     }])
 
 
@@ -100,13 +101,13 @@ def test_company_products(client, app):
         '_id': 'p-1',
         'name': 'Sport',
         'description': 'sport product',
-        'companies': ['59bc460f1d41c8fa815cc2c2'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
     }, {
         '_id': 'p-2',
         'name': 'News',
         'description': 'news product',
-        'companies': ['59bc460f1d41c8fa815cc2c2', '59c38b965057fb87d7eda9ab'],
+        'companies': [COMPANY_1_ID, COMPANY_2_ID],
         'is_enabled': True,
     }])
 
@@ -126,13 +127,13 @@ def test_product_companies(client, app):
         '_id': 'p-1',
         'name': 'Sport',
         'description': 'sport product',
-        'companies': ['59bc460f1d41c8fa815cc2c2'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
     }, {
         '_id': 'p-2',
         'name': 'News',
         'description': 'news product',
-        'companies': ['59bc460f1d41c8fa815cc2c2', '59c38b965057fb87d7eda9ab'],
+        'companies': [COMPANY_1_ID, COMPANY_2_ID],
         'is_enabled': True,
     }])
 

--- a/tests/core/test_wire.py
+++ b/tests/core/test_wire.py
@@ -1,5 +1,4 @@
 import pytz
-import pytest
 from flask import json, g, session as server_session
 from datetime import datetime, timedelta
 from urllib import parse

--- a/tests/core/test_wire.py
+++ b/tests/core/test_wire.py
@@ -1,12 +1,12 @@
 import pytz
 import pytest
-from flask import json, g
+from flask import json, g, session as server_session
 from datetime import datetime, timedelta
 from urllib import parse
 from bson import ObjectId
 from copy import deepcopy
 
-from ..fixtures import items, init_items, init_auth, init_company, PUBLIC_USER_ID  # noqa
+from ..fixtures import items, init_items, init_auth, init_company, PUBLIC_USER_ID, COMPANY_1_ID  # noqa
 from ..utils import get_json, get_admin_user_id, mock_send_email
 from unittest import mock
 from newsroom.tests.users import ADMIN_USER_ID
@@ -98,7 +98,7 @@ def test_bookmarks_by_section(client, app):
             "query": "service.code: a",
             "is_enabled": True,
             "description": "Service A",
-            "companies": ['1'],
+            "companies": [COMPANY_1_ID],
             "sd_product_id": None,
             "product_type": "wire"
         }
@@ -221,7 +221,7 @@ def test_search_filtered_by_users_products(client, app):
         '_id': 10,
         'name': 'product test',
         'sd_product_id': 1,
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
         'product_type': 'wire'
     }])
@@ -253,7 +253,7 @@ def test_search_filter_by_individual_navigation(client, app):
         '_id': 10,
         'name': 'product test',
         'sd_product_id': 1,
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['51'],
         'product_type': 'wire',
         'is_enabled': True
@@ -261,7 +261,7 @@ def test_search_filter_by_individual_navigation(client, app):
         '_id': 11,
         'name': 'product test 2',
         'sd_product_id': 2,
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['52'],
         'product_type': 'wire',
         'is_enabled': True
@@ -310,7 +310,7 @@ def test_search_filtered_by_query_product(client, app):
         '_id': 12,
         'name': 'product test',
         'query': 'headline:more',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['51'],
         'product_type': 'wire',
         'is_enabled': True
@@ -318,7 +318,7 @@ def test_search_filtered_by_query_product(client, app):
         '_id': 13,
         'name': 'product test 2',
         'query': 'headline:Weather',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['52'],
         'product_type': 'wire',
         'is_enabled': True
@@ -397,7 +397,7 @@ def test_item_detail_access(client, app):
     app.data.insert('products', [{
         '_id': 10,
         'name': 'matching product',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
         'product_type': 'wire',
         'query': 'slugline:%s' % items[0]['slugline']
@@ -426,7 +426,7 @@ def test_search_using_section_filter_for_public_user(client, app):
         '_id': 12,
         'name': 'product test',
         'query': 'headline:more',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['51'],
         'is_enabled': True,
         'product_type': 'wire'
@@ -434,7 +434,7 @@ def test_search_using_section_filter_for_public_user(client, app):
         '_id': 13,
         'name': 'product test 2',
         'query': 'headline:Weather',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'navigations': ['52'],
         'is_enabled': True,
         'product_type': 'wire'
@@ -497,7 +497,7 @@ def test_time_limited_access(client, app):
         '_id': 10,
         'name': 'product test',
         'query': 'versioncreated:<=now-2d',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
         'product_type': 'wire'
     }])
@@ -522,8 +522,8 @@ def test_time_limited_access(client, app):
     assert 2 == len(data['_items'])
 
     g.settings['wire_time_limit_days']['value'] = 1
-    company = app.data.find_one('companies', req=None, _id=1)
-    app.data.update('companies', 1, {'archive_access': True}, company)
+    company = app.data.find_one('companies', req=None, _id=COMPANY_1_ID)
+    app.data.update('companies', COMPANY_1_ID, {'archive_access': True}, company)
     resp = client.get('/wire/search')
     data = json.loads(resp.get_data())
     assert 2 == len(data['_items'])
@@ -534,7 +534,7 @@ def test_company_type_filter(client, app):
         '_id': 10,
         'name': 'product test',
         'query': 'versioncreated:<=now-2d',
-        'companies': ['1'],
+        'companies': [COMPANY_1_ID],
         'is_enabled': True,
         'product_type': 'wire'
     }])
@@ -551,8 +551,8 @@ def test_company_type_filter(client, app):
         dict(id='test', wire_must={'term': {'service.code': 'b'}}),
     ]
 
-    company = app.data.find_one('companies', req=None, _id=1)
-    app.data.update('companies', 1, {'company_type': 'test'}, company)
+    company = app.data.find_one('companies', req=None, _id=COMPANY_1_ID)
+    app.data.update('companies', COMPANY_1_ID, {'company_type': 'test'}, company)
 
     resp = client.get('/wire/search')
     data = json.loads(resp.get_data())
@@ -569,47 +569,51 @@ def test_company_type_filter(client, app):
     assert 'WEATHER' != data['_items'][0]['slugline']
 
 
-@pytest.mark.skip(reason="Issue with app context, skipping for now")
 def test_search_by_products_and_filtered_by_embargoe(client, app):
-    app.data.insert('products', [{
-        '_id': 10,
-        'name': 'product test',
-        'query': 'headline:china',
-        'companies': ['1'],
-        'is_enabled': True,
-        'product_type': 'wire'
-    }])
+    with app.test_request_context():
+        server_session['user'] = str(PUBLIC_USER_ID)
+        server_session['user_type'] = 'public'
+        app.data.insert('products', [{
+            '_id': 10,
+            'name': 'product test',
+            'query': 'headline:china',
+            'companies': [COMPANY_1_ID],
+            'is_enabled': True,
+            'product_type': 'wire'
+        }])
 
-    # embargoed item is not fetched
-    app.data.insert('items', [{
-        '_id': 'foo',
-        'headline': 'china',
-        'embargoed': (datetime.now() + timedelta(days=10)).replace(tzinfo=pytz.UTC),
-        'products': [{'code': '10'}]
-    }])
+        # embargoed item is not fetched
+        app.data.insert('items', [{
+            '_id': 'foo',
+            'headline': 'china',
+            'embargoed': (datetime.now() + timedelta(days=10)).replace(tzinfo=pytz.UTC),
+            'products': [{'code': '10'}]
+        }])
 
-    items = get_resource_service('wire_search').get_product_items(10, 20)
-    assert 1 == len(items)
+        items = get_resource_service('wire_search').get_product_items(10, 20)
+        assert 1 == len(items)
 
-    app.config['COMPANY_TYPES'] = [
-        dict(id='test', wire_must_not={'range': {'embargoed': {'gte': 'now'}}}),
-    ]
+        app.config['COMPANY_TYPES'] = [
+            dict(id='test', wire_must_not={'range': {'embargoed': {'gte': 'now'}}}),
+        ]
 
-    company = app.data.find_one('companies', req=None, _id=1)
-    app.data.update('companies', 1, {'company_type': 'test'}, company)
-    items = get_resource_service('wire_search').get_product_items(10, 20)
-    assert 0 == len(items)
+        company = app.data.find_one('companies', req=None, _id=COMPANY_1_ID)
+        app.data.update('companies', COMPANY_1_ID, {'company_type': 'test'}, company)
 
-    # ex-embargoed item is fetched
-    app.data.insert('items', [{
-        '_id': 'bar',
-        'headline': 'china story',
-        'embargoed': (datetime.now() - timedelta(days=10)).replace(tzinfo=pytz.UTC),
-        'products': [{'code': '10'}]
-    }])
-    items = get_resource_service('wire_search').get_product_items(10, 20)
-    assert 1 == len(items)
-    assert items[0]['headline'] == 'china story'
+        items = get_resource_service('wire_search').get_product_items(10, 20)
+        assert 0 == len(items)
+
+        # ex-embargoed item is fetched
+        app.data.insert('items', [{
+            '_id': 'bar',
+            'headline': 'china story',
+            'embargoed': (datetime.now() - timedelta(days=10)).replace(tzinfo=pytz.UTC),
+            'products': [{'code': '10'}]
+        }])
+
+        items = get_resource_service('wire_search').get_product_items(10, 20)
+        assert 1 == len(items)
+        assert items[0]['headline'] == 'china story'
 
 
 def test_wire_delete(client, app):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,6 +4,8 @@ from newsroom.tests.fixtures import (  # noqa
     PUBLIC_USER_LASTNAME,
     PUBLIC_USER_NAME,
     TEST_USER_ID,
+    COMPANY_1_ID,
+    COMPANY_2_ID,
     items,
     agenda_items,
     init_items,

--- a/tests/news_api/test_api_audit.py
+++ b/tests/news_api/test_api_audit.py
@@ -3,6 +3,7 @@ from eve.methods.get import get_internal, getitem_internal
 from superdesk import get_resource_service
 from flask import g
 from bson import ObjectId
+from newsroom.tests.fixtures import COMPANY_1_ID, COMPANY_2_ID
 
 company_id = "5c3eb6975f627db90c84093c"
 
@@ -21,9 +22,9 @@ def init(app):
         "name": "Sample Product X",
         "decsription": "a description",
         "companies": [
-            "5aa5e9fbbdd7810885f0dac1",
-            "company_123"
-            ],
+            COMPANY_1_ID,
+            COMPANY_2_ID,
+        ],
         "navigations": [
             "5aa5e94ebdd7810884f66ed3"
         ],
@@ -49,7 +50,7 @@ def test_get_item_audit_creation(client, app):
 
 def test_get_all_company_products_audit_creation(client, app):
     with app.test_request_context(path='/account/products/'):
-        g.user = 'company_123'
+        g.user = COMPANY_2_ID
         response = get_internal('account/products')
         assert len(response[0]['_items']) == 1
         audit_check('5ab03a87bdd78169bb6d0783')
@@ -57,7 +58,7 @@ def test_get_all_company_products_audit_creation(client, app):
 
 def test_get_single_product_audit_creation(client, app):
     with app.test_request_context(path='/account/products/'):
-        g.user = 'company_123'
+        g.user = COMPANY_2_ID
         response = getitem_internal('account/products', _id='5ab03a87bdd78169bb6d0783')
         assert str(response[0]['_id']) == '5ab03a87bdd78169bb6d0783'
         audit_check('5ab03a87bdd78169bb6d0783')

--- a/tests/search/fixtures.py
+++ b/tests/search/fixtures.py
@@ -73,29 +73,29 @@ PRODUCTS = [{
     '_id': PROD_1, 'name': 'Sport1', 'description': 'sport product 1',
     'is_enabled': True, 'product_type': 'wire',
     'navigations': [str(NAV_1), str(NAV_2)],
-    'companies': [str(COMPANY_1), str(COMPANY_2)],
+    'companies': [COMPANY_1, COMPANY_2],
     'query': 'service.code:a'
 }, {
     '_id': PROD_2, 'name': 'Sport2', 'description': 'sport product 2',
     'is_enabled': True, 'product_type': 'wire',
     'navigations': [str(NAV_3)],
-    'companies': [str(COMPANY_2), str(COMPANY_3)],
+    'companies': [COMPANY_2, COMPANY_3],
     'query': 'service.code:b', 'sd_product_id': 'sd_product_1'
 }, {
     '_id': PROD_3, 'name': 'Sport3', 'description': 'sport product 3',
     'is_enabled': False, 'product_type': 'wire',
     'navigations': [str(NAV_4)],
-    'companies': [str(COMPANY_1)]
+    'companies': [COMPANY_1]
 }, {
     '_id': PROD_4, 'name': 'Sport4', 'description': 'sport product 4',
     'is_enabled': True, 'product_type': 'agenda',
     'navigations': [str(NAV_5)],
-    'companies': [str(COMPANY_1), str(COMPANY_2)]
+    'companies': [COMPANY_1, COMPANY_2]
 }, {
     '_id': PROD_5, 'name': 'Sport4', 'description': 'sport product 4',
     'is_enabled': True, 'product_type': 'wire',
     'navigations': [str(NAV_6)],
-    'companies': [str(COMPANY_1), str(COMPANY_3)]
+    'companies': [COMPANY_1, COMPANY_3]
 }]
 
 SECTION_FILTERS = [{

--- a/tests/search/test_search_filters.py
+++ b/tests/search/test_search_filters.py
@@ -145,7 +145,7 @@ def test_apply_products_filter(client, app):
         # Filter results by navigation
         assert_products_query(ADMIN_USER_ID, {'navigation': str(NAV_3)}, [PRODUCTS[1]])
 
-        # Public user has access only to their allwed products
+        # Public user has access only to their allowed products
         assert_products_query(PUBLIC_USER_ID, None, [PRODUCTS[0], PRODUCTS[1]])
         # Filter results by navigation
         assert_products_query(PUBLIC_USER_ID, {'navigation': str(NAV_1)}, [PRODUCTS[0]])


### PR DESCRIPTION
The `Management API` was specifically searching for `Company Products` using `ObjectId`, as well as updating `Navigation Companies` using `ObjectId`.

The `Web API` on the other hand was using `str` instead, so any `Company Product` permissions updated from the `Web UI` would not be returned from the `Management API`.

Instead of placing a hack fix into the `Management API`, I updated the Navigation schema to use `ObjectId`.