### PR TITLE
[NHUB-99] Improve initial load times for home page

### DIFF
--- a/assets/home/actions.js
+++ b/assets/home/actions.js
@@ -30,6 +30,19 @@ export function setCardItems(cardLabel, items) {
     return {type: SET_CARD_ITEMS, payload: {card: cardLabel, items: items}};
 }
 
+export const SET_MULTIPLE_CARD_ITEMS = 'SET_MULTIPLE_CARD_ITEMS'
+export function getMultipleCardItems(itemsByCard) {
+    return {type: SET_MULTIPLE_CARD_ITEMS, payload: itemsByCard};
+}
+
+export function fetchCompanyCardItems() {
+    return (dispatch) => {
+        return server.get('/card_items')
+            .then((data) => dispatch(getMultipleCardItems(data._items)))
+            .catch(errorHandler);
+    }
+}
+
 export function fetchCardExternalItems(cardId, cardLabel) {
     return (dispatch) => {
         return server.get(`/media_card_external/${cardId}`)

--- a/assets/home/actions.js
+++ b/assets/home/actions.js
@@ -30,7 +30,7 @@ export function setCardItems(cardLabel, items) {
     return {type: SET_CARD_ITEMS, payload: {card: cardLabel, items: items}};
 }
 
-export const SET_MULTIPLE_CARD_ITEMS = 'SET_MULTIPLE_CARD_ITEMS'
+export const SET_MULTIPLE_CARD_ITEMS = 'SET_MULTIPLE_CARD_ITEMS';
 export function getMultipleCardItems(itemsByCard) {
     return {type: SET_MULTIPLE_CARD_ITEMS, payload: itemsByCard};
 }
@@ -40,7 +40,7 @@ export function fetchCompanyCardItems() {
         return server.get('/card_items')
             .then((data) => dispatch(getMultipleCardItems(data._items)))
             .catch(errorHandler);
-    }
+    };
 }
 
 export function fetchCardExternalItems(cardId, cardLabel) {

--- a/assets/home/components/HomeApp.jsx
+++ b/assets/home/components/HomeApp.jsx
@@ -53,7 +53,7 @@ class HomeApp extends React.Component {
         ])
             .then(() => {
                 this.setState({loadingItems: false});
-            })
+            });
     }
 
     renderModal(specs) {

--- a/assets/home/components/HomeApp.jsx
+++ b/assets/home/components/HomeApp.jsx
@@ -10,7 +10,7 @@ import {
 
 import getItemActions from 'wire/item-actions';
 import ItemDetails from 'wire/components/ItemDetails';
-import {openItemDetails, setActive, fetchCardExternalItems} from '../actions';
+import {openItemDetails, setActive, fetchCardExternalItems, fetchCompanyCardItems} from '../actions';
 import ShareItemModal from 'components/ShareItemModal';
 import DownloadItemsModal from 'wire/components/DownloadItemsModal';
 import WirePreview from 'wire/components/WirePreview';
@@ -19,6 +19,7 @@ import {downloadVideo} from 'wire/actions';
 import {SearchBar} from './search-bar';
 import {previewConfigSelector, listConfigSelector, detailsConfigSelector, isSearchEnabled} from 'ui/selectors';
 import {filterGroupsToLabelMap} from 'search/selectors';
+import CardRow from 'components/cards/render/CardRow';
 
 const modals = {
     shareItem: ShareItemModal,
@@ -33,18 +34,26 @@ class HomeApp extends React.Component {
         this.renderModal = this.renderModal.bind(this);
         this.onHomeScroll = this.onHomeScroll.bind(this);
         this.height = 0;
+
+        this.state = {loadingItems: true};
     }
 
     componentDidMount() {
         document.getElementById('footer').className = 'footer footer--home';
         this.height = this.elem.offsetHeight;
 
-        // Load any external media items for cards
-        this.props.cards
-            .filter((card) => card.dashboard === 'newsroom' && card.type === '4-photo-gallery')
-            .forEach((card) => {
-                this.props.fetchCardExternalItems(get(card, '_id'), get(card, 'label'));
-            });
+        // Load items for cards
+        Promise.all([
+            this.props.fetchCompanyCardItems(),
+            ...this.props.cards
+                .filter((card) => card.dashboard === 'newsroom' && card.type === '4-photo-gallery')
+                .map((card) => (
+                    this.props.fetchCardExternalItems(get(card, '_id'), get(card, 'label'))
+                )),
+        ])
+            .then(() => {
+                this.setState({loadingItems: false});
+            })
     }
 
     renderModal(specs) {
@@ -71,6 +80,17 @@ class HomeApp extends React.Component {
     }
 
     getPanels(card) {
+        if (this.state.loadingItems) {
+            return (
+                <CardRow title={card.label} product={this.getProduct(card)} isActive={this.props.activeCard === card._id}>
+                    <div className='col-sm-6 col-md-4 col-lg-3 col-xxl-2 d-flex mb-4'>
+                        <div className="spinner-border text-success" />
+                        <span className="a11y-only">{gettext('Loading Card Items')}</span>
+                    </div>
+                </CardRow>
+            );
+        }
+
         const Panel = getCardDashboardComponent(card.type);
         const items = this.props.itemsByCard[card.label] || [];
 
@@ -206,6 +226,7 @@ HomeApp.propTypes = {
         action: PropTypes.func,
     })),
     fetchCardExternalItems: PropTypes.func,
+    fetchCompanyCardItems: PropTypes.func,
     followStory: PropTypes.func,
     previewConfig: PropTypes.object,
     listConfig: PropTypes.object,
@@ -243,6 +264,7 @@ const mapDispatchToProps = (dispatch) => ({
     },
     actions: getItemActions(dispatch),
     fetchCardExternalItems: (cardId, cardLabel) => dispatch(fetchCardExternalItems(cardId, cardLabel)),
+    fetchCompanyCardItems: () => dispatch(fetchCompanyCardItems()),
     followStory: (item) => followStory(item, 'wire'),
     downloadVideo: (href, id, mimeType) => dispatch(downloadVideo(href, id, mimeType)),
 });

--- a/assets/home/reducers.js
+++ b/assets/home/reducers.js
@@ -4,6 +4,7 @@ import {
     OPEN_ITEM,
     SET_ACTIVE,
     SET_CARD_ITEMS,
+    SET_MULTIPLE_CARD_ITEMS,
 } from './actions';
 import {BOOKMARK_ITEMS, REMOVE_BOOKMARK} from '../wire/actions';
 import {CLOSE_MODAL, MODAL_FORM_VALID, RENDER_MODAL} from '../actions';
@@ -27,7 +28,7 @@ export default function homeReducer(state=initialState, action) {
         return {
             ...state,
             cards: action.data.cards,
-            itemsByCard: action.data.itemsByCard,
+            itemsByCard: {},
             products: action.data.products,
             user: action.data.user,
             userType: action.data.userType,
@@ -79,6 +80,16 @@ export default function homeReducer(state=initialState, action) {
             itemsByCard: {
                 ...state.itemsByCard,
                 [action.payload.card]: action.payload.items,
+            },
+        };
+    }
+
+    case SET_MULTIPLE_CARD_ITEMS: {
+        return {
+            ...state,
+            itemsByCard: {
+                ...state.itemsByCard,
+                ...action.payload,
             },
         };
     }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -14,3 +14,4 @@
 @import './agenda.scss';
 @import './api.scss';
 @import './reports.scss';
+@import './spinner.scss';

--- a/assets/styles/spinner.scss
+++ b/assets/styles/spinner.scss
@@ -1,0 +1,75 @@
+// Copied directly from Bootstrap 4.2.1
+// ====================================
+
+// Spinner Border
+// --------------
+@-webkit-keyframes spinner-border {
+    to {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes spinner-border {
+    to {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+
+.spinner-border {
+    display: inline-block;
+    width: 2rem;
+    height: 2rem;
+    vertical-align: text-bottom;
+    border: 0.25em solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    -webkit-animation: spinner-border .75s linear infinite;
+    animation: spinner-border .75s linear infinite;
+}
+
+.spinner-border-sm {
+    width: 1rem;
+    height: 1rem;
+    border-width: 0.2em;
+}
+
+// Spinner Grow
+// ------------
+@-webkit-keyframes spinner-grow {
+    0% {
+        -webkit-transform: scale(0);
+        transform: scale(0);
+    }
+    50% {
+        opacity: 1;
+    }
+}
+
+@keyframes spinner-grow {
+    0% {
+        -webkit-transform: scale(0);
+        transform: scale(0);
+    }
+    50% {
+        opacity: 1;
+    }
+}
+
+.spinner-grow {
+    display: inline-block;
+    width: 2rem;
+    height: 2rem;
+    vertical-align: text-bottom;
+    background-color: currentColor;
+    border-radius: 50%;
+    opacity: 0;
+    -webkit-animation: spinner-grow .75s linear infinite;
+    animation: spinner-grow .75s linear infinite;
+}
+
+.spinner-grow-sm {
+    width: 1rem;
+    height: 1rem;
+}

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -17,7 +17,7 @@ from newsroom.utils import parse_dates, get_user_dict, get_company_dict, parse_d
 from newsroom.email import send_new_item_notification_email, \
     send_history_match_notification_email, send_item_killed_notification_email
 from newsroom.history import get_history_users
-from newsroom.wire.views import HOME_ITEMS_CACHE_KEY
+from newsroom.wire.views import delete_dashboard_caches
 from newsroom.wire import url_for_wire
 from newsroom.upload import ASSETS_RESOURCE
 from newsroom.signals import publish_item as publish_item_signal
@@ -88,7 +88,8 @@ def push():
     else:
         flask.abort(400, gettext('Unknown type {}'.format(item.get('type'))))
 
-    app.cache.delete(HOME_ITEMS_CACHE_KEY)
+    if app.config.get("DELETE_DASHBOARD_CACHE_ON_PUSH", True):
+        delete_dashboard_caches()
     return flask.jsonify({})
 
 

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -417,3 +417,15 @@ AGENDA_GROUPS = None
 #: .. versionadded:: 2.1.0
 #:
 ALLOW_EXPIRED_COMPANY_LOGINS = False
+
+#: The timeout used on the cache for the dashboard items
+#:
+#: .. versionadded:: 2.1.0
+#:
+DASHBOARD_CACHE_TIMEOUT = 300
+
+#: If True, deletes all Dashboard item caches when new items are pushed
+#:
+#: .. versionadded:: 2.1.0
+#:
+DELETE_DASHBOARD_CACHE_ON_PUSH = True

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -101,8 +101,14 @@ def get_items_by_card(cards, company_id):
             # using '/media_card_external' endpoint
             items_by_card[card['label']] = None
 
-    app.cache.set(cache_key, items_by_card, timeout=300)
+    app.cache.set(cache_key, items_by_card, timeout=app.config.get("DASHBOARD_CACHE_TIMEOUT", 300))
     return items_by_card
+
+
+def delete_dashboard_caches():
+    app.cache.delete(HOME_ITEMS_CACHE_KEY)
+    for company in query_resource("companies"):
+        app.cache.delete(f"{HOME_ITEMS_CACHE_KEY}{company['_id']}")
 
 
 def get_home_data():
@@ -155,7 +161,7 @@ def get_media_card_external(card_id):
     else:
         card = get_entity_or_404(card_id, 'cards')
         card_items = app.get_media_cards_external(card)
-        app.cache.set(cache_id, card_items, timeout=300)
+        app.cache.set(cache_id, card_items, timeout=app.config.get("DASHBOARD_CACHE_TIMEOUT", 300))
 
     return flask.jsonify({'_items': card_items})
 

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -116,11 +116,9 @@ def get_home_data():
     cards = list(query_resource('cards', lookup={'dashboard': 'newsroom'}))
     company_id = str(user['company']) if user and user.get('company') else None
     topics = get_user_topics(user['_id']) if user else []
-    items_by_card = get_items_by_card(cards, company_id)
 
     return {
         'cards': cards,
-        'itemsByCard': items_by_card,
         'products': get_products_by_company(company_id),
         'user': str(user['_id']) if user else None,
         'userType': user.get('user_type'),
@@ -164,6 +162,16 @@ def get_media_card_external(card_id):
         app.cache.set(cache_id, card_items, timeout=app.config.get("DASHBOARD_CACHE_TIMEOUT", 300))
 
     return flask.jsonify({'_items': card_items})
+
+
+@blueprint.route('/card_items')
+@login_required
+def get_card_items():
+    user = get_user()
+    cards = list(query_resource('cards', lookup={'dashboard': 'newsroom'}))
+    company_id = str(user['company']) if user and user.get('company') else None
+    items_by_card = get_items_by_card(cards, company_id)
+    return flask.jsonify({"_items": items_by_card})
 
 
 @blueprint.route('/wire')


### PR DESCRIPTION
The following has been implemented to improve the home page loading times:

- Delete dashboard cache on push (so new items show up without waiting for cache timeout)
- Load the home page first, then load the card items thereafter
- Show a spinner while loading card items, so user knows items are loading