### PR TITLE
[CPNHUB-159] fix(search): Dont add _type to resource searches

### DIFF
--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -298,7 +298,7 @@ class AgendaResource(newsroom.Resource):
 def _agenda_query():
     return {
         "bool": {
-            "must": [{"term": {"_type": "agenda"}}],
+            "must": [],
             "should": [],
             "must_not": [{"term": {"state": "killed"}}],
         }

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -667,6 +667,7 @@ def set_item_reference(coverage):
     if item:
         if "planning_id" not in item and "coverage_id" not in item:
             service = superdesk.get_resource_service("content_api")
+            service.datasource = "items"
             service.patch(
                 item.get("_id"),
                 updates={

--- a/newsroom/search.py
+++ b/newsroom/search.py
@@ -437,7 +437,6 @@ class BaseSearchService(Service):
         """
 
         search.query["bool"]["must_not"].append({"term": {"type": "composite"}})
-        search.query["bool"]["must"].append({"term": {"_type": "items"}})
         if not search.args.get("ignore_latest", False):
             search.query["bool"]["must_not"].append(
                 {"constant_score": {"filter": {"exists": {"field": "nextversion"}}}}

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -42,7 +42,6 @@ class WireSearchResource(newsroom.Resource):
             "charcount": 1,
             "version": 1,
         },
-        "elastic_filter": {"bool": {"must": [{"term": {"_type": "items"}}]}},
     }
 
     item_methods = ["GET"]
@@ -78,7 +77,7 @@ def items_query(ignore_latest=False):
     query = {
         "bool": {
             "must_not": [{"term": {"type": "composite"}}],
-            "must": [{"term": {"_type": "items"}}],
+            "must": [],
         }
     }
 

--- a/tests/search/test_search_params.py
+++ b/tests/search/test_search_params.py
@@ -286,7 +286,6 @@ def test_prefill_search_products__public_products(client, app):
 def test_prefill_search_items(client, app):
     with app.test_request_context():
         search = get_search_instance()
-        assert {"term": {"_type": "items"}} in search.query["bool"]["must"]
         assert {"term": {"type": "composite"}} in search.query["bool"]["must_not"]
         assert {"constant_score": {"filter": {"exists": {"field": "nextversion"}}}} in search.query["bool"]["must_not"]
 


### PR DESCRIPTION
From what I could tell, `_type` was required in searches as Agenda items used to be stored in the `items` resource. This was changed before first production release of Newsroom, so we don't need this anymore.

It also looks like linking of Content to Coverages changed this `_type` on push.