### PR TITLE
Fix report date formatting

### DIFF
--- a/assets/company-reports/actions.js
+++ b/assets/company-reports/actions.js
@@ -41,11 +41,11 @@ function getReportQueryString(currentState, next, exportReport, notify) {
         }
 
         if (params.date_from) {
-            params.date_from = getDateInputDate(params.date_from);
+            params.date_from = getDateInputDate((new Date(params.date_from)).toISOString());
         }
 
         if (params.date_to) {
-            params.date_to = getDateInputDate(params.date_to);
+            params.date_to = getDateInputDate((new Date(params.date_to)).toISOString());
         }
 
         if (params.section) {

--- a/newsroom/reports/content_activity.py
+++ b/newsroom/reports/content_activity.py
@@ -57,7 +57,7 @@ def get_items(args):
     get_resource_service("section_filters").apply_section_filter(source["query"], section)
 
     while True:
-        results = get_resource_service("{}_search".format(section)).search(source)
+        results = get_resource_service(section if section == "agenda" else f"{section}_search").search(source)
         items = list(results)
 
         if not len(items):
@@ -147,7 +147,7 @@ def get_facets(args):
         section = args["section"]
         get_resource_service("section_filters").apply_section_filter(source["query"], section)
 
-        results = get_resource_service("{}_search".format(section)).search(source)
+        results = get_resource_service(section if section == "agenda" else f"{section}_search").search(source)
 
         buckets = ((results.hits.get("aggregations") or {}).get("genres") or {}).get("buckets") or []
 


### PR DESCRIPTION
`date_from` and `date_to` is stored used number not string, and was throwing the following:
```
newsroom_js.5b7207d103d2857d2911.js:332 Uncaught TypeError: dateString.substring is not a function
    at getDateInputDate (newsroom_js.5b7207d103d2857d2911.js:332:43)
    at getReportQueryString (company_reports_js.cbe68e636033e691c9f6.js:2766:60)
    at company_reports_js.cbe68e636033e691c9f6.js:2870:27
    at common.29dfbea423aa904b3128.js:33153:18
```

Was also throwing this on the backend:
```
File "/home/marklark/miniconda3/envs/cp-nhub/lib/python3.8/site-packages/newsroom/reports/content_activity.py", line 303, in get_content_activity_report
  for items in get_items(args):
File "/home/marklark/miniconda3/envs/cp-nhub/lib/python3.8/site-packages/newsroom/reports/content_activity.py", line 60, in get_items
  results = get_resource_service("{}_search".format(section)).search(source)
File "/home/marklark/miniconda3/envs/cp-nhub/lib/python3.8/site-packages/superdesk/__init__.py", line 122, in get_resource_service
  return resources[resource_name].service
KeyError: 'agenda_search'
```