### PR TITLE
fix agenda items display when filtering by date

### DIFF
--- a/assets/agenda/tests/utils.spec.js
+++ b/assets/agenda/tests/utils.spec.js
@@ -42,9 +42,9 @@ describe('utils', () => {
                 },
             ];
 
-            const groupedItems = keyBy(utils.groupItems(items, '2018-10-16', 'day'), 'date');
+            const groupedItems = keyBy(utils.groupItems(items, '2018-10-21', 'day'), 'date');
 
-            expect(groupedItems.hasOwnProperty('15-10-2018')).toBe(false);
+            expect(groupedItems['15-10-2018']['items']).toEqual(['foo']);
             expect(groupedItems['16-10-2018']['items']).toEqual(['foo']);
             expect(groupedItems['17-10-2018']['items']).toEqual(['foo', 'bar']);
             expect(groupedItems['18-10-2018']['items']).toEqual(['bar']);

--- a/assets/agenda/utils.js
+++ b/assets/agenda/utils.js
@@ -671,7 +671,7 @@ export function groupItems (items, activeDate, activeGrouping, featuredOnly) {
             const itemExtraDates = getExtraDates(item);
             const itemStartDate = getStartDate(item);
             const start = item._display_from ? moment(item._display_from) :
-                moment.max(maxStart, moment.min(itemExtraDates.concat([itemStartDate])));
+                moment.min(maxStart, moment.min(itemExtraDates.concat([itemStartDate])));
             const itemEndDate = getEndDate(item);
 
             // If item is an event and was actioned (postponed, rescheduled, cancelled only incase of multi-day event)


### PR DESCRIPTION
when using from filter it can go before selected day on top
and then no items were visible

CPNHUB-196