### PR TITLE
[CPCN-232] fix(ui): Reload items when opening AdvancedSearch panel

### DIFF
--- a/assets/layout/components/BaseApp.jsx
+++ b/assets/layout/components/BaseApp.jsx
@@ -77,6 +77,9 @@ export default class BaseApp extends React.Component {
 
         if (this.props.setQuery != null) {
             this.props.setQuery('');
+            if (this.props.fetchItems != null) {
+                this.props.fetchItems();
+            }
         }
     }
 


### PR DESCRIPTION
This is required as we're clearing the TopSearch bar query, and item's weren't reflecting this