### PR TITLE
fix(push/notify): Add default value for search.planning_items_should

### DIFF
--- a/newsroom/search.py
+++ b/newsroom/search.py
@@ -63,6 +63,7 @@ class SearchQuery(object):
         self.query = {"bool": {"must": [], "must_not": [], "should": []}}
         self.highlight = None
         self.item_type = None
+        self.planning_items_should = []
 
 
 class BaseSearchService(Service):


### PR DESCRIPTION
This was happening when pushing Agenda items and checking for matching Topics.
```
ERROR:newsroom.push:'SearchQuery' object has no attribute 'planning_items_should'
Traceback (most recent call last):
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/push.py", line 703, in notify_new_item
    notify_agenda_topic_matches(item, user_dict, company_dict)
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/push.py", line 798, in notify_agenda_topic_matches
    topic_matches = superdesk.get_resource_service("agenda").get_matching_topics(
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/agenda/agenda.py", line 1226, in get_matching_topics
    return self.get_matching_topics_for_item(
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/search.py", line 668, in get_matching_topics_for_item
    self.apply_products_filter(search)
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/search.py", line 540, in apply_products_filter
    self.apply_product_filter(search, product)
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/agenda/agenda.py", line 920, in apply_product_filter
    search.planning_items_should.append(planning_items_query_string(product.get("planning_item_query")))
AttributeError: 'SearchQuery' object has no attribute 'planning_items_should'
ERROR:newsroom.push:Failed to notify users for new agenda item
```