### PR TITLE
[NHUB-263] fix(user_update): Remove unnecessary cache delete in blueprint

### DIFF
--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -202,9 +202,7 @@ def edit(_id):
                         {"_id": product["_id"], "section": product["product_type"]} for product in products.values()
                     ]
 
-            user = get_resource_service("users").patch(ObjectId(_id), updates=updates)
-            app.cache.delete(user.get("email"))
-            app.cache.delete(_id)
+            get_resource_service("users").patch(ObjectId(_id), updates=updates)
             return jsonify({"success": True}), 200
         return jsonify(form.errors), 400
     return jsonify(user), 200


### PR DESCRIPTION
As the cache delete happens on the resource service now
https://github.com/superdesk/newsroom-core/blob/develop/newsroom/users/users.py#L160.

This was causing an issue only where cache is enabled. From the cp-uat logs:
```
Traceback (most recent call last):
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/decorator.py", line 19, in decorated_function
    return f(*args, **kwargs)
  File "/opt/newsroom/env/lib/python3.8/site-packages/newsroom/users/views.py", line 206, in edit
    app.cache.delete(user.get("email"))
  File "/opt/newsroom/env/lib/python3.8/site-packages/flask_caching/__init__.py", line 206, in delete
    return self.cache.delete(*args, **kwargs)
  File "/opt/newsroom/env/lib/python3.8/site-packages/cachelib/redis.py", line 119, in delete
    return bool(self._write_client.delete(self.key_prefix + key))
TypeError: can only concatenate str (not "NoneType") to str
```