### PR TITLE
Fix select all products v2

### DIFF
--- a/assets/company-admin/components/CompanyAdminApp.tsx
+++ b/assets/company-admin/components/CompanyAdminApp.tsx
@@ -12,7 +12,7 @@ import {
     resendUserInvite,
     newUser,
     cancelEdit,
-    editUser,
+    editUser_DEPRECATED,
     setError,
     fetchUsers,
     setSort,
@@ -55,7 +55,7 @@ interface IStateProps {
 interface IDispatchProps {
     setSection: (sectionId: string) => any;
     newUser: () => IUser;
-    editUser: (event: any) => any;
+    editUser_DEPRECATED: (event: any) => any;
     setError: (errors: any) => any;
     saveUser: () => any;
     closeUserEditor: () => any;
@@ -242,7 +242,7 @@ class CompanyAdminAppComponent extends React.Component<IProps, IState> {
                                     <EditUser
                                         original={userToEdit._id != null ? this.props.usersById[userToEdit._id] : {}}
                                         user={userToEdit}
-                                        onChange={this.props.editUser}
+                                        onChange_DEPRECATED={this.props.editUser_DEPRECATED}
                                         errors={this.props.errors}
                                         companies={this.props.companies}
                                         onSave={this.saveUser}
@@ -290,7 +290,7 @@ const mapStateToProps = (state: ICompanyAdminStore): IStateProps => ({
 const mapDispatchToProps = (dispatch: any): IDispatchProps => ({
     setSection: (sectionId: any) => dispatch(setSection(sectionId)),
     newUser: () => dispatch(newUser()),
-    editUser: (event: any) => dispatch(editUser(event)),
+    editUser_DEPRECATED: (event: any) => dispatch(editUser_DEPRECATED(event)),
     setError: (errors: any) => dispatch(setError(errors)),
     saveUser: () => dispatch(postUser()),
     closeUserEditor: () => dispatch(cancelEdit()),

--- a/assets/company-admin/components/CompanyAdminApp.tsx
+++ b/assets/company-admin/components/CompanyAdminApp.tsx
@@ -17,6 +17,7 @@ import {
     fetchUsers,
     setSort,
     toggleSortDirection,
+    editUser,
 } from 'users/actions';
 import {setSearchQuery} from 'search/actions';
 import {productListSelector, companyListSelector, currentUserSelector} from '../selectors';
@@ -55,6 +56,7 @@ interface IStateProps {
 interface IDispatchProps {
     setSection: (sectionId: string) => any;
     newUser: () => IUser;
+    editUser: (nextUser: IUser) => void;
     editUser_DEPRECATED: (event: any) => any;
     setError: (errors: any) => any;
     saveUser: () => any;
@@ -242,6 +244,7 @@ class CompanyAdminAppComponent extends React.Component<IProps, IState> {
                                     <EditUser
                                         original={userToEdit._id != null ? this.props.usersById[userToEdit._id] : {}}
                                         user={userToEdit}
+                                        onChange={this.props.editUser}
                                         onChange_DEPRECATED={this.props.editUser_DEPRECATED}
                                         errors={this.props.errors}
                                         companies={this.props.companies}
@@ -290,6 +293,7 @@ const mapStateToProps = (state: ICompanyAdminStore): IStateProps => ({
 const mapDispatchToProps = (dispatch: any): IDispatchProps => ({
     setSection: (sectionId: any) => dispatch(setSection(sectionId)),
     newUser: () => dispatch(newUser()),
+    editUser: (nextUser: IUser) => dispatch(editUser(nextUser)),
     editUser_DEPRECATED: (event: any) => dispatch(editUser_DEPRECATED(event)),
     setError: (errors: any) => dispatch(setError(errors)),
     saveUser: () => dispatch(postUser()),

--- a/assets/users/actions.ts
+++ b/assets/users/actions.ts
@@ -21,9 +21,12 @@ export function getUser(user: any) {
     return {type: GET_USER, user};
 }
 
-export const EDIT_USER = 'EDIT_USER';
-export function editUser(event: any) {
-    return {type: EDIT_USER, event};
+/**@deprecated because it uses DOM elements inside reducer */
+export const EDIT_USER__DEPRECATED = 'EDIT_USER__DEPRECATED';
+
+/**@deprecated because it uses DOM elements inside reducer */
+export function editUser_DEPRECATED(event: any) {
+    return {type: EDIT_USER__DEPRECATED, event};
 }
 
 export const NEW_USER = 'NEW_USER';

--- a/assets/users/actions.ts
+++ b/assets/users/actions.ts
@@ -29,6 +29,12 @@ export function editUser_DEPRECATED(event: any) {
     return {type: EDIT_USER__DEPRECATED, event};
 }
 
+export const EDIT_USER = 'EDIT_USER';
+
+export function editUser(nextUser: IUser) {
+    return {type: EDIT_USER, payload: nextUser};
+}
+
 export const NEW_USER = 'NEW_USER';
 export function newUser(data?: any) {
     return {type: NEW_USER, data};

--- a/assets/users/components/EditUser.tsx
+++ b/assets/users/components/EditUser.tsx
@@ -41,7 +41,10 @@ interface IReduxStoreProps {
 interface IProps extends IReduxStoreProps {
     original: IUser;
     user: IUser;
-    onChange: (event: any) => void;
+
+    /** @deprecated because it doesn't send changes and relies on DOM manipulation */
+    onChange_DEPRECATED: (event: any) => void;
+
     errors: any;
     companies: Array<ICompany>;
     onSave: (event: any) => void;
@@ -59,7 +62,7 @@ interface IProps extends IReduxStoreProps {
 const EditUserComponent: React.ComponentType<IProps> = ({
     original,
     user,
-    onChange,
+    onChange_DEPRECATED,
     errors,
     companies,
     onSave,
@@ -171,42 +174,42 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                 name='first_name'
                                 label={gettext('First Name')}
                                 value={user.first_name}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.first_name : null} />)}
 
                             {hideFields.includes('last_name') ? null : (<TextInput
                                 name='last_name'
                                 label={gettext('Last Name')}
                                 value={user.last_name}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.last_name : null} />)}
 
                             {hideFields.includes('email') ? null : (<TextInput
                                 name='email'
                                 label={gettext('Email')}
                                 value={user.email}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.email : null} />)}
 
                             {hideFields.includes('phone') ? null : (<TextInput
                                 name='phone'
                                 label={gettext('Phone')}
                                 value={user.phone}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.phone : null} />)}
 
                             {hideFields.includes('mobile') ? null : (<TextInput
                                 name='mobile'
                                 label={gettext('Mobile')}
                                 value={user.mobile}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.mobile : null} />)}
 
                             {hideFields.includes('role') ? null : (<TextInput
                                 name='role'
                                 label={gettext('Role')}
                                 value={user.role}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.role : null} />)}
                             {hideFields.includes('user_type') ? null : (<SelectInput
                                 name='user_type'
@@ -215,14 +218,14 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                 options={userTypeReadOnly(user, currentUser) ? [] : getUserTypes(currentUser) }
                                 defaultOption={userTypeReadOnly(user, currentUser) ? getUserLabel(user.user_type) : undefined}
                                 readOnly={userTypeReadOnly(user, currentUser) || isUserCompanyAdmin(currentUser)}
-                                onChange={onChange}
+                                onChange={onChange_DEPRECATED}
                                 error={errors ? errors.user_type : null}/>)}
                             {hideFields.includes('company') ? (
                                 <TextInput
                                     name='company'
                                     label={gettext('Company')}
                                     value={company?.name}
-                                    onChange={onChange}
+                                    onChange={onChange_DEPRECATED}
                                     readOnly={isUserCompanyAdmin(currentUser)}
                                     error={errors ? errors.company : null}
                                 />
@@ -233,7 +236,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                     value={user.company}
                                     defaultOption={''}
                                     options={getCompanyOptions(companies)}
-                                    onChange={(e) => onChange({
+                                    onChange={(e) => onChange_DEPRECATED({
                                         ...e,
                                         changeType: 'company',
                                     })}
@@ -246,7 +249,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                     name={'locale'}
                                     label={gettext('Language')}
                                     value={user.locale}
-                                    onChange={onChange}
+                                    onChange={onChange_DEPRECATED}
                                     options={localeOptions}
                                     defaultOption={getDefaultLocale()}
                                     error={errors ? errors.locale : null}
@@ -266,7 +269,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                                 name={`sections.${section._id}`}
                                                 label={section.name}
                                                 value={get(user, `sections.${section._id}`) === true}
-                                                onChange={onChange}
+                                                onChange={onChange_DEPRECATED}
                                             />
                                         </div>
                                     </div>
@@ -280,7 +283,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                 testId="toggle--products"
                             >
                                 {isCompanyAdmin ? <div className="products-list__heading d-flex justify-content-between align-items-center">
-                                    <button type='button' name='selectAllBtn' className='nh-button nh-button--tertiary nh-button--small' onClick={onChange} >
+                                    <button type='button' name='selectAllBtn' className='nh-button nh-button--tertiary nh-button--small' onClick={onChange_DEPRECATED} >
                                         {gettext('Select All')}
                                     </button>
                                 </div> : null}
@@ -303,7 +306,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                                 section={section}
                                                 product={product}
                                                 seats={seats}
-                                                onChange={onChange}
+                                                onChange={onChange_DEPRECATED}
                                             />
                                         ))}
                                     </React.Fragment>
@@ -321,7 +324,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='is_approved'
                                         label={gettext('Approved')}
                                         value={user.is_approved === true}
-                                        onChange={onChange} />
+                                        onChange={onChange_DEPRECATED} />
                                 </div>
                             </div>)}
 
@@ -331,7 +334,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='is_enabled'
                                         label={gettext('Enabled')}
                                         value={user.is_enabled === true}
-                                        onChange={onChange} />
+                                        onChange={onChange_DEPRECATED} />
                                 </div>
                             </div>)}
 
@@ -341,7 +344,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='expiry_alert'
                                         label={gettext('Company Expiry Alert')}
                                         value={user.expiry_alert === true}
-                                        onChange={onChange} />
+                                        onChange={onChange_DEPRECATED} />
                                 </div>
                             </div>)}
 
@@ -351,7 +354,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='manage_company_topics'
                                         label={gettext('Manage Company Topics')}
                                         value={user.manage_company_topics === true}
-                                        onChange={onChange} />
+                                        onChange={onChange_DEPRECATED} />
                                 </div>
                             </div>)}
                         </FormToggle>

--- a/assets/users/components/EditUser.tsx
+++ b/assets/users/components/EditUser.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
 
-import {ICompany, IProduct} from '../../interfaces';
+import {ICompany, IProduct, ISection} from '../../interfaces';
 
 import TextInput from 'components/TextInput';
 import SelectInput from 'components/SelectInput';
@@ -20,6 +20,8 @@ import {
     getLocaleInputOptions,
     getDefaultLocale,
     isUserCompanyAdmin,
+    hasSeatsAvailable,
+    seatOccupiedByUser,
 } from '../utils';
 import {FormToggle} from 'ui/components/FormToggle';
 
@@ -42,6 +44,8 @@ interface IProps extends IReduxStoreProps {
     original: IUser;
     user: IUser;
 
+    onChange(user: IUser): void;
+
     /** @deprecated because it doesn't send changes and relies on DOM manipulation */
     onChange_DEPRECATED: (event: any) => void;
 
@@ -56,35 +60,36 @@ interface IProps extends IReduxStoreProps {
     resendUserInvite: () => void;
     hideFields: Array<string>;
     toolbar?: any;
-
 }
 
-const EditUserComponent: React.ComponentType<IProps> = ({
-    original,
-    user,
-    onChange_DEPRECATED,
-    errors,
-    companies,
-    onSave,
-    onResetPassword,
-    onClose,
-    onDelete,
-    currentUser,
-    toolbar,
-    products,
-    hideFields,
-    allSections,
-    companySections,
-    seats,
-    resendUserInvite,
-}) => {
+const EditUserComponent: React.ComponentType<IProps> = (props: IProps) => {
+    const {
+        original,
+        user,
+        onChange,
+        errors,
+        companies,
+        onSave,
+        onResetPassword,
+        onClose,
+        onDelete,
+        currentUser,
+        toolbar,
+        products,
+        hideFields,
+        allSections,
+        companySections,
+        seats,
+        resendUserInvite,
+    } = props;
+
     const companyId = user.company;
     const localeOptions = getLocaleInputOptions();
     const stateLabelDetails = getUserStateLabelDetails(user);
     const companyProductIds = companyId != null
         ? Object.keys(seats[companyId] || {})
         : products.map((product: any) => product._id);
-    const sections = companyId != null ? companySections[companyId] || [] : allSections;
+    const sections: Array<ISection> = companyId != null ? companySections[companyId] || [] : allSections;
     const companySectionIds = sections.map((section: any) => section._id);
     const currentUserIsAdmin = isUserAdmin(currentUser);
     const isCompanyAdmin = isUserCompanyAdmin(currentUser);
@@ -113,7 +118,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
             aria-label={gettext('Edit User')}
         >
             <div className='list-item__preview-header'>
-                <h3>{ gettext('Add/Edit User') }</h3>
+                <h3>{gettext('Add/Edit User')}</h3>
                 <button
                     id='hide-sidebar'
                     type='button'
@@ -174,58 +179,58 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                 name='first_name'
                                 label={gettext('First Name')}
                                 value={user.first_name}
-                                onChange={onChange_DEPRECATED}
+                                onChange={props.onChange_DEPRECATED}
                                 error={errors ? errors.first_name : null} />)}
 
                             {hideFields.includes('last_name') ? null : (<TextInput
                                 name='last_name'
                                 label={gettext('Last Name')}
                                 value={user.last_name}
-                                onChange={onChange_DEPRECATED}
+                                onChange={props.onChange_DEPRECATED}
                                 error={errors ? errors.last_name : null} />)}
 
                             {hideFields.includes('email') ? null : (<TextInput
                                 name='email'
                                 label={gettext('Email')}
                                 value={user.email}
-                                onChange={onChange_DEPRECATED}
+                                onChange={props.onChange_DEPRECATED}
                                 error={errors ? errors.email : null} />)}
 
                             {hideFields.includes('phone') ? null : (<TextInput
                                 name='phone'
                                 label={gettext('Phone')}
                                 value={user.phone}
-                                onChange={onChange_DEPRECATED}
+                                onChange={props.onChange_DEPRECATED}
                                 error={errors ? errors.phone : null} />)}
 
                             {hideFields.includes('mobile') ? null : (<TextInput
                                 name='mobile'
                                 label={gettext('Mobile')}
                                 value={user.mobile}
-                                onChange={onChange_DEPRECATED}
+                                onChange={props.onChange_DEPRECATED}
                                 error={errors ? errors.mobile : null} />)}
 
                             {hideFields.includes('role') ? null : (<TextInput
                                 name='role'
                                 label={gettext('Role')}
                                 value={user.role}
-                                onChange={onChange_DEPRECATED}
+                                onChange={props.onChange_DEPRECATED}
                                 error={errors ? errors.role : null} />)}
                             {hideFields.includes('user_type') ? null : (<SelectInput
                                 name='user_type'
                                 label={gettext('User Type')}
                                 value={user.user_type}
-                                options={userTypeReadOnly(user, currentUser) ? [] : getUserTypes(currentUser) }
+                                options={userTypeReadOnly(user, currentUser) ? [] : getUserTypes(currentUser)}
                                 defaultOption={userTypeReadOnly(user, currentUser) ? getUserLabel(user.user_type) : undefined}
                                 readOnly={userTypeReadOnly(user, currentUser) || isUserCompanyAdmin(currentUser)}
-                                onChange={onChange_DEPRECATED}
-                                error={errors ? errors.user_type : null}/>)}
+                                onChange={props.onChange_DEPRECATED}
+                                error={errors ? errors.user_type : null} />)}
                             {hideFields.includes('company') ? (
                                 <TextInput
                                     name='company'
                                     label={gettext('Company')}
                                     value={company?.name}
-                                    onChange={onChange_DEPRECATED}
+                                    onChange={props.onChange_DEPRECATED}
                                     readOnly={isUserCompanyAdmin(currentUser)}
                                     error={errors ? errors.company : null}
                                 />
@@ -236,7 +241,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                     value={user.company}
                                     defaultOption={''}
                                     options={getCompanyOptions(companies)}
-                                    onChange={(e) => onChange_DEPRECATED({
+                                    onChange={(e) => props.onChange_DEPRECATED({
                                         ...e,
                                         changeType: 'company',
                                     })}
@@ -249,7 +254,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                     name={'locale'}
                                     label={gettext('Language')}
                                     value={user.locale}
-                                    onChange={onChange_DEPRECATED}
+                                    onChange={props.onChange_DEPRECATED}
                                     options={localeOptions}
                                     defaultOption={getDefaultLocale()}
                                     error={errors ? errors.locale : null}
@@ -269,7 +274,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                                 name={`sections.${section._id}`}
                                                 label={section.name}
                                                 value={get(user, `sections.${section._id}`) === true}
-                                                onChange={onChange_DEPRECATED}
+                                                onChange={props.onChange_DEPRECATED}
                                             />
                                         </div>
                                     </div>
@@ -277,42 +282,88 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                             </FormToggle>
                         )}
 
-                        {(userIsAdmin || hideFields.includes('products')) ? null : (
-                            <FormToggle
-                                title={gettext('Products')}
-                                testId="toggle--products"
-                            >
-                                {isCompanyAdmin ? <div className="products-list__heading d-flex justify-content-between align-items-center">
-                                    <button type='button' name='selectAllBtn' className='nh-button nh-button--tertiary nh-button--small' onClick={onChange_DEPRECATED} >
-                                        {gettext('Select All')}
-                                    </button>
-                                </div> : null}
-                                {sections.filter((section: any) => (
-                                    companySectionIds.includes(section._id) &&
-                                    get(user, `sections.${section._id}`) === true
-                                )).map((section: any) => (
-                                    <React.Fragment key={section._id}>
-                                        <div className="list-item__preview-subheading">
-                                            {section.name}
-                                        </div>
-                                        {products.filter(
-                                            (product: any) => product.product_type === section._id &&
-                                                companyProductIds.includes(product._id)
-                                        ).map((product: any) => (
-                                            <EditUserProductPermission
-                                                key={product._id}
-                                                original={original}
-                                                user={user}
-                                                section={section}
-                                                product={product}
-                                                seats={seats}
-                                                onChange={onChange_DEPRECATED}
-                                            />
-                                        ))}
-                                    </React.Fragment>
-                                ))}
-                            </FormToggle>
-                        )}
+                        {(userIsAdmin || hideFields.includes('products')) ? null : (() => {
+                            const filteredSections = sections.filter((section: any) => (
+                                companySectionIds.includes(section._id) &&
+                                get(user, `sections.${section._id}`) === true
+                            ));
+
+                            const filterProductsForSection = (product: IProduct, section: ISection) =>
+                                product.product_type === section._id
+                                && companyProductIds.includes(product._id);
+
+                            const productsFromSections = filteredSections
+                                .flatMap(
+                                    (section) => products.filter((product) => filterProductsForSection(product, section)),
+                                );
+
+                            return (
+                                <FormToggle
+                                    title={gettext('Products')}
+                                    testId="toggle--products"
+                                >
+                                    {(() => {
+                                        if (productsFromSections.length < 1) {
+                                            return (
+                                                <div>{gettext('No products available')}</div>
+                                            );
+                                        } else {
+                                            return (
+                                                <>
+                                                    {isCompanyAdmin && (
+                                                        <div className="products-list__heading d-flex justify-content-between align-items-center">
+                                                            <button
+                                                                type='button'
+                                                                name='selectAllBtn'
+                                                                className='nh-button nh-button--tertiary nh-button--small'
+                                                                onClick={() => {
+                                                                    onChange({
+                                                                        ...user,
+                                                                        products: productsFromSections
+                                                                            .filter((product) =>
+                                                                                hasSeatsAvailable(user.company, seats, product)
+                                                                                || seatOccupiedByUser(user, product))
+                                                                            .map((product) => ({
+                                                                                _id: product._id,
+                                                                                section: product.product_type,
+                                                                            }))
+                                                                    });
+                                                                }}
+                                                            >
+                                                                {gettext('Select All')}
+                                                            </button>
+                                                        </div>
+                                                    )}
+
+                                                    {filteredSections.map((section: any) => (
+                                                        <React.Fragment key={section._id}>
+                                                            <div className="list-item__preview-subheading">
+                                                                {section.name}
+                                                            </div>
+                                                            {
+                                                                products
+                                                                    .filter((product) => filterProductsForSection(product, section))
+                                                                    .map((product) => (
+                                                                        <EditUserProductPermission
+                                                                            key={product._id}
+                                                                            original={original}
+                                                                            user={user}
+                                                                            section={section}
+                                                                            product={product}
+                                                                            seats={seats}
+                                                                            onChange={props.onChange_DEPRECATED}
+                                                                        />
+                                                                    ))
+                                                            }
+                                                        </React.Fragment>
+                                                    ))}
+                                                </>
+                                            );
+                                        }
+                                    })()}
+                                </FormToggle>
+                            );
+                        })()}
 
                         <FormToggle
                             title={gettext('User Settings')}
@@ -324,7 +375,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='is_approved'
                                         label={gettext('Approved')}
                                         value={user.is_approved === true}
-                                        onChange={onChange_DEPRECATED} />
+                                        onChange={props.onChange_DEPRECATED} />
                                 </div>
                             </div>)}
 
@@ -334,7 +385,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='is_enabled'
                                         label={gettext('Enabled')}
                                         value={user.is_enabled === true}
-                                        onChange={onChange_DEPRECATED} />
+                                        onChange={props.onChange_DEPRECATED} />
                                 </div>
                             </div>)}
 
@@ -344,7 +395,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='expiry_alert'
                                         label={gettext('Company Expiry Alert')}
                                         value={user.expiry_alert === true}
-                                        onChange={onChange_DEPRECATED} />
+                                        onChange={props.onChange_DEPRECATED} />
                                 </div>
                             </div>)}
 
@@ -354,7 +405,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                         name='manage_company_topics'
                                         label={gettext('Manage Company Topics')}
                                         value={user.manage_company_topics === true}
-                                        onChange={onChange_DEPRECATED} />
+                                        onChange={props.onChange_DEPRECATED} />
                                 </div>
                             </div>)}
                         </FormToggle>
@@ -370,7 +421,7 @@ const EditUserComponent: React.ComponentType<IProps> = ({
                                 id='resetPassword'
                                 onClick={onResetPassword} />
                         )}
-                        {user._id && (currentUserIsAdmin||isCompanyAdmin) && user._id !== currentUser._id && <input
+                        {user._id && (currentUserIsAdmin || isCompanyAdmin) && user._id !== currentUser._id && <input
                             type='button'
                             className='nh-button nh-button--secondary'
                             value={gettext('Delete')}

--- a/assets/users/components/Users.tsx
+++ b/assets/users/components/Users.tsx
@@ -7,7 +7,7 @@ import {gettext} from 'utils';
 import {
     deleteUser,
     resendUserInvite,
-    editUser,
+    editUser_DEPRECATED,
     newUser,
     postUser,
     resetPassword,
@@ -94,7 +94,7 @@ class Users extends React.Component<any, any> {
                         hideFields={[]}
                         original={this.props.usersById[this.props.userToEdit._id] || {}}
                         user={this.props.userToEdit}
-                        onChange={this.props.editUser}
+                        onChange_DEPRECATED={this.props.editUser_DEPRECATED}
                         errors={this.props.errors}
                         companies={this.props.companies}
                         onSave={this.save}
@@ -152,7 +152,7 @@ const mapStateToProps = (state: any) => ({
 
 const mapDispatchToProps = (dispatch: any) => ({
     selectUser: (_id: any) => dispatch(selectUser(_id)),
-    editUser: (event: any) => dispatch(editUser(event)),
+    editUser_DEPRECATED: (event: any) => dispatch(editUser_DEPRECATED(event)),
     saveUser: () => dispatch(postUser()),
     deleteUser: () => dispatch(deleteUser()),
     resendUserInvite: () => dispatch(resendUserInvite()),

--- a/assets/users/components/Users.tsx
+++ b/assets/users/components/Users.tsx
@@ -13,7 +13,8 @@ import {
     resetPassword,
     selectUser,
     setError,
-    cancelEdit
+    cancelEdit,
+    editUser
 } from '../actions';
 import {searchQuerySelector} from 'search/selectors';
 import {userSelector} from '../selectors';
@@ -21,6 +22,7 @@ import {userSelector} from '../selectors';
 import EditUser from './EditUser';
 import UsersList from './UsersList';
 import SearchResults from 'search/components/SearchResults';
+import {IUser} from 'interfaces';
 
 
 class Users extends React.Component<any, any> {
@@ -95,6 +97,7 @@ class Users extends React.Component<any, any> {
                         original={this.props.usersById[this.props.userToEdit._id] || {}}
                         user={this.props.userToEdit}
                         onChange_DEPRECATED={this.props.editUser_DEPRECATED}
+                        onChange={this.props.editUser}
                         errors={this.props.errors}
                         companies={this.props.companies}
                         onSave={this.save}
@@ -153,6 +156,7 @@ const mapStateToProps = (state: any) => ({
 const mapDispatchToProps = (dispatch: any) => ({
     selectUser: (_id: any) => dispatch(selectUser(_id)),
     editUser_DEPRECATED: (event: any) => dispatch(editUser_DEPRECATED(event)),
+    editUser: (nextUser: IUser) => dispatch(editUser(nextUser)),
     saveUser: () => dispatch(postUser()),
     deleteUser: () => dispatch(deleteUser()),
     resendUserInvite: () => dispatch(resendUserInvite()),

--- a/assets/users/reducers.ts
+++ b/assets/users/reducers.ts
@@ -13,6 +13,7 @@ import {
     SET_COMPANY,
     SET_SORT,
     TOGGLE_SORT_DIRECTION,
+    EDIT_USER,
 } from './actions';
 
 import {ADD_EDIT_USERS} from 'actions';
@@ -109,17 +110,6 @@ export default function userReducer(state: any = initialState, action: any) {
             } else {
                 user.products = (user.products || []).filter((product: any) => product._id !== productId);
             }
-        } else if (field.includes('selectAllBtn')) {
-            const seats = companyProductSeatsSelector(state);
-
-            user.products = (state.products as Array<IProduct>)
-                .filter((product: IProduct) =>
-                    user.sections[product.product_type]
-                    && (
-                        hasSeatsAvailable(user.company, seats, product) || seatOccupiedByUser(user, product)
-                    )
-                )
-                .map((product) => ({_id : product._id , section: product.product_type}));
         }
         else {
             user[field] = value;
@@ -127,6 +117,13 @@ export default function userReducer(state: any = initialState, action: any) {
 
         return {...state, userToEdit: user, errors: null};
     }
+
+    case EDIT_USER:
+        return {
+            ...state,
+            userToEdit: action.payload,
+            errors: null,
+        };
 
     case NEW_USER: {
         const newUser =  {

--- a/assets/users/reducers.ts
+++ b/assets/users/reducers.ts
@@ -4,7 +4,7 @@ import {
     GET_USER,
     REMOVE_USER,
     SELECT_USER,
-    EDIT_USER,
+    EDIT_USER__DEPRECATED,
     QUERY_USERS,
     CANCEL_EDIT,
     NEW_USER,
@@ -78,7 +78,7 @@ export default function userReducer(state: any = initialState, action: any) {
         };
     }
 
-    case EDIT_USER: {
+    case EDIT_USER__DEPRECATED: {
         const target = action.event.target;
         const field = target.name;
         const user: any = {...state.userToEdit};


### PR DESCRIPTION
NHUB-401

There is a bug in the initial implementation. It crashes when there are more products that are not being displayed in the user>products section. When trying to "select all" I was selecting ALL that were in the redux store, rather than all that were rendered in the products section. I fixed that now and also deprecated the messy `editUser` action/reducer that were coupled with DOM