### PR TITLE
[STTNHUB-177] fix: Add coverage hits to search results

### DIFF
--- a/assets/agenda/components/AgendaList.jsx
+++ b/assets/agenda/components/AgendaList.jsx
@@ -101,7 +101,7 @@ class AgendaList extends React.Component {
         }
 
         this.previewTimeout = setTimeout(() => this.props.dispatch(
-            previewItem(nextItem, nextItemInList.group, nextItemInList.plan)
+            previewItem(nextItem, nextItemInList.group, get(nextItemInList, 'plan.guid'))
         ), PREVIEW_TIMEOUT);
 
         const activeElements = document.getElementsByClassName('wire-articles__item--open');

--- a/assets/agenda/components/AgendaPreviewPlanning.jsx
+++ b/assets/agenda/components/AgendaPreviewPlanning.jsx
@@ -24,7 +24,7 @@ export class AgendaPreviewPlanning extends React.Component {
         if (isPlanningItem(item)) {
             return (
                 <AgendaPreviewCoverages
-                    key={plan.guid}
+                    key={item.guid}
                     item={item}
                     plan={plan}
                     wireItems={wireItems}

--- a/features/web_api/agenda_search.feature
+++ b/features/web_api/agenda_search.feature
@@ -159,7 +159,7 @@ Feature: Agenda Search
         ["plan1", "plan2", "plan3"]
         """
 
-    @auth @admin @wip
+    @auth @admin
     Scenario: Search Planning with Events
         When we get "/agenda/search"
         Then we get aggregations
@@ -183,7 +183,8 @@ Feature: Agenda Search
             "_id": "event1",
             "_hits": {
                 "matched_event": true,
-                "matched_planning_items": ["plan1", "plan2"]
+                "matched_planning_items": ["plan1", "plan2"],
+                "matched_coverages": "__none__"
             }
         }]}
         """
@@ -194,7 +195,8 @@ Feature: Agenda Search
             "_id": "event1",
             "_hits": {
                 "matched_event": false,
-                "matched_planning_items": ["plan1"]
+                "matched_planning_items": ["plan1"],
+                "matched_coverages": "__none__"
             }
         }]}
         """
@@ -205,7 +207,8 @@ Feature: Agenda Search
             "_id": "event1",
             "_hits": {
                 "matched_event": true,
-                "matched_planning_items": ["plan2"]
+                "matched_planning_items": ["plan2"],
+                "matched_coverages": ["plan2_cov1"]
             }
         }]}
         """


### PR DESCRIPTION
Fixes the issue where planning/coverages were still shown if another planning/coverage matched from same parent Event