### PR TITLE
avoid long lines in email body

### DIFF
--- a/newsroom/data_updates.py
+++ b/newsroom/data_updates.py
@@ -290,7 +290,7 @@ superdesk.command('data:downgrade', Downgrade())
 class DataUpdate:
 
     def apply(self, direction):
-        assert(direction in ['forwards', 'backwards'])
+        assert direction in ['forwards', 'backwards']
         collection = current_app.data.get_mongo_collection(self.resource)
         db = current_app.data.driver.db
         getattr(self, direction)(collection, db)

--- a/newsroom/tests/news_api/steps.py
+++ b/newsroom/tests/news_api/steps.py
@@ -49,10 +49,10 @@ def we_get_text_in_response(context, text):
 @then('we "{get}" "{text}" in atom xml response')
 def we_get_text_in_atom_xml_response(context, get, text):
     with context.app.test_request_context(context.app.config['URL_PREFIX']):
-        assert(isinstance(get_body(context.response), str))
+        assert (isinstance(get_body(context.response), str))
         tree = lxml.etree.fromstring(get_body(context.response).encode('utf-8'))
         assert '{http://www.w3.org/2005/Atom}feed' == tree.tag
         if get == 'get':
-            assert(text in get_body(context.response))
+            assert (text in get_body(context.response))
         else:
             assert (text not in get_body(context.response))

--- a/newsroom/tests/steps.py
+++ b/newsroom/tests/steps.py
@@ -49,10 +49,10 @@ def we_get_text_in_response(context, text):
 @then('we "{get}" "{text}" in atom xml response')
 def we_get_text_in_atom_xml_response(context, get, text):
     with context.app.test_request_context(context.app.config['URL_PREFIX']):
-        assert(isinstance(get_body(context.response), str))
+        assert (isinstance(get_body(context.response), str))
         tree = lxml.etree.fromstring(get_body(context.response).encode('utf-8'))
         assert '{http://www.w3.org/2005/Atom}feed' == tree.tag
         if get == 'get':
-            assert(text in get_body(context.response))
+            assert (text in get_body(context.response))
         else:
             assert (text not in get_body(context.response))


### PR DESCRIPTION
according to RFC 5322 any line in an email can't be longer than 998
characters so try to pretty print the html which reformats it
instead of printing everything on a single line, also enforce
line limit on text via splitting longer lines.

CPNHUB-132