### PR TITLE
[CPNHUB-248] fix: Change companies.auth_provider to be optional

### DIFF
--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -67,11 +67,7 @@ class CompaniesResource(newsroom.Resource):
             "type": "string",
             "nullable": True,
         },
-        "auth_provider": {
-            "type": "string",
-            "required": True,
-            "default": "newshub",
-        },
+        "auth_provider": {"type": "string"},
     }
 
     datasource = {"source": "companies", "default_sort": [("name", 1)]}

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -108,7 +108,7 @@ def get_company_updates(data, original=None):
         "monitoring_administrator": data.get("monitoring_administrator") or original.get("monitoring_administrator"),
         "allowed_ip_list": data.get("allowed_ip_list") or original.get("allowed_ip_list"),
         "auth_domain": data.get("auth_domain"),
-        "auth_provider": data.get("auth_provider"),
+        "auth_provider": data.get("auth_provider") or original.get("auth_provider") or "newshub",
     }
 
     for field in ["sections", "archive_access", "events_only", "restrict_coverage_info", "products", "seats"]:


### PR DESCRIPTION
* Set the default value from web api in the views and not the resource
* Allow company_create signal to define it's own defaults (such as in mgmt_api)