### PR TITLE
[CPNHUB-108] fix: Use ObjectId everywhere for product.navigations

### DIFF
--- a/data_updates/00007_20220502-134524_products.py
+++ b/data_updates/00007_20220502-134524_products.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Mark Pittaway
+# Creation: 2022-05-02 13:45
+
+from bson import ObjectId
+from eve.utils import config
+from superdesk.commands.data_updates import DataUpdate as _DataUpdate
+
+
+class DataUpdate(_DataUpdate):
+
+    resource = 'products'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        for product in mongodb_collection.find({}):
+            if not product.get("navigations"):
+                continue
+
+            print(mongodb_collection.update(
+                {config.ID_FIELD: product.get(config.ID_FIELD)},
+                {
+                    "$set": {
+                        "navigations": [
+                            ObjectId(nav_id)
+                            for nav_id in product.get("navigations")
+                        ]
+                    }
+                }
+            ))
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        pass

--- a/features/web_api/navigations.feature
+++ b/features/web_api/navigations.feature
@@ -1,0 +1,36 @@
+Feature: Navigations
+    @auth @admin
+    Scenario: Removes Navigations from Products when updating list of Navigations
+        When we post form to "/navigations/new"
+        """
+        {
+            "navigation": {
+                "name": "Sports", "description": "Sports stories",
+                "is_enabled": true, "product_type": "wire"
+            }
+        }
+        """
+        Then we store "NAV_ID" with item id
+        When we post json to "/products/new"
+        """
+        {
+            "name": "Sports", "description": "Sports stories",
+            "query": "sports", "product_type": "wire"
+        }
+        """
+        Then we store "PROD_ID" with item id
+        When we post json to "/products/#PROD_ID#/navigations"
+        """
+        {
+            "navigations": ["#NAV_ID#"]
+        }
+        """
+        When we delete "/navigations/#NAV_ID#"
+        And we get "/products"
+        Then we get existing resource
+        """
+        [{
+            "_id": "#PROD_ID#",
+            "navigations": "__empty__"
+        }]
+        """

--- a/newsroom/products/products.py
+++ b/newsroom/products/products.py
@@ -61,9 +61,9 @@ class ProductsService(newsroom.Service):
 
 
 def _get_navigation_query(ids):
-    return {'$in': [str(oid) for oid in ids]} \
+    return {'$in': [ObjectId(oid) for oid in ids]} \
         if type(ids) is list \
-        else str(ids)
+        else ObjectId(ids)
 
 
 def get_products_by_navigation(navigation_id, product_type=None):

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -104,6 +104,11 @@ def update_companies(id):
 @admin_only
 def update_navigations(id):
     updates = flask.request.get_json()
+    if updates.get("navigations"):
+        updates["navigations"] = [
+            ObjectId(nav_id)
+            for nav_id in updates["navigations"]
+        ]
     get_resource_service('products').patch(id=ObjectId(id), updates=updates)
     return jsonify({'success': True}), 200
 

--- a/newsroom/tests/web_api/steps.py
+++ b/newsroom/tests/web_api/steps.py
@@ -1,7 +1,12 @@
-from behave import then
+from behave import then, when
 from flask import json
+from wooper.expect import expect_status_in
 
-from superdesk.tests.steps import assert_200, get_json_data
+from superdesk.tests.steps import assert_200, get_json_data, apply_placeholders, get_prefixed_url, set_placeholder
+
+
+def assert_ok(response):
+    expect_status_in(response, [200, 201])
 
 
 @then('we get the following order')
@@ -12,3 +17,42 @@ def step_impl_ordered_list(context):
     expected_order = json.loads(context.text)
 
     assert ids == expected_order, "{} != {}".format(",".join(ids), ",".join(expected_order))
+
+
+@when('we post form to "{url}"')
+def step_impl_when_post_form_to_url(context, url):
+    url = apply_placeholders(context, url)
+    data = json.loads(apply_placeholders(context, context.text))
+    context.response = context.client.post(
+        get_prefixed_url(context.app, url),
+        data={
+            key: json.dumps(val)
+            for key, val in data.items()
+        },
+        headers=[
+            header
+            for header in context.headers
+            if header[0] != "Content-Type"
+        ]
+    )
+
+    assert_ok(context.response)
+
+
+@when('we post json to "{url}"')
+def step_impl_when_post_json_to_url(context, url):
+    url = apply_placeholders(context, url)
+    data = apply_placeholders(context, context.text)
+    context.response = context.client.post(
+        get_prefixed_url(context.app, url),
+        data=data,
+        headers=context.headers
+    )
+
+    assert_ok(context.response)
+
+
+@then('we store "{tag}" with item id')
+def step_impl_store_response_item_id(context, tag):
+    data = get_json_data(context.response)
+    set_placeholder(context, tag, data.get('_id'))

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -184,13 +184,16 @@ def test_share_items(client, app, mocker):
 
 
 def test_agenda_search_filtered_by_query_product(client, app):
+    NAV_1 = ObjectId('5e65964bf5db68883df561c0')
+    NAV_2 = ObjectId('5e65964bf5db68883df561c1')
+
     app.data.insert('navigations', [{
-        '_id': 51,
+        '_id': NAV_1,
         'name': 'navigation-1',
         'is_enabled': True,
         'product_type': 'agenda'
     }, {
-        '_id': 52,
+        '_id': NAV_2,
         'name': 'navigation-2',
         'is_enabled': True,
         'product_type': 'agenda'
@@ -201,7 +204,7 @@ def test_agenda_search_filtered_by_query_product(client, app):
         'name': 'product test',
         'query': 'headline:test',
         'companies': [COMPANY_1_ID],
-        'navigations': ['51'],
+        'navigations': [NAV_1],
         'is_enabled': True,
         'product_type': 'agenda'
     }, {
@@ -209,7 +212,7 @@ def test_agenda_search_filtered_by_query_product(client, app):
         'name': 'product test 2',
         'query': 'slugline:prime',
         'companies': [COMPANY_1_ID],
-        'navigations': ['52'],
+        'navigations': [NAV_2],
         'is_enabled': True,
         'product_type': 'agenda'
     }])
@@ -227,7 +230,7 @@ def test_agenda_search_filtered_by_query_product(client, app):
     assert 'internal_note' not in data['_items'][0]['planning_items'][0]
     assert 'internal_note' not in data['_items'][0]['planning_items'][0]['coverages'][0]['planning']
     assert 'internal_note' not in data['_items'][0]['coverages'][0]['planning']
-    resp = client.get('/agenda/search?navigation=51')
+    resp = client.get(f'/agenda/search?navigation={NAV_1}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
     assert '_aggregations' in data

--- a/tests/core/test_agenda_events_only.py
+++ b/tests/core/test_agenda_events_only.py
@@ -1,3 +1,4 @@
+from bson import ObjectId
 from flask import json
 from pytest import fixture
 from copy import deepcopy
@@ -7,6 +8,9 @@ from tests.fixtures import items, init_items, agenda_items, init_agenda_items, i
 from tests.utils import post_json, mock_send_email
 from .test_push_events import test_event, test_planning
 from unittest import mock
+
+NAV_1 = ObjectId('5e65964bf5db68883df561c0')
+NAV_2 = ObjectId('5e65964bf5db68883df561c1')
 
 
 @fixture(autouse=True)
@@ -24,12 +28,12 @@ def set_events_only_company(app):
 
 def set_products(app):
     app.data.insert('navigations', [{
-        '_id': 51,
+        '_id': NAV_1,
         'name': 'navigation-1',
         'is_enabled': True,
         'product_type': 'agenda'
     }, {
-        '_id': 52,
+        '_id': NAV_2,
         'name': 'navigation-2',
         'is_enabled': True,
         'product_type': 'agenda'
@@ -40,7 +44,7 @@ def set_products(app):
         'name': 'product test',
         'query': 'headline:test',
         'companies': [COMPANY_1_ID],
-        'navigations': ['51'],
+        'navigations': [NAV_1],
         'is_enabled': True,
         'product_type': 'agenda'
     }, {
@@ -48,7 +52,7 @@ def set_products(app):
         'name': 'product test 2',
         'query': 'slugline:prime',
         'companies': [COMPANY_1_ID],
-        'navigations': ['52'],
+        'navigations': [NAV_2],
         'is_enabled': True,
         'product_type': 'agenda'
     }])
@@ -84,7 +88,7 @@ def test_search(client, app):
     assert 'planning_items' not in data['_items'][0]
     assert 'coverages' not in data['_items'][0]
 
-    resp = client.get('/agenda/search?navigation=51')
+    resp = client.get(f'/agenda/search?navigation={NAV_1}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
     assert '_aggregations' in data
@@ -97,7 +101,7 @@ def test_search(client, app):
 
 def set_watch_products(app):
     app.data.insert('navigations', [{
-        '_id': 51,
+        '_id': NAV_1,
         'name': 'navigation-1',
         'is_enabled': True,
         'product_type': 'agenda'
@@ -108,7 +112,7 @@ def set_watch_products(app):
         'name': 'product test',
         'query': 'press',
         'companies': [COMPANY_1_ID],
-        'navigations': ['51'],
+        'navigations': [NAV_1],
         'is_enabled': True,
         'product_type': 'agenda'
     }])

--- a/tests/core/test_navigations.py
+++ b/tests/core/test_navigations.py
@@ -126,7 +126,7 @@ def test_update_navigation_with_products(client, app):
         '_id': 'p-2',
         'name': 'News',
         'description': 'news product',
-        'navigations': [str(NAV_ID)],
+        'navigations': [NAV_ID],
         'is_enabled': True,
         'product_type': 'wire'
     }])

--- a/tests/core/test_wire.py
+++ b/tests/core/test_wire.py
@@ -12,6 +12,10 @@ from newsroom.tests.users import ADMIN_USER_ID
 from superdesk import get_resource_service
 
 
+NAV_1 = ObjectId('5e65964bf5db68883df561c0')
+NAV_2 = ObjectId('5e65964bf5db68883df561c1')
+
+
 def test_item_detail(client):
     resp = client.get('/wire/tag:foo')
     assert resp.status_code == 200
@@ -237,12 +241,12 @@ def test_search_filtered_by_users_products(client, app):
 
 def test_search_filter_by_individual_navigation(client, app):
     app.data.insert('navigations', [{
-        '_id': 51,
+        '_id': NAV_1,
         'name': 'navigation-1',
         'is_enabled': True,
         'product_type': 'wire'
     }, {
-        '_id': 52,
+        '_id': NAV_2,
         'name': 'navigation-2',
         'is_enabled': True,
         'product_type': 'wire'
@@ -253,7 +257,7 @@ def test_search_filter_by_individual_navigation(client, app):
         'name': 'product test',
         'sd_product_id': 1,
         'companies': [COMPANY_1_ID],
-        'navigations': ['51'],
+        'navigations': [NAV_1],
         'product_type': 'wire',
         'is_enabled': True
     }, {
@@ -261,7 +265,7 @@ def test_search_filter_by_individual_navigation(client, app):
         'name': 'product test 2',
         'sd_product_id': 2,
         'companies': [COMPANY_1_ID],
-        'navigations': ['52'],
+        'navigations': [NAV_2],
         'product_type': 'wire',
         'is_enabled': True
     }])
@@ -273,7 +277,7 @@ def test_search_filter_by_individual_navigation(client, app):
     data = json.loads(resp.get_data())
     assert 2 == len(data['_items'])
     assert '_aggregations' in data
-    resp = client.get('/wire/search?navigation=51')
+    resp = client.get(f'/wire/search?navigation={NAV_1}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
     assert '_aggregations' in data
@@ -287,19 +291,19 @@ def test_search_filter_by_individual_navigation(client, app):
     data = json.loads(resp.get_data())
     assert 3 == len(data['_items'])  # gets all by default
 
-    resp = client.get('/wire/search?navigation=51')
+    resp = client.get(f'/wire/search?navigation={NAV_1}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
 
 
 def test_search_filtered_by_query_product(client, app):
     app.data.insert('navigations', [{
-        '_id': 51,
+        '_id': NAV_1,
         'name': 'navigation-1',
         'is_enabled': True,
         'product_type': 'wire',
     }, {
-        '_id': 52,
+        '_id': NAV_2,
         'name': 'navigation-2',
         'is_enabled': True,
         'product_type': 'wire'
@@ -310,7 +314,7 @@ def test_search_filtered_by_query_product(client, app):
         'name': 'product test',
         'query': 'headline:more',
         'companies': [COMPANY_1_ID],
-        'navigations': ['51'],
+        'navigations': [NAV_1],
         'product_type': 'wire',
         'is_enabled': True
     }, {
@@ -318,7 +322,7 @@ def test_search_filtered_by_query_product(client, app):
         'name': 'product test 2',
         'query': 'headline:Weather',
         'companies': [COMPANY_1_ID],
-        'navigations': ['52'],
+        'navigations': [NAV_2],
         'product_type': 'wire',
         'is_enabled': True
     }])
@@ -331,7 +335,7 @@ def test_search_filtered_by_query_product(client, app):
     data = json.loads(resp.get_data())
     assert 2 == len(data['_items'])
     assert '_aggregations' in data
-    resp = client.get('/wire/search?navigation=52')
+    resp = client.get(f'/wire/search?navigation={NAV_2}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
     assert '_aggregations' in data
@@ -410,12 +414,12 @@ def test_item_detail_access(client, app):
 
 def test_search_using_section_filter_for_public_user(client, app):
     app.data.insert('navigations', [{
-        '_id': 51,
+        '_id': NAV_1,
         'name': 'navigation-1',
         'is_enabled': True,
         'product_type': 'wire'
     }, {
-        '_id': 52,
+        '_id': NAV_2,
         'name': 'navigation-2',
         'is_enabled': True,
         'product_type': 'wire'
@@ -426,7 +430,7 @@ def test_search_using_section_filter_for_public_user(client, app):
         'name': 'product test',
         'query': 'headline:more',
         'companies': [COMPANY_1_ID],
-        'navigations': ['51'],
+        'navigations': [NAV_1],
         'is_enabled': True,
         'product_type': 'wire'
     }, {
@@ -434,7 +438,7 @@ def test_search_using_section_filter_for_public_user(client, app):
         'name': 'product test 2',
         'query': 'headline:Weather',
         'companies': [COMPANY_1_ID],
-        'navigations': ['52'],
+        'navigations': [NAV_2],
         'is_enabled': True,
         'product_type': 'wire'
     }])
@@ -447,7 +451,7 @@ def test_search_using_section_filter_for_public_user(client, app):
     data = json.loads(resp.get_data())
     assert 2 == len(data['_items'])
     assert '_aggregations' in data
-    resp = client.get('/wire/search?navigation=52')
+    resp = client.get(f'/wire/search?navigation={NAV_2}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
     assert '_aggregations' in data
@@ -464,11 +468,11 @@ def test_search_using_section_filter_for_public_user(client, app):
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
 
-    resp = client.get('/wire/search?navigation=52')
+    resp = client.get(f'/wire/search?navigation={NAV_2}')
     data = json.loads(resp.get_data())
     assert 1 == len(data['_items'])
 
-    resp = client.get('/wire/search?navigation=51')
+    resp = client.get(f'/wire/search?navigation={NAV_1}')
     data = json.loads(resp.get_data())
     assert 0 == len(data['_items'])
 


### PR DESCRIPTION
Fixes bug introduced in https://github.com/superdesk/newsroom-core/pull/122