### PR TITLE
[CPCN-138] fix(api): Include False values when generating flask.g.settings

### DIFF
--- a/newsroom/settings.py
+++ b/newsroom/settings.py
@@ -59,7 +59,7 @@ def get_setting(setting_key=None, include_audit=False):
         settings = copy.deepcopy(flask.current_app._general_settings)
         if values:
             for key, val in values.get("values", {}).items():
-                if val is not None and settings.get(key):
+                if (val or val is False) and settings.get(key):
                     settings[key]["value"] = val
             if include_audit:
                 settings["_updated"] = values.get("_updated")

--- a/newsroom/settings.py
+++ b/newsroom/settings.py
@@ -59,7 +59,7 @@ def get_setting(setting_key=None, include_audit=False):
         settings = copy.deepcopy(flask.current_app._general_settings)
         if values:
             for key, val in values.get("values", {}).items():
-                if (val or val is False) and settings.get(key):
+                if not (val is None or val == "") and settings.get(key) is not None:
                     settings[key]["value"] = val
             if include_audit:
                 settings["_updated"] = values.get("_updated")

--- a/newsroom/settings.py
+++ b/newsroom/settings.py
@@ -59,7 +59,7 @@ def get_setting(setting_key=None, include_audit=False):
         settings = copy.deepcopy(flask.current_app._general_settings)
         if values:
             for key, val in values.get("values", {}).items():
-                if val and settings.get(key):
+                if val is not None and settings.get(key):
                     settings[key]["value"] = val
             if include_audit:
                 settings["_updated"] = values.get("_updated")

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -18,6 +18,26 @@ def test_general_settings(client, app):
     assert "bar" == get_setting()["foo"]["default"]
 
 
+def test_boolean_settings(client, app):
+    app.general_setting("foo", "Foo", default=False)
+    assert get_setting("foo") is False
+    post_json(client, "/settings/general_settings", {"foo": True})
+    assert get_setting("foo") is True
+    post_json(client, "/settings/general_settings", {"foo": False})
+    assert get_setting("foo") is False
+    post_json(client, "/settings/general_settings", {"foo": None})
+    assert get_setting("foo") is False
+
+    app.general_setting("bar", "Bar", default=True)
+    assert get_setting("bar") is True
+    post_json(client, "/settings/general_settings", {"bar": False})
+    assert get_setting("bar") is False
+    post_json(client, "/settings/general_settings", {"bar": True})
+    assert get_setting("bar") is True
+    post_json(client, "/settings/general_settings", {"foo": None})
+    assert get_setting("bar") is True
+
+
 def test_news_only_filter(client, app):
     query = get_setting("news_only_filter")
     assert query is None


### PR DESCRIPTION
A bug with boolean settings, such as `allow_companies_to_manage_products`, where a valid `False` value was not being stored in `flask.g.settings`, resulting in the default value being used instead.