### PR TITLE
[SDCP-609] fix: Page Navbar dropdowns hidden due to css overflow

### DIFF
--- a/assets/styles/navbar.scss
+++ b/assets/styles/navbar.scss
@@ -18,7 +18,9 @@
         box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.3);
         z-index: 1007;
         flex: 0 0 auto;
-        overflow: hidden;
+
+        // [SDCP-609]: Commenting the next line until a better fix is implemented
+        //overflow: hidden;
     }
     .notif {
         width: 56px;


### PR DESCRIPTION
This was caused by changes in the PR https://github.com/superdesk/newsroom-core/pull/108.

@darconny I tried using Bootstrap Dropdown but it doesn't have an append to body option. Therefor this CSS rule is blocking the `Notification` and `User Profile` dropdown menus from appearing.

If you have a better solution that fixes this and the reason for this css rule in the first place, please let me know.