### PR TITLE
[CPNHUB-179] fix(schema): Make `user` attribute mandatory for Topics

### DIFF
--- a/newsroom/topics/topics.py
+++ b/newsroom/topics/topics.py
@@ -14,7 +14,7 @@ class TopicsResource(newsroom.Resource):
         "query": {"type": "string", "nullable": True},
         "filter": {"type": "dict", "nullable": True},
         "created": {"type": "dict", "nullable": True},
-        "user": newsroom.Resource.rel("users"),  # This is the owner of the "My Topic"
+        "user": newsroom.Resource.rel("users", required=True),  # This is the owner of the "My Topic"
         "company": newsroom.Resource.rel("companies", required=True),
         "is_global": {"type": "boolean", "default": False},
         "subscribers": {


### PR DESCRIPTION
This is required as there is no way to know who to return the Topic to if it is converted from a `Company Topic` to a `My Topic`.