### PR TITLE
[CPCN-139] fix(ui): Sort users by is_validated instead of is_enabled

### DIFF
--- a/assets/users/components/filters/UserListSortFilter.jsx
+++ b/assets/users/components/filters/UserListSortFilter.jsx
@@ -31,7 +31,7 @@ export class UserListSortFilter extends React.PureComponent {
             _id: 'user_type',
             name: gettext('User Type'),
         }, {
-            _id: 'is_enabled',
+            _id: 'is_validated',
             name: gettext('User Status'),
         }];
 


### PR DESCRIPTION
This will sort by users who have validated their account and logged in at least once, vs those who have never logged in