### PR TITLE
fix signature check on push

### DIFF
--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -12,6 +12,7 @@ import importlib
 import eve
 import flask
 import newsroom
+import sentry_sdk
 
 from flask_mail import Mail
 from flask_caching import Cache
@@ -21,7 +22,7 @@ from superdesk.json_utils import SuperdeskJSONEncoder
 from superdesk.validator import SuperdeskValidator
 from superdesk.logging import configure_logging
 from elasticapm.contrib.flask import ElasticAPM
-from superdesk.factory.sentry import SuperdeskSentry
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from newsroom.auth import SessionAuth
 from newsroom.utils import is_json_request
@@ -74,6 +75,7 @@ class BaseNewsroomApp(eve.Eve):
         newsroom.flask_app = self
 
         self.setup_error_handlers()
+        self.setup_sentry()
         self.setup_apm()
         self.setup_media_storage()
         self.setup_babel()
@@ -170,7 +172,6 @@ class BaseNewsroomApp(eve.Eve):
         self.register_error_handler(AssertionError, assertion_error)
         self.register_error_handler(404, render_404)
         self.register_error_handler(403, render_403)
-        self.sentry = SuperdeskSentry(self)
 
     def general_setting(self, _id, label, type='text', default=None,
                         weight=0, description=None, min=None, client_setting=False):
@@ -204,3 +205,10 @@ class BaseNewsroomApp(eve.Eve):
         if settings.get("mongo_indexes__init") and not settings.get("mongo_indexes"):
             settings["mongo_indexes"] = settings["mongo_indexes__init"]
         super().register_resource(resource, settings)
+
+    def setup_sentry(self):
+        if self.config.get("SENTRY_DSN"):
+            sentry_sdk.init(
+                dsn=self.config["SENTRY_DSN"],
+                integrations=[FlaskIntegration()],
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ honcho>=1.0.1
 gunicorn>=20.0.4,<20.1
 PyRTF3>=0.47.5
 xhtml2pdf>=0.2.4
+sentry-sdk[flask]>=1.5.7,<1.6
 
 # Fix an issue between xhtml2pdf v0.2.4 and reportlab v3.6.7
 # https://github.com/xhtml2pdf/xhtml2pdf/issues/589


### PR DESCRIPTION
this was an issue with sentry integration:

https://github.com/getsentry/raven-python/issues/457

which resulted in empty request body so there was
no data to check signature on. switching from raven
to sentry_sdk which doesn't have that issue.

CPNHUB-96