### PR TITLE
improve saml config options

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,10 @@ jobs:
           cache: 'pip'
       - name: Install node_modules
         run: npm install
+      - name: Install APT packages
+        run: |
+             sudo apt-get update
+             sudo apt-get install pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
       - name: Upgrade python tools
         run: pip install --upgrade pip wheel setuptools
       - name: Install python modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ jobs:
       - name: docker-compose
         run: docker-compose -f .actions-docker-compose.yml up -d
 
+      - run: |
+             sudo apt-get update
+             sudo apt-get install pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
       - name: pip install
         run: |
              python -m pip install --upgrade pip wheel setuptools

--- a/assets/companies/components/EditCompany.jsx
+++ b/assets/companies/components/EditCompany.jsx
@@ -155,6 +155,7 @@ class EditCompany extends React.Component {
                                 onChange={this.props.onChange}
                                 save={this.save}
                                 deleteCompany={this.deleteCompany}
+                                ssoEnabled={this.props.ssoEnabled}
                             />
                         </div>
                     }
@@ -210,6 +211,7 @@ EditCompany.propTypes = {
     fetchCompanyUsers: PropTypes.func.isRequired,
     companyTypes: PropTypes.array,
     apiEnabled: PropTypes.bool,
+    ssoEnabled: PropTypes.bool,
     companiesById: PropTypes.object,
 
     sections: PropTypes.arrayOf(PropTypes.shape({
@@ -232,6 +234,7 @@ const mapStateToProps = (state) => ({
     users: state.companyUsers,
     companyTypes: state.companyTypes,
     apiEnabled: state.apiEnabled,
+    ssoEnabled: state.ssoEnabled,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/assets/companies/components/EditCompanyDetails.jsx
+++ b/assets/companies/components/EditCompanyDetails.jsx
@@ -81,6 +81,14 @@ export function EditCompanyDetails({company, companyTypes, users, errors, onChan
                     error={errors ? errors.contact_email : null}
                 />
 
+                <TextInput
+                    name='auth_domain'
+                    label={gettext('SSO domain')}
+                    value={company.auth_domain || ''}
+                    onChange={onChange}
+                    error={errors ? errors.auth_domain : null}
+                />
+
                 <SelectInput
                     name='country'
                     label={gettext('Country')}

--- a/assets/companies/components/EditCompanyDetails.jsx
+++ b/assets/companies/components/EditCompanyDetails.jsx
@@ -11,7 +11,7 @@ import DateInput from 'components/DateInput';
 import CheckboxInput from 'components/CheckboxInput';
 
 
-export function EditCompanyDetails({company, companyTypes, users, errors, onChange, save, deleteCompany}) {
+export function EditCompanyDetails({company, companyTypes, users, errors, onChange, save, deleteCompany, ssoEnabled}) {
     return (
         <form>
             <div className="list-item__preview-form">
@@ -81,13 +81,15 @@ export function EditCompanyDetails({company, companyTypes, users, errors, onChan
                     error={errors ? errors.contact_email : null}
                 />
 
-                <TextInput
-                    name='auth_domain'
-                    label={gettext('SSO domain')}
-                    value={company.auth_domain || ''}
-                    onChange={onChange}
-                    error={errors ? errors.auth_domain : null}
-                />
+                {ssoEnabled && (
+                    <TextInput
+                        name='auth_domain'
+                        label={gettext('SSO domain')}
+                        value={company.auth_domain || ''}
+                        onChange={onChange}
+                        error={errors ? errors.auth_domain : null}
+                    />
+                )}
 
                 <SelectInput
                     name='country'
@@ -153,4 +155,5 @@ EditCompanyDetails.propTypes = {
     onChange: PropTypes.func,
     save: PropTypes.func,
     deleteCompany: PropTypes.func,
+    ssoEnabled: PropTypes.bool,
 };

--- a/assets/companies/reducers.js
+++ b/assets/companies/reducers.js
@@ -198,6 +198,7 @@ export default function companyReducer(state = initialState, action) {
             sections: action.data.sections,
             companyTypes: action.data.company_types || [],
             apiEnabled: action.data.api_enabled || false,
+            ssoEnabled: action.data.sso_enabled || false,
             ui_config: action.data.ui_config,
         };
 

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -255,11 +255,3 @@ def set_locale():
     if locale and locale in app.config["LANGUAGES"]:
         flask.session["locale"] = locale
     return flask.redirect(flask.url_for("auth.login"))
-
-
-@blueprint.route("/login/<client>", methods=["GET"])
-def client_login(client):
-    if not client or client not in app.config["SAML_CLIENTS"]:
-        return abort(404)
-    flask.session["_saml_client"] = client
-    return flask.render_template("login_client.html", client=client)

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -255,3 +255,11 @@ def set_locale():
     if locale and locale in app.config["LANGUAGES"]:
         flask.session["locale"] = locale
     return flask.redirect(flask.url_for("auth.login"))
+
+
+@blueprint.route("/login/<client>", methods=["GET"])
+def client_login(client):
+    if not client or client not in app.config["SAML_CLIENTS"]:
+        return abort(404)
+    flask.session["_saml_client"] = client
+    return flask.render_template("login_client.html", client=client)

--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -60,6 +60,10 @@ class CompaniesResource(newsroom.Resource):
                 },
             },
         },
+        "auth_domain": {
+            "type": "string",
+            "nullable": True,
+        },
     }
 
     datasource = {"source": "companies", "default_sort": [("name", 1)]}
@@ -71,6 +75,14 @@ class CompaniesResource(newsroom.Resource):
         "name_1": (
             [("name", 1)],
             {"unique": True, "collation": {"locale": "en", "strength": 2}},
+        ),
+        "auth_domain_1": (
+            [("auth_domain", 1)],
+            {
+                "unique": True,
+                "collation": {"locale": "en", "strength": 2},
+                "partialFilterExpression": {"auth_domain": {"$gt": ""}},  # filters out None and ""
+            },
         ),
     }
 

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -104,6 +104,7 @@ def get_company_updates(data, original=None):
         "company_type": data.get("company_type") or original.get("company_type"),
         "monitoring_administrator": data.get("monitoring_administrator") or original.get("monitoring_administrator"),
         "allowed_ip_list": data.get("allowed_ip_list") or original.get("allowed_ip_list"),
+        "auth_domain": data.get("auth_domain"),
     }
 
     for field in ["sections", "archive_access", "events_only", "restrict_coverage_info", "products", "seats"]:

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -36,6 +36,7 @@ def get_settings_data():
         "company_types": get_company_types_options(app.config.get("COMPANY_TYPES", [])),
         "api_enabled": app.config.get("NEWS_API_ENABLED", False),
         "ui_config": get_resource_service("ui_config").get_section_config("companies"),
+        "sso_enabled": bool(app.config.get("SAML_COMPANIES") or app.config.get("SAML_PATH")),
     }
 
 

--- a/newsroom/templates/layout_login.html
+++ b/newsroom/templates/layout_login.html
@@ -1,0 +1,22 @@
+{% extends "layout_wire.html" %}
+
+{% block contentMain %}
+<div class="container-fluid py-5 overflow-auto">
+    <div class="row">
+        <div class="col-12 col-md-8 col-lg-6 col-xxl-4 mx-auto">
+            <div class="card border-0 bg-white box-shadow--z1">
+                <div class="card-header pt-4 border-0 bg-white">
+                    <div class="text-center mb-4">
+                        {% include 'login_logo.html' %}
+                    </div>
+                    {% block login_title %}
+                    {% endblock %}
+                </div>
+
+                {% block login_content %}
+                {% endblock %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/newsroom/templates/login_client.html
+++ b/newsroom/templates/login_client.html
@@ -1,0 +1,15 @@
+{% extends "layout_login.html" %}
+
+{% block login_title %}
+<h5 class="mb-0">{{ gettext("Login") }}</h5>
+{% endblock %}
+
+{% block login_content %}
+<div class="card-body pt-1">
+    <a href="{{ url_for('auth.saml') }}" title="{{ gettext('Login using Single Sign On') }}" class="btn btn-primary w-100">{{ config.SAML_LABEL }}</a>
+</div>
+
+<div class="card-footer bg-white border-0 text-muted small">
+    <p>{{ gettext("If you have trouble logging in, please contact your own IT support.") }}</p>
+</div>
+{% endblock %}

--- a/newsroom/templates/login_locale_dropdown.html
+++ b/newsroom/templates/login_locale_dropdown.html
@@ -1,0 +1,16 @@
+{% if get_client_locales()|length is gt 1 %}
+<div class="card-body pt-1">
+    <form class="form" role="form" method="post" action="{{ url_for('auth.set_locale') }}">
+        <div class="form-group">
+            <label for="language">{{ gettext('Language') }}</label>
+            <div class="field">
+                <select name="locale" class="form-control" onchange="this.form.submit()">
+                    {% for locale in get_client_locales() %}
+                    <option value="{{ locale.locale }}" {% if locale.locale == get_locale() %}selected{% endif %}>{{ locale.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+    </form>
+</div>
+{% endif %}

--- a/newsroom/templates/login_locale_dropdown.html
+++ b/newsroom/templates/login_locale_dropdown.html
@@ -2,9 +2,9 @@
 <div class="card-body pt-1">
     <form class="form" role="form" method="post" action="{{ url_for('auth.set_locale') }}">
         <div class="form-group">
-            <label for="language">{{ gettext('Language') }}</label>
+            <label for="language-select">{{ gettext('Language') }}</label>
             <div class="field">
-                <select name="locale" class="form-control" onchange="this.form.submit()">
+                <select id="language-select" name="language" class="form-control" onchange="this.form.submit()">
                     {% for locale in get_client_locales() %}
                     <option value="{{ locale.locale }}" {% if locale.locale == get_locale() %}selected{% endif %}>{{ locale.name }}</option>
                     {% endfor %}

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from typing import List
 import tzlocal
 import logging
 
@@ -477,7 +478,7 @@ DELETE_DASHBOARD_CACHE_ON_PUSH = True
 #:
 #: .. versionadded:: 2.3
 #:
-SAML_PATH = ""
+SAML_PATH = os.environ.get("SAML_PATH") or ""
 
 #: Company name which will be assigned to newsly created users
 #:
@@ -490,6 +491,27 @@ SAML_COMPANY = ""
 #: .. versionadded:: 2.3
 #:
 SAML_LABEL = "SSO"
+
+#: List of available configs for SAML, there should be a folder inside SAML_BASE_PATH for each.
+#:
+#: .. versionadded:: 2.5
+#:
+SAML_CLIENTS: List[str] = []
+
+#: Base path for SAML_COMPANIES config
+#:
+#: .. versionadded:: 2.5
+#:
+SAML_BASE_PATH: str = os.environ.get("SAML_BASE_PATH") or ""
+
+#: Mapping SAML claims to user data fields.
+#:
+#: .. versionadded:: 2.5
+#:
+SAML_USER_MAPPING = {
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname": "first_name",
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": "last_name",
+}
 
 #: Rebuild elastic mapping on ``initialize_data`` mapping error
 #:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ xhtml2pdf>=0.2.4
 sentry-sdk[flask]>=1.5.7,<1.6
 eve-elastic==7.3.1
 MarkupSafe<2.1
+python3-saml>=1.15,<1.16
+
 
 # Fix an issue between xhtml2pdf v0.2.4 and reportlab v3.6.7
 # https://github.com/xhtml2pdf/xhtml2pdf/issues/589

--- a/tests/core/test_saml.py
+++ b/tests/core/test_saml.py
@@ -1,0 +1,66 @@
+import pytest
+import werkzeug.exceptions
+
+from newsroom.auth.saml import get_userdata
+
+
+def test_user_data_with_matching_company(app):
+    company = {
+        "name": "test",
+        "auth_domain": "example.com",
+    }
+    app.data.insert("companies", [company])
+
+    saml_data = {
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname": ["Foo"],
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": ["Bar"],
+    }
+
+    with app.test_request_context():
+        user_data = get_userdata("foo@example.com", saml_data)
+        assert user_data.get("company") == company["_id"]
+
+        user_data = get_userdata("foo@newcomp.com", saml_data)
+        assert user_data.get("company") is None
+
+
+def test_user_data_with_matching_preconfigured_client(app, client):
+    company = {
+        "name": "test",
+        "auth_domain": "samplecomp",
+    }
+
+    app.data.insert("companies", [company])
+
+    saml_data = {
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname": ["Foo"],
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": ["Bar"],
+    }
+
+    with app.test_client() as c:
+        resp = c.get("/login/samplecomp")
+        assert 404 == resp.status_code
+
+        user_data = get_userdata("foo@example.com", saml_data)
+        assert "company" not in user_data
+
+    app.config["SAML_CLIENTS"] = ["samplecomp"]
+
+    with app.test_client() as c:
+        resp = c.get("/login/samplecomp")
+        assert 200 == resp.status_code
+
+        user_data = get_userdata("foo@example.com", saml_data)
+        assert user_data.get("company") == company["_id"]
+
+
+def test_auth_domain_unique_for_company(app):
+    app.data.insert("companies", [{"name": "test", "auth_domain": "example.com"}])
+    with pytest.raises(werkzeug.exceptions.Conflict):
+        app.data.insert("companies", [{"name": "test2", "auth_domain": "example.com"}])
+    with pytest.raises(werkzeug.exceptions.Conflict):
+        app.data.insert("companies", [{"name": "TEST2", "auth_domain": "EXAMPLE.COM"}])
+    app.data.insert("companies", [{"name": "test3", "auth_domain": None}])
+    app.data.insert("companies", [{"name": "test4", "auth_domain": None}])
+    app.data.insert("companies", [{"name": "test5", "auth_domain": ""}])
+    app.data.insert("companies", [{"name": "test6", "auth_domain": ""}])


### PR DESCRIPTION
we can set on company email domain which will be tested when authenticating via saml and if user email matches it it will assign the company to user.

there is also new config for custom client saml configs which allows us to configure user specific login page which picks the config to be used for SAML auth. then it uses the company domain to match the config value.

STTNHUB-222