### PR TITLE
[NHUB-259] fix(bs5): Dropdown menus not hiding if filter is active

### DIFF
--- a/assets/agenda/components/AgendaFilterButton.jsx
+++ b/assets/agenda/components/AgendaFilterButton.jsx
@@ -1,27 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {gettext} from 'utils';
-import classNames from 'classnames';
+
+import DropdownFilterButton from 'components/DropdownFilterButton';
 
 const getActiveFilterLabel = (filter, activeFilter, isActive) => {
     return isActive ? gettext(activeFilter[filter.field][0]) : gettext(filter.label);
 };
 
 function AgendaFilterButton({filter, activeFilter, autoToggle, onClick}) {
-    const isActive = activeFilter[filter.field];
-    return (<button
-        id={filter.field}
-        type='button'
-        className={classNames('btn btn-outline-primary btn-sm d-flex align-items-center px-2 ms-2',
-            {'active': isActive})}
-        data-bs-toggle={autoToggle ? 'dropdown' : undefined}
-        aria-haspopup='true'
-        aria-expanded='false'
-        onClick={onClick} >
-        <i className={`${filter.icon} d-md-none`}></i>
-        <span className='d-none d-md-block'>{getActiveFilterLabel(filter, activeFilter, isActive)}</span>
-        <i className={classNames('icon-small--arrow-down ms-1', {'icon--white': isActive})}></i>
-    </button>);
+    const isActive = (activeFilter[filter.field] || []).length > 0;
+
+    return (
+        <DropdownFilterButton
+            id={filter.field}
+            isActive={isActive}
+            autoToggle={autoToggle}
+            onClick={onClick}
+            icon={filter.icon}
+            label={getActiveFilterLabel(filter, activeFilter, isActive)}
+        />
+    );
 }
 
 AgendaFilterButton.propTypes = {

--- a/assets/components/DropdownFilterButton.jsx
+++ b/assets/components/DropdownFilterButton.jsx
@@ -2,41 +2,64 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-function DropdownFilterButton({id, isActive, autoToggle, onClick, icon, label, textOnly, iconColour}) {
-    return (
-        <button
-            id={id}
-            type="button"
-            className={classNames(
-                'btn btn-sm d-flex align-items-center px-2 ms-2',
-                {
-                    active: isActive,
-                    'btn-text-only': textOnly,
-                    'btn-outline-primary': !textOnly,
-                }
-            )}
-            data-bs-toggle={autoToggle ? 'dropdown' : undefined}
-            aria-haspopup="true"
-            aria-expanded="false"
-            onClick={onClick}
-        >
-            {!icon ? null : (
-                <i className={`${icon} d-md-none`} />
-            )}
-            {textOnly ? label : (
-                <span className="d-none d-md-block">
-                    {label}
-                </span>
-            )}
-            <i className={classNames(
-                'icon-small--arrow-down ms-1',
-                {
-                    'icon--white': isActive && !iconColour,
-                    [`icon--${iconColour}`]: iconColour
-                }
-            )} />
-        </button>
-    );
+class DropdownFilterButton extends React.PureComponent {
+    constructor(props) {
+        super(props);
+
+        this.dom = {button: null};
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.isActive !== prevProps.isActive && this.dom.button != null) {
+            // Manually add/remove the ``active`` class on the button through the DOM
+            // As the dropdown menu doesn't hide if we manage this class name using React
+            if (this.props.isActive) {
+                this.dom.button.classList.add('active');
+            } else {
+                this.dom.button.classList.remove('active');
+            }
+        }
+    }
+
+    render() {
+        const {id, isActive, autoToggle, onClick, icon, label, textOnly, iconColour} = this.props;
+
+        return (
+            <button
+                id={id}
+                key={id}
+                type="button"
+                ref={(elem) => this.dom.button = elem}
+                className={classNames(
+                    'btn btn-sm d-flex align-items-center px-2 ms-2',
+                    {
+                        'btn-text-only': textOnly,
+                        'btn-outline-primary': !textOnly,
+                    }
+                )}
+                data-bs-toggle={autoToggle ? 'dropdown' : undefined}
+                aria-haspopup="true"
+                aria-expanded="false"
+                onClick={onClick}
+            >
+                {!icon ? null : (
+                    <i className={`${icon} d-md-none`} />
+                )}
+                {textOnly ? label : (
+                    <span className="d-none d-md-block">
+                        {label}
+                    </span>
+                )}
+                <i className={classNames(
+                    'icon-small--arrow-down ms-1',
+                    {
+                        'icon--white': isActive && !iconColour,
+                        [`icon--${iconColour}`]: iconColour
+                    }
+                )} />
+            </button>
+        );
+    }
 }
 
 DropdownFilterButton.propTypes = {

--- a/assets/components/MultiSelectDropdown.jsx
+++ b/assets/components/MultiSelectDropdown.jsx
@@ -2,8 +2,34 @@ import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-function MultiSelectDropdown({values, label, field, options, onChange, showAllButton, multi}) {
-    const onChanged = (option) => {
+class MultiSelectDropdown extends React.PureComponent {
+    constructor(props) {
+        super(props);
+
+        this.dom = {button: null};
+    }
+
+    isActive(props) {
+        return (props.multi && !!props.values.length) || (!props.multi && props.values !== null);
+    }
+
+    componentDidUpdate(prevProps) {
+        const isActive = this.isActive(this.props);
+
+        if (isActive !== this.isActive(prevProps) && this.dom.button != null) {
+            // Manually add/remove the ``active`` class on the button through the DOM
+            // As the dropdown menu doesn't hide if we manage this class name using React
+            if (isActive) {
+                this.dom.button.classList.add('active');
+            } else {
+                this.dom.button.classList.remove('active');
+            }
+        }
+    }
+
+    onChanged(option) {
+        const {values, field, onChange, multi} = this.props;
+
         if (multi) {
             if (option === 'all') {
                 onChange(field, []);
@@ -19,79 +45,80 @@ function MultiSelectDropdown({values, label, field, options, onChange, showAllBu
                 onChange(field, option);
             }
         }
-    };
+    }
 
-    const isActive = (multi && !!values.length) || (!multi && values !== null);
+    render() {
+        const {values, label, field, options, showAllButton, multi} = this.props;
+        const isActive = this.isActive(this.props);
 
-    return (
-        <div className='btn-group' key={field}>
-            <button
-                id={field}
-                type='button'
-                className={classNames(
-                    'btn btn-outline-primary btn-sm d-flex align-items-center px-2 ms-2',
-                    {'active': isActive}
-                )}
-                aria-haspopup='true'
-                aria-expanded='false'
-                data-bs-toggle='dropdown'
-            >
-                {multi && (
-                    <span className='d-block'>{label}</span>
-                )}
+        return (
+            <div className='btn-group' key={field}>
+                <button
+                    id={field}
+                    type='button'
+                    ref={(elem) => this.dom.button = elem}
+                    className="btn btn-outline-primary btn-sm d-flex align-items-center px-2 ms-2"
+                    aria-haspopup='true'
+                    aria-expanded='false'
+                    data-bs-toggle='dropdown'
+                >
+                    {multi && (
+                        <span className='d-block'>{label}</span>
+                    )}
 
-                {(!multi && !values) && (
-                    <span className='d-block'>All {label}</span>
-                )}
+                    {(!multi && !values) && (
+                        <span className='d-block'>All {label}</span>
+                    )}
 
-                {(!multi && values) && (
-                    <span className='d-block'>{values}</span>
-                )}
-                <i className={classNames('icon-small--arrow-down ms-1', {'icon--white': isActive})}  />
-            </button>
-            <div className='dropdown-menu' aria-labelledby={field}>
-                {showAllButton && (
-                    <Fragment>
-                        <button
-                            className='dropdown-item'
-                            onClick={onChanged.bind(null, 'all')}
-                        >
-                            <i className={classNames(
-                                'me-2',
-                                {
-                                    'icon--': isActive,
-                                    'icon--check': !isActive,
-                                }
-                            )}
-                            />
-                            <span>All {label}</span>
-                        </button>
-                        <div className='dropdown-divider' />
-                    </Fragment>
-                )}
-                {options.map((option) => (
-                    <Fragment key={option.value}>
-                        <button
-                            className='dropdown-item'
-                            onClick={onChanged.bind(null, option.value)}
-                        >
-                            <i className={classNames(
-                                'me-2',
-                                {
-                                    'icon--': (multi && !values.includes(option.value)) ||
-                                        (!multi && values !== option.value),
-                                    'icon--check': (multi && values.includes(option.value)) ||
-                                        (!multi && values === option.value),
-                                }
-                            )}
-                            />
-                            <span>{option.label}</span>
-                        </button>
-                    </Fragment>
-                ))}
+                    {(!multi && values) && (
+                        <span className='d-block'>{values}</span>
+                    )}
+                    <i className={classNames('icon-small--arrow-down ms-1', {'icon--white': isActive})}  />
+                </button>
+                <div className='dropdown-menu' aria-labelledby={field}>
+                    {showAllButton && (
+                        <Fragment>
+                            <button
+                                className='dropdown-item'
+                                onClick={this.onChanged.bind(this, 'all')}
+                            >
+                                <i className={classNames(
+                                    'me-2',
+                                    {
+                                        'icon--': isActive,
+                                        'icon--check': !isActive,
+                                    }
+                                )}
+                                />
+                                <span>All {label}</span>
+                            </button>
+                            <div className='dropdown-divider' />
+                        </Fragment>
+                    )}
+                    {options.map((option) => (
+                        <Fragment key={option.value}>
+                            <button
+                                className='dropdown-item'
+                                onClick={this.onChanged.bind(this, option.value)}
+                            >
+                                <i className={classNames(
+                                    'me-2',
+                                    {
+                                        'icon--': (multi && !values.includes(option.value)) ||
+                                            (!multi && values !== option.value),
+                                        'icon--check': (multi && values.includes(option.value)) ||
+                                            (!multi && values === option.value),
+                                    }
+                                )}
+                                />
+                                <span>{option.label}</span>
+                            </button>
+                        </Fragment>
+                    ))}
+                </div>
             </div>
-        </div>
-    );
+        );
+    }
 }
 
 MultiSelectDropdown.propTypes = {

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -700,7 +700,7 @@ class AgendaService(BaseSearchService):
                     if all([coverage_id in items for items in coverages_by_filter.values()])
                 ]
 
-            if doc["item_type"] == "planning":
+            if doc.get("item_type") == "planning":
                 # If this is a Planning item, then ``inner_hits`` should only include the
                 # fields relevant to the Coverages (as this is the only nested field of a Planning item)
                 inner_hits = {key: val for key, val in inner_hits.items() if key in planning_filters}


### PR DESCRIPTION
The solution here is a hack, as I was unable to get the dropdown button & menu to behave properly when applying the `active` class using React.

It seems that whenever the `className` of the `DropdownFilterButton` is changed via React, Bootstrap loses control of the menu (show/hide etc). I tested this by adding a `className` property and passing in the `active` class from a higher component, which caused the menu to not behave properly when the class changed