### PR TITLE
fix es highlights with multi word queries

### DIFF
--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -594,12 +594,21 @@ class BaseSearchService(Service):
                 ]
             )
 
+            field_query = highlight_search.query["bool"]["must"] or highlight_search.query["bool"]["filter"]
+            try:
+                # pop query_string type from the query which breaks the highlighting
+                field_query[0]["query_string"].pop("type", None)
+                field_query[0]["query_string"].pop("fields", None)
+            except KeyError:
+                pass
+
             for field in fields_to_highlight:
                 highlight_search.source["highlight"]["fields"][field] = {
                     "number_of_fragments": 0,
+                    "require_field_match": False,
                     "highlight_query": {
                         "bool": {
-                            "filter": highlight_search.query["bool"]["must"] or highlight_search.query["bool"]["filter"]
+                            "must": field_query,
                         }
                     },
                 }

--- a/tests/core/test_wire.py
+++ b/tests/core/test_wire.py
@@ -843,6 +843,16 @@ def test_highlighting(client, app):
     data = json.loads(resp.get_data())
     assert data["_items"][0]["es_highlight"]["headline"][0] == '<span class="es-highlight">Demo</span> Article'
 
+    resp = client.get(
+        "/wire/search?q={query}&es_highlight=1".format(query='article AND "cheese and onions" AND "slugline" AND story')
+    )
+    data = json.loads(resp.get_data())
+    highlights = data["_items"][0]["es_highlight"]
+    assert "slugline" in highlights
+    assert "headline" in highlights
+    assert "body_html" in highlights
+    assert 4 == highlights["body_html"][0].count("es-highlight")
+
 
 def test_highlighting_with_advanced_search(client, app):
     app.data.insert(


### PR DESCRIPTION
remove cross_fields type from the highlights query

CPCN-339