### PR TITLE
[CPNHUB-157] fix(email): Use SMTP so headers are escaped

### DIFF
--- a/newsroom/email.py
+++ b/newsroom/email.py
@@ -26,7 +26,7 @@ from superdesk.logging import logger
 class NewsroomMessage(Message):
     def _message(self):
         msg = super()._message()
-        msg.policy = email_policy.SMTPUTF8
+        msg.policy = email_policy.SMTP
         return msg
 
 


### PR DESCRIPTION
Using SMTPUTF8 was causing issues with some subjects not rendering properly in Outlook. Based on the docs `Useful for serializing messages to a message store without using encoded words in the headers`.