### PR TITLE
[CPCN-110] fix: Create separate endpoint to update User Profile

### DIFF
--- a/assets/user-profile/actions.js
+++ b/assets/user-profile/actions.js
@@ -96,7 +96,7 @@ export function saveUser() {
     return function (dispatch, getState) {
 
         const editedUser = {...getState().editedUser};
-        const url = `/users/${editedUser._id}`;
+        const url = `/users/${editedUser._id}/profile`;
 
         // Remove ``sections`` and ``products`` as these aren't managed in the ``UserProfile`` app
         delete editedUser.sections;

--- a/newsroom/users/users.py
+++ b/newsroom/users/users.py
@@ -100,7 +100,7 @@ class UsersResource(newsroom.Resource):
     }
 
 
-NON_ADMIN_ALLOWED_UPDATES = {
+USER_PROFILE_UPDATES = {
     "locale",
     "first_name",
     "last_name",
@@ -113,7 +113,7 @@ NON_ADMIN_ALLOWED_UPDATES = {
 }
 
 
-COMPANY_ADMIN_ALLOWED_UPDATES = NON_ADMIN_ALLOWED_UPDATES.union(
+COMPANY_ADMIN_ALLOWED_UPDATES = USER_PROFILE_UPDATES.union(
     {
         "email",
         "products",
@@ -219,6 +219,6 @@ class UsersService(newsroom.Service):
             if request.url_rule.rule in ["/reset_password/<token>", "/token/<token_type>"]:
                 return
             elif request.url_rule.rule == "/users/<_id>":
-                if not updated_fields or all([key in NON_ADMIN_ALLOWED_UPDATES for key in updated_fields]):
+                if not updated_fields or all([key in USER_PROFILE_UPDATES for key in updated_fields]):
                     return
         abort(403)

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -235,7 +235,7 @@ def get_updates_from_form(form: UserForm):
 @login_required
 def edit_user_profile(_id):
     if not is_current_user(_id):
-        flask.abort(401)
+        flask.abort(403)
 
     user_id = ObjectId(_id)
     user = find_one("users", _id=user_id)

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -27,7 +27,7 @@ from newsroom.notifications import push_user_notification, push_company_notifica
 from newsroom.topics import get_user_topics
 from newsroom.users import blueprint
 from newsroom.users.forms import UserForm
-from newsroom.users.users import COMPANY_ADMIN_ALLOWED_UPDATES, NON_ADMIN_ALLOWED_UPDATES
+from newsroom.users.users import COMPANY_ADMIN_ALLOWED_UPDATES, USER_PROFILE_UPDATES
 from newsroom.utils import query_resource, find_one, get_json_or_400, get_vocabulary
 from newsroom.monitoring.views import get_monitoring_for_company
 
@@ -202,7 +202,7 @@ def edit(_id):
                 flask.abort(401)
 
             if user_is_non_admin or user_is_company_admin:
-                allowed_fields = NON_ADMIN_ALLOWED_UPDATES if user_is_non_admin else COMPANY_ADMIN_ALLOWED_UPDATES
+                allowed_fields = USER_PROFILE_UPDATES if user_is_non_admin else COMPANY_ADMIN_ALLOWED_UPDATES
                 for field in list(updates.keys()):
                     if field not in allowed_fields:
                         updates.pop(field, None)
@@ -229,6 +229,26 @@ def get_updates_from_form(form: UserForm):
             {"_id": product["_id"], "section": product["product_type"]} for product in products.values()
         ]
     return updates
+
+
+@blueprint.route("/users/<_id>/profile", methods=["POST"])
+@login_required
+def edit_user_profile(_id):
+    if not is_current_user(_id):
+        flask.abort(401)
+
+    user_id = ObjectId(_id)
+    user = find_one("users", _id=user_id)
+
+    if not user:
+        return NotFound(gettext("User not found"))
+
+    form = UserForm(user=user)
+    if form.validate_on_submit():
+        updates = {key: val for key, val in form.data.items() if key in USER_PROFILE_UPDATES}
+        get_resource_service("users").patch(user_id, updates=updates)
+        return jsonify({"success": True}), 200
+    return jsonify(form.errors), 400
 
 
 @blueprint.route("/users/<_id>/validate", methods=["POST"])


### PR DESCRIPTION
@petrjasek I created a new endpoint specifically for updating of User Profiles, as we've had numerous issues around creating/updating users between the profile page and settings page (section & product privileges being lost, profile data not being saved etc).

Having a dedicated endpoint that only allows `USER_PROFILE_UPDATES` reduces the risks of breaking the ability to save a User Profile