### PR TITLE
[CPCN-153] fix: Send company product updates via company endpoint

### DIFF
--- a/assets/companies/actions.js
+++ b/assets/companies/actions.js
@@ -20,6 +20,28 @@ export function editCompany(event) {
     return {type: EDIT_COMPANY, event};
 }
 
+export const TOGGLE_COMPANY_SECTION = 'TOGGLE_COMPANY_SECTION';
+export function toggleCompanySection(sectionId) {
+    return {type: TOGGLE_COMPANY_SECTION, sectionId: sectionId};
+}
+
+export const TOGGLE_COMPANY_PRODUCT = 'TOGGLE_COMPANY_PRODUCT';
+export function toggleCompanyProduct(productId, sectionId, enable) {
+    return {type: TOGGLE_COMPANY_PRODUCT, payload: {
+        productId: productId,
+        sectionId: sectionId,
+        enable: enable,
+    }};
+}
+
+export const UPDATE_COMPANY_SEATS = 'UPDATE_COMPANY_SEATS';
+export function updateCompanySeats(productId, seats) {
+    return {type: UPDATE_COMPANY_SEATS, payload: {
+        productId: productId,
+        seats: seats,
+    }};
+}
+
 export const NEW_COMPANY = 'NEW_COMPANY';
 export function newCompany(data) {
     return {type: NEW_COMPANY, data};
@@ -97,28 +119,23 @@ export function fetchCompanyUsers(companyId, force = false) {
  * Creates new company
  *
  */
-export function postCompany(permissions = null) {
+export function postCompany() {
     return function (dispatch, getState) {
-
         const company = getState().companyToEdit;
         const url = `/companies/${company._id ? company._id : 'new'}`;
 
-        return (permissions == null ?
-            Promise.resolve() :
-            dispatch(savePermissions(company, permissions))
-        ).then(() => {
-            return server.post(url, company)
-                .then(function() {
-                    if (company._id) {
-                        notify.success(gettext('Company updated successfully'));
-                    } else {
-                        notify.success(gettext('Company created successfully'));
-                    }
-                    dispatch(fetchProducts());
-                    dispatch(fetchCompanies());
-                })
-                .catch((error) => errorHandler(error, dispatch, setError));
-        });
+        return server.post(url, company)
+            .then(function () {
+                if (company._id) {
+                    notify.success(gettext('Company updated successfully'));
+                } else {
+                    notify.success(gettext('Company created successfully'));
+                }
+                dispatch(fetchProducts());
+                dispatch(fetchCompanies());
+                dispatch(cancelEdit());
+            })
+            .catch((error) => errorHandler(error, dispatch, setError));
     };
 }
 
@@ -133,18 +150,6 @@ export function fetchProducts() {
             .then((data) => {
                 dispatch(getProducts(data));
             })
-            .catch((error) => errorHandler(error, dispatch, setError));
-    };
-}
-
-
-/**
- * Save permissions for a company
- *
- */
-export function savePermissions(company, permissions) {
-    return function (dispatch) {
-        return server.post(`/companies/${company._id}/permissions`, permissions)
             .catch((error) => errorHandler(error, dispatch, setError));
     };
 }

--- a/assets/companies/components/CompanyPermissions.jsx
+++ b/assets/companies/components/CompanyPermissions.jsx
@@ -5,14 +5,22 @@ import {gettext} from 'utils';
 import CheckboxInput from 'components/CheckboxInput';
 
 function CompanyPermissions({
+    company,
     sections,
     products,
-    permissions,
     save,
-    toggleGeneralPermission,
-    toggleProductPermission,
-    updateProductSeats,
+    onChange,
+    toggleCompanySection,
+    toggleCompanyProduct,
+    updateCompanySeats,
 }) {
+    const productsEnabled = (company.products || []).map((product) => product._id);
+    const seats = (company.products || []).reduce((productSeats, product) => {
+        productSeats[product._id] = product.seats;
+
+        return productSeats;
+    }, {});
+
     return (
         <div className='tab-pane active' id='company-permissions'>
             <form onSubmit={save}>
@@ -24,28 +32,22 @@ function CompanyPermissions({
                                 <CheckboxInput
                                     name="archive_access"
                                     label={gettext('Grant Access To Archived Wire')}
-                                    value={!!permissions.archive_access}
-                                    onChange={() => {
-                                        toggleGeneralPermission('archive_access');
-                                    }}
+                                    value={company.archive_access}
+                                    onChange={onChange}
                                 />
                             </li>
                             <li>
                                 <CheckboxInput
                                     name="events_only"
                                     label={gettext('Events Only Access')}
-                                    value={!!permissions.events_only}
-                                    onChange={() => {
-                                        toggleGeneralPermission('events_only');
-                                    }}
+                                    value={company.events_only}
+                                    onChange={onChange}
                                 />
                                 <CheckboxInput
                                     name="restrict_coverage_info"
                                     label={gettext('Restrict Coverage Info')}
-                                    value={!!permissions.restrict_coverage_info}
-                                    onChange={() => {
-                                        toggleGeneralPermission('restrict_coverage_info');
-                                    }}
+                                    value={company.restrict_coverage_info}
+                                    onChange={onChange}
                                 />
                             </li>
                         </ul>
@@ -59,10 +61,8 @@ function CompanyPermissions({
                                     <CheckboxInput
                                         name={item._id}
                                         label={item.name}
-                                        value={!!permissions.sections[item._id]}
-                                        onChange={() => {
-                                            toggleProductPermission('sections', item._id);
-                                        }}
+                                        value={company.sections[item._id] === true}
+                                        onChange={toggleCompanySection.bind(null, item._id)}
                                     />
                                 </li>
                             ))}
@@ -70,7 +70,7 @@ function CompanyPermissions({
                     </div>
 
                     <div className="form-group" key='products'>
-                        {sections.map((section) => (
+                        {sections.filter((section) => company.sections[section._id] === true).map((section) => (
                             [<label key={`${section.id}label`}>{gettext('Products')} {`(${section.name})`}</label>,
                                 <ul key={`${section.id}product`} className="list-unstyled">
                                     {products.filter((p) => (p.product_type || 'wire').toLowerCase() === section._id.toLowerCase())
@@ -81,13 +81,17 @@ function CompanyPermissions({
                                                         <CheckboxInput
                                                             name={product._id}
                                                             label={product.name}
-                                                            value={!!permissions.products[product._id]}
+                                                            value={productsEnabled.includes(product._id)}
                                                             onChange={() => {
-                                                                toggleProductPermission('products', product._id);
+                                                                toggleCompanyProduct(
+                                                                    product._id,
+                                                                    section._id,
+                                                                    !productsEnabled.includes(product._id)
+                                                                );
                                                             }}
                                                         />
                                                     </div>
-                                                    {!permissions.products[product._id] ? null : (
+                                                    {!productsEnabled.includes(product._id) ? null : (
                                                         <React.Fragment>
                                                             <label
                                                                 className="input-group-text border-0 bg-transparent ms-auto"
@@ -103,9 +107,12 @@ function CompanyPermissions({
                                                                 style={{maxWidth: '100px'}}
                                                                 min="0"
                                                                 tabIndex="0"
-                                                                value={(permissions.seats[product._id] || 0).toString()}
+                                                                value={(seats[product._id] || 0).toString()}
                                                                 onChange={(event) => {
-                                                                    updateProductSeats(product._id, event.target.value);
+                                                                    updateCompanySeats(
+                                                                        product._id,
+                                                                        parseInt(event.target.value)
+                                                                    );
                                                                 }}
                                                             />
                                                         </React.Fragment>
@@ -131,6 +138,7 @@ function CompanyPermissions({
 }
 
 CompanyPermissions.propTypes = {
+    company: PropTypes.object,
     sections: PropTypes.arrayOf(PropTypes.shape({
         _id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
@@ -150,9 +158,10 @@ CompanyPermissions.propTypes = {
     }),
 
     save: PropTypes.func.isRequired,
-    toggleGeneralPermission: PropTypes.func.isRequired,
-    toggleProductPermission: PropTypes.func.isRequired,
-    updateProductSeats: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    toggleCompanySection: PropTypes.func.isRequired,
+    toggleCompanyProduct: PropTypes.func.isRequired,
+    updateCompanySeats: PropTypes.func.isRequired,
 };
 
 export default CompanyPermissions;

--- a/assets/companies/reducers.js
+++ b/assets/companies/reducers.js
@@ -1,5 +1,9 @@
+import {cloneDeep} from 'lodash';
 import {
     EDIT_COMPANY,
+    TOGGLE_COMPANY_SECTION,
+    TOGGLE_COMPANY_PRODUCT,
+    UPDATE_COMPANY_SEATS,
     NEW_COMPANY,
     QUERY_COMPANIES,
     SELECT_COMPANY,
@@ -8,7 +12,7 @@ import {
     GET_COMPANY_USERS,
     INIT_VIEW_DATA,
     SET_ERROR,
-    GET_PRODUCTS
+    GET_PRODUCTS,
 } from './actions';
 
 import {ADD_EDIT_USERS} from 'actions';
@@ -77,10 +81,54 @@ export default function companyReducer(state = initialState, action) {
     case EDIT_COMPANY: {
         const target = action.event.target;
         const field = target.name;
-        const company = {...state.companyToEdit};
+        const company = cloneDeep(state.companyToEdit);
 
         company[field] = target.type === 'checkbox' ? target.checked : target.value;
         return {...state, companyToEdit: company, errors: null};
+    }
+
+    case TOGGLE_COMPANY_SECTION: {
+        const company = cloneDeep(state.companyToEdit);
+
+        company.sections[action.sectionId] = !company.sections[action.sectionId];
+
+        return {...state, companyToEdit: company};
+    }
+
+    case TOGGLE_COMPANY_PRODUCT: {
+        const company = cloneDeep(state.companyToEdit);
+
+        const {productId, sectionId, enable} = action.payload;
+
+        if (enable === true) {
+            company.products.push({
+                _id: productId,
+                section: sectionId,
+                seats: 0,
+            });
+        } else {
+            company.products = company.products.filter(
+                (product) => (
+                    product._id !== productId
+                )
+            );
+        }
+
+        return {...state, companyToEdit: company};
+    }
+
+    case UPDATE_COMPANY_SEATS: {
+        const company = cloneDeep(state.companyToEdit);
+
+        const {productId, seats} = action.payload;
+
+        company.products.forEach((product) => {
+            if (product._id === productId) {
+                product.seats = seats;
+            }
+        });
+
+        return {...state, companyToEdit: company};
     }
 
     case NEW_COMPANY: {

--- a/features/web_api/companies_products.feature
+++ b/features/web_api/companies_products.feature
@@ -88,12 +88,14 @@ Feature: Company Products
         """
 
         # 2. Remove access to product: All wire, 69b4c5c61d41c8d736852fbf
-        When we post json to "/companies/1e65964bf5db68883df561b0/permissions"
+        When we post json to "/companies/1e65964bf5db68883df561b0"
         """
         {
-            "name": "All Access Co. 2",
             "sections": {"wire": true, "agenda": true},
-            "products": {"69b4c5c61d41c8d736852fba": true, "69b4c5c61d41c8d736852fbb": true}
+            "products": [
+                {"_id": "69b4c5c61d41c8d736852fba", "section": "wire"},
+                {"_id": "69b4c5c61d41c8d736852fbb", "section": "agenda"}
+            ]
         }
         """
         # Check company permissions
@@ -122,12 +124,14 @@ Feature: Company Products
         """
 
         # 3. Remove access to section: wire
-        When we post json to "/companies/1e65964bf5db68883df561b0/permissions"
+        When we post json to "/companies/1e65964bf5db68883df561b0"
         """
         {
-            "name": "All Access Co. 2",
             "sections": {"wire": false, "agenda": true},
-            "products": {"69b4c5c61d41c8d736852fba": true, "69b4c5c61d41c8d736852fbb": true}
+            "products": [
+                {"_id": "69b4c5c61d41c8d736852fba", "section": "wire"},
+                {"_id": "69b4c5c61d41c8d736852fbb", "section": "agenda"}
+            ]
         }
         """
         # Check company permissions
@@ -150,12 +154,14 @@ Feature: Company Products
         """
 
         # 4. Re-add access to section: wire, & product: All wire, 69b4c5c61d41c8d736852fba
-        When we post json to "/companies/1e65964bf5db68883df561b0/permissions"
+        When we post json to "/companies/1e65964bf5db68883df561b0"
         """
         {
-            "name": "All Access Co. 2",
             "sections": {"wire": true, "agenda": true},
-            "products": {"69b4c5c61d41c8d736852fba": true, "69b4c5c61d41c8d736852fbb": true}
+            "products": [
+                {"_id": "69b4c5c61d41c8d736852fba", "section": "wire"},
+                {"_id": "69b4c5c61d41c8d736852fbb", "section": "agenda"}
+            ]
         }
         """
         # Check company permissions
@@ -181,16 +187,15 @@ Feature: Company Products
         """
 
         # 5. Re-add access to product: All wire, 69b4c5c61d41c8d736852fbf
-        When we post json to "/companies/1e65964bf5db68883df561b0/permissions"
+        When we post json to "/companies/1e65964bf5db68883df561b0"
         """
         {
-            "name": "All Access Co. 2",
             "sections": {"wire": true, "agenda": true},
-            "products": {
-                "69b4c5c61d41c8d736852fbf": true,
-                "69b4c5c61d41c8d736852fba": true,
-                "69b4c5c61d41c8d736852fbb": true
-            }
+            "products": [
+                {"_id": "69b4c5c61d41c8d736852fbf", "section": "wire"},
+                {"_id": "69b4c5c61d41c8d736852fba", "section": "wire"},
+                {"_id": "69b4c5c61d41c8d736852fbb", "section": "agenda"}
+            ]
         }
         """
         # Check company permissions

--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -77,13 +77,13 @@ class CompaniesResource(newsroom.Resource):
 
 class CompaniesService(newsroom.Service):
     def on_update(self, updates, original):
-        if "sections" in updates:
-            original_products = updates.get("products") or original.get("products") or []
-            enabled_sections = [section for section, active in updates.get("sections").items() if active]
-            new_products = [product for product in original_products if product.get("section") in enabled_sections]
-
-            if len(new_products) != len(original_products):
-                updates["products"] = new_products
+        if "sections" in updates or "products" in updates:
+            sections = updates.get("sections", original.get("sections")) or {}
+            updates["products"] = [
+                product
+                for product in updates.get("products", original.get("products")) or []
+                if product.get("section") and sections.get(product["section"]) is True
+            ]
 
     def on_updated(self, updates, original):
         original_section_names = get_company_section_names(original)

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -17,7 +17,6 @@ from newsroom.companies import blueprint
 from newsroom.utils import (
     query_resource,
     find_one,
-    get_entity_or_404,
     get_json_or_400,
     set_original_creator,
     set_version_creator,
@@ -69,13 +68,16 @@ def create():
     return jsonify({"success": True, "_id": ids[0]}), 201
 
 
-def get_errors_company(company):
-    if not company.get("name"):
+def get_errors_company(updates, original=None):
+    if original is None:
+        original = {}
+
+    if not (updates.get("name") or original.get("name")):
         return jsonify({"name": gettext("Name not found")}), 400
 
-    if company.get("allowed_ip_list"):
+    if updates.get("allowed_ip_list"):
         errors = []
-        for ip in company["allowed_ip_list"]:
+        for ip in updates["allowed_ip_list"]:
             try:
                 ipaddress.ip_network(ip, strict=True)
             except ValueError as e:
@@ -85,24 +87,35 @@ def get_errors_company(company):
             return jsonify({"allowed_ip_list": errors}), 400
 
 
-def get_company_updates(company):
+def get_company_updates(data, original=None):
+    if original is None:
+        original = {}
+
     updates = {
-        "name": company.get("name"),
-        "url": company.get("url"),
-        "sd_subscriber_id": company.get("sd_subscriber_id"),
-        "account_manager": company.get("account_manager"),
-        "contact_name": company.get("contact_name"),
-        "contact_email": company.get("contact_email"),
-        "phone": company.get("phone"),
-        "country": company.get("country"),
-        "is_enabled": company.get("is_enabled"),
-        "company_type": company.get("company_type"),
-        "monitoring_administrator": company.get("monitoring_administrator"),
-        "allowed_ip_list": company.get("allowed_ip_list"),
+        "name": data.get("name") or original.get("name"),
+        "url": data.get("url") or original.get("url"),
+        "sd_subscriber_id": data.get("sd_subscriber_id") or original.get("sd_subscriber_id"),
+        "account_manager": data.get("account_manager") or original.get("account_manager"),
+        "contact_name": data.get("contact_name") or original.get("contact_name"),
+        "contact_email": data.get("contact_email") or original.get("contact_email"),
+        "phone": data.get("phone") or original.get("phone"),
+        "country": data.get("country") or original.get("country"),
+        "is_enabled": data.get("is_enabled") or original.get("is_enabled"),
+        "company_type": data.get("company_type") or original.get("company_type"),
+        "monitoring_administrator": data.get("monitoring_administrator") or original.get("monitoring_administrator"),
+        "allowed_ip_list": data.get("allowed_ip_list") or original.get("allowed_ip_list"),
     }
 
-    if company.get("expiry_date"):
-        updates["expiry_date"] = datetime.strptime(str(company.get("expiry_date"))[:10], "%Y-%m-%d")
+    for field in ["sections", "archive_access", "events_only", "restrict_coverage_info", "products", "seats"]:
+        if field in data:
+            updates[field] = data[field]
+
+    for product in updates.get("products") or []:
+        product["_id"] = ObjectId(product["_id"])
+        product.setdefault("seats", 0)
+
+    if data.get("expiry_date"):
+        updates["expiry_date"] = datetime.strptime(str(data.get("expiry_date"))[:10], "%Y-%m-%d")
     else:
         updates["expiry_date"] = None
 
@@ -112,23 +125,23 @@ def get_company_updates(company):
 @blueprint.route("/companies/<_id>", methods=["GET", "POST"])
 @account_manager_only
 def edit(_id):
-    company = find_one("companies", _id=ObjectId(_id))
+    original = find_one("companies", _id=ObjectId(_id))
 
-    if not company:
+    if not original:
         return NotFound(gettext("Company not found"))
 
     if flask.request.method == "POST":
         company = get_json_or_400()
-        errors = get_errors_company(company)
+        errors = get_errors_company(company, original)
         if errors:
             return errors
 
-        updates = get_company_updates(company)
+        updates = get_company_updates(company, original)
         set_version_creator(updates)
         get_resource_service("companies").patch(ObjectId(_id), updates=updates)
         app.cache.delete(_id)
         return jsonify({"success": True}), 200
-    return jsonify(company), 200
+    return jsonify(original), 200
 
 
 @blueprint.route("/companies/<_id>", methods=["DELETE"])
@@ -168,26 +181,3 @@ def get_product_updates(updates: Dict[str, bool], seats: Dict[str, int]):
         }
         for product in products
     ]
-
-
-def update_company(data, _id):
-    updates = {
-        k: v
-        for k, v in data.items()
-        if k in ("sections", "archive_access", "events_only", "restrict_coverage_info", "products")
-    }
-    get_resource_service("companies").patch(_id, updates=updates)
-
-
-@blueprint.route("/companies/<_id>/permissions", methods=["POST"])
-@account_manager_only
-def save_company_permissions(_id):
-    orig = get_entity_or_404(_id, "companies")
-    data = get_json_or_400()
-    seats = {product["_id"]: product.get("seats") or 0 for product in orig.get("products") or []}
-    if data.get("seats"):
-        seats.update(data["seats"])
-    if data.get("products"):
-        data["products"] = get_product_updates(data["products"], seats)
-    update_company(data, orig["_id"])
-    return jsonify(), 200

--- a/tests/core/test_companies.py
+++ b/tests/core/test_companies.py
@@ -115,6 +115,7 @@ def test_get_company_users(client):
 
 
 def test_save_company_permissions(client, app):
+    sports_id = ObjectId()
     app.data.insert(
         "products",
         [
@@ -126,7 +127,7 @@ def test_save_company_permissions(client, app):
                 "is_enabled": True,
             },
             {
-                "_id": "p-2",
+                "_id": sports_id,
                 "name": "News",
                 "description": "news product",
                 "is_enabled": True,
@@ -135,10 +136,15 @@ def test_save_company_permissions(client, app):
     )
 
     test_login_succeeds_for_admin(client)
-    data = json.dumps({"products": {"p-2": True}, "sections": {"wire": True}, "archive_access": True})
     client.post(
-        f"companies/{COMPANY_1_ID}/permissions",
-        data=data,
+        f"companies/{COMPANY_1_ID}",
+        data=json.dumps(
+            {
+                "archive_access": True,
+                "sections": {"wire": True},
+                "products": [{"_id": sports_id, "section": "wire"}],
+            }
+        ),
         content_type="application/json",
     )
 
@@ -146,7 +152,7 @@ def test_save_company_permissions(client, app):
     assert updated["sections"]["wire"]
     assert not updated["sections"].get("agenda")
     assert updated["archive_access"]
-    assert updated["products"] == [{"section": "wire", "seats": 0, "_id": "p-2"}]
+    assert updated["products"] == [{"section": "wire", "seats": 0, "_id": sports_id}]
 
     # available by default
     resp = client.get(url_for("agenda.index"))

--- a/tests/core/test_products.py
+++ b/tests/core/test_products.py
@@ -24,7 +24,7 @@ def product(app):
 @fixture
 def companies(app):
     _companies = [
-        {"name": "test1"},
+        {"name": "test1", "sections": {"wire": True}},
         {"name": "test2"},
         {"name": "test3"},
     ]


### PR DESCRIPTION
The previous logic used to separate out company permission api complicated things from the front-end. Now we're adding the ability to save company product/section permissions from the same endpoint to update a company, thus reducing the logic to calculate the new section/product for a company.

There was also a bug in the company update logic, if `updates['products'] == []`, then the original products would be used instead.