### PR TITLE
[CPCN-155] fix(api): User update logic uses previous company when removing the company

### DIFF
--- a/features/web_api/user_permissions.feature
+++ b/features/web_api/user_permissions.feature
@@ -1,0 +1,84 @@
+Feature: User Permissions
+    @auth @admin
+    Scenario: Remove company from user should allow any section
+        Given "navigations"
+        """
+        [{
+            "_id": "59b4c5c61d41c8d736852fbf", "product_type": "wire", "is_enabled": true,
+            "name": "All wire", "description": "All wire content"
+        }, {
+            "_id": "59b4c5c61d41c8d736852fbg", "product_type": "wire", "is_enabled": true,
+            "name": "Sports", "description": "Sports content"
+        }, {
+            "_id": "59b4c5c61d41c8d736852fbh", "product_type": "agenda", "is_enabled": true,
+            "name": "Sports", "description": "Sports coverages"
+        }]
+        """
+        And "products"
+        """
+        [{
+            "_id": "69b4c5c61d41c8d736852fbf", "product_type": "wire", "is_enabled": true,
+            "name": "All wire", "query": "slugline:wire",
+            "navigations": ["59b4c5c61d41c8d736852fbf"]
+        }, {
+            "_id": "69b4c5c61d41c8d736852fba", "product_type": "wire", "is_enabled": true,
+            "name": "Sports content", "query": "slugline:sports",
+            "navigations": ["59b4c5c61d41c8d736852fbf"]
+        }, {
+            "_id": "69b4c5c61d41c8d736852fbb", "product_type": "agenda", "is_enabled": true,
+            "name": "Sports coverages", "query": "slugline:sports",
+            "navigations": ["59b4c5c61d41c8d736852fbh"]
+        }]
+        """
+        And "companies"
+        """
+        [{
+            "_id": "1e65964bf5db68883df561b0", "company_type": "public",
+            "name": "All Access Co.", "is_enabled": true,
+            "sections": {"wire": true, "agenda": false},
+            "products": [
+                {"_id": "69b4c5c61d41c8d736852fbf", "section": "wire", "seats": 2},
+                {"_id": "69b4c5c61d41c8d736852fba", "section": "wire", "seats": 2}
+            ]
+        }]
+        """
+        And "users"
+        """
+        [{
+            "_id": "4e65964bf5db68883df561b0", "user_type": "company_admin",
+            "company": "1e65964bf5db68883df561b0",
+            "email": "test1@test.org", "first_name": "admin", "last_name": "admin",
+            "password": "$2b$12$HGyWCf9VNfnVAwc2wQxQW.Op3Ejk7KIGE6urUXugpI0KQuuK6RWIG",
+            "is_validated": true, "is_enabled": true, "is_approved": true,
+            "sections": {"wire": true, "agenda": false},
+            "products": [
+                {"_id": "69b4c5c61d41c8d736852fbf", "section": "wire"},
+                {"_id": "69b4c5c61d41c8d736852fba", "section": "wire"}
+            ]
+        }]
+        """
+        When we get json from "/users/search"
+        Then we get products assigned to items
+        """
+        {"4e65964bf5db68883df561b0": {
+            "sections": ["wire"],
+            "products": ["69b4c5c61d41c8d736852fbf", "69b4c5c61d41c8d736852fba"]
+        }}
+        """
+        When we post json to "/users/4e65964bf5db68883df561b0"
+        """
+        {
+            "company": null, "user_type": "administrator",
+            "email": "test1@test.org", "first_name": "admin", "last_name": "admin",
+            "sections": "wire,agenda",
+            "products": "69b4c5c61d41c8d736852fbf,69b4c5c61d41c8d736852fba,69b4c5c61d41c8d736852fbb"
+        }
+        """
+        When we get json from "/users/search"
+        Then we get products assigned to items
+        """
+        {"4e65964bf5db68883df561b0": {
+            "sections": ["wire", "agenda"],
+            "products": ["69b4c5c61d41c8d736852fbf", "69b4c5c61d41c8d736852fba", "69b4c5c61d41c8d736852fbb"]
+        }}
+        """

--- a/newsroom/auth/utils.py
+++ b/newsroom/auth/utils.py
@@ -141,7 +141,10 @@ def get_user_sections() -> Dict[str, bool]:
     user = get_user()
     if not user:
         return {}
-    if user.get("sections"):
+    elif is_current_user_admin():
+        # Admin users should see all sections
+        return {section["_id"]: True for section in app.sections}
+    elif user.get("sections"):
         return user["sections"]
     company = get_company(user)
     if company and company.get("sections"):

--- a/newsroom/users/users.py
+++ b/newsroom/users/users.py
@@ -190,15 +190,12 @@ class UsersService(newsroom.Service):
         if "password" in updates:
             updates["password"] = self._get_password_hash(updates["password"])
 
-        company = get_company_from_user({"company": updates.get("company") or original.get("company")})
+        company = get_company_from_user({"company": updates.get("company", original.get("company"))})
         company_changed = updates.get("company") and updates["company"] != original.get("company")
 
         if company_changed or "sections" in updates or "products" in updates:
-            # Company or Sections have changed, recalculate the list of sections
+            # Company, Sections or Products have changed, recalculate the list of sections & products
             updates["sections"] = get_updated_sections(updates, original, company)
-
-        if company_changed or "sections" in updates or "products" in updates:
-            # Company, Sections or Products have changed, recalculate the list of products
             updates["products"] = get_updated_products(updates, original, company)
 
         app.cache.delete(str(original.get("_id")))


### PR DESCRIPTION
Also show all sections to admin users, regardless of config (similar to how we're allowing all products, regardless of admin user settings).