### PR TITLE
[CPNHUB-157] fix: Email subjects include html entities from template vars

### DIFF
--- a/newsroom/email_templates.py
+++ b/newsroom/email_templates.py
@@ -35,9 +35,9 @@ class EmailTemplatesResource(Resource):
 
 DEFAULT_SUBJECTS = {
     "agenda_new_coverage_email": "New coverage",
-    "agenda_updated_email": "{{ agenda.name or agenda.headline or agenda.slugline | safe }}"
+    "agenda_updated_email": "{{ (agenda.name or agenda.headline or agenda.slugline) | safe }}"
     " -{{ ' Coverage' if coverage_modified else '' }} updated",
-    "coverage_request_email": "Coverage inquiry: {{ item.name or item.slugline | safe }}",
+    "coverage_request_email": "Coverage inquiry: {{ (item.name or item.slugline) | safe }}",
     "company_expiry_alert_user": "Your Company's account is expiring on {{ expires_on }}",
     "company_expiry_email": "Companies expired or due to expire within the next 7 days ({{ expires_on }})",
     "signup_request_email": "A new Newshub signup request",
@@ -49,12 +49,12 @@ DEFAULT_SUBJECTS = {
     "updated_wire_notification_email": "New update for your previously accessed story {{ item.headline | safe }}",
     "updated_agenda_notification_email": "New update for your previously accessed agenda {{ item.name | safe }}",
     "monitoring_email": "{% if profile.headline_subject and items | length == 1 %}"
-    "{{ items[0].headline or profile.subject or profile.name | safe }}"
+    "{{ (items[0].headline or profile.subject or profile.name) | safe }}"
     "{% else %}"
-    "{{ profile.subject or profile.name | safe }}"
+    "{{ (profile.subject or profile.name) | safe }}"
     "{% endif %}",
     "monitoring_error": "Error sending alerts for monitoring: {{ profile.name | safe }}",
-    "monitoring_email_no_updates": "{{ profile.subject or profile.name | safe }}",
+    "monitoring_email_no_updates": "{{ (profile.subject or profile.name) | safe }}",
     "share_items": "From {{ app_name }}: {{ subject_name | safe }}",
     "share_topic": "From {{ app_name }}: {{ topic.label | safe }}",
     "share_wire": "From {{ app_name }}: {{ subject_name | safe }}",


### PR DESCRIPTION
`safe` was only applied to the last variable when expanding template vars