### PR TITLE
implement locale aware template loader

### DIFF
--- a/newsroom/email.py
+++ b/newsroom/email.py
@@ -13,6 +13,7 @@ from jinja2 import TemplateNotFound
 from newsroom.auth import get_company
 
 from newsroom.celery_app import celery
+from newsroom.template_loaders import set_template_locale
 from newsroom.utils import (
     get_agenda_dates,
     get_location_string,
@@ -201,13 +202,17 @@ def send_template_email(
         template_kwargs.setdefault("subject", subject)
         template_kwargs.setdefault("recipient_language", language)
 
-        send_email(
-            to=group["emails"],
-            subject=subject,
-            text_body=render_template(group["text_template"], **template_kwargs),
-            html_body=render_template(group["html_template"], **template_kwargs),
-            **kwargs,
-        )
+        try:
+            set_template_locale(language)
+            send_email(
+                to=group["emails"],
+                subject=subject,
+                text_body=render_template(group["text_template"], **template_kwargs),
+                html_body=render_template(group["html_template"], **template_kwargs),
+                **kwargs,
+            )
+        finally:
+            set_template_locale()
 
 
 def send_validate_account_email(user_name, user_email, token):

--- a/newsroom/gettext.py
+++ b/newsroom/gettext.py
@@ -3,6 +3,7 @@ from flask import request, current_app, session
 from flask_babel import Babel, get_translations, format_datetime
 
 from newsroom.auth import get_user
+from newsroom.template_loaders import get_template_locale
 
 
 def get_client_translations(domain="client"):
@@ -40,6 +41,8 @@ def get_session_locale():
             return request.accept_languages.best_match(
                 current_app.config["LANGUAGES"], current_app.config["DEFAULT_LANGUAGE"]
             )
+    if get_template_locale():
+        return get_template_locale()
     return current_app.config["DEFAULT_LANGUAGE"]
 
 

--- a/newsroom/template_loaders.py
+++ b/newsroom/template_loaders.py
@@ -1,0 +1,46 @@
+import flask
+import jinja2
+
+from typing import Optional
+
+TEMPLATE_LOCALE = "template_locale"
+
+
+def set_template_locale(language: Optional[str] = None) -> None:
+    setattr(flask.g, TEMPLATE_LOCALE, language)
+
+
+def get_template_locale() -> Optional[str]:
+    return getattr(flask.g, TEMPLATE_LOCALE, None)
+
+
+def noop():
+    return False
+
+
+class LocaleTemplateLoader(jinja2.FileSystemLoader):
+    def get_source(self, environment: jinja2.Environment, template: str):
+        source = None
+        filename = None
+        file_uptodate = noop
+        template_locale = get_template_locale()
+
+        if template_locale and f".{template_locale}." not in template:
+            template_name, extension = template.rsplit(".", maxsplit=1)
+
+            try:
+                source, filename, file_uptodate = super().get_source(
+                    environment, f"{template_name}.{template_locale}.{extension}"
+                )
+            except jinja2.TemplateNotFound:
+                # no template for selected locale
+                pass
+
+        if not source:
+            source, filename, file_uptodate = super().get_source(environment, template)
+
+        def uptodate():
+            """Must return False when locale changes to reload template."""
+            return template_locale == get_template_locale() and file_uptodate()
+
+        return source, filename, uptodate

--- a/newsroom/web/factory.py
+++ b/newsroom/web/factory.py
@@ -1,6 +1,5 @@
 import os
 import flask
-import jinja2
 
 from newsroom.factory import BaseNewsroomApp
 from newsroom.template_filters import (
@@ -33,6 +32,7 @@ from newsroom.template_filters import (
     get_highlighted_field,
     get_item_category_names,
 )
+from newsroom.template_loaders import LocaleTemplateLoader
 from newsroom.notifications.notifications import get_initial_notifications
 from newsroom.limiter import limiter
 from newsroom.celery_app import init_celery
@@ -140,9 +140,7 @@ class NewsroomWebApp(BaseNewsroomApp):
         self.add_template_filter(get_agenda_dates, "agenda_dates_string")
         self.add_template_filter(get_item_category_names, "category_names")
 
-        jinja2_loaders = [jinja2.FileSystemLoader(folder) for folder in self._theme_folders]
-
-        self.jinja_loader = jinja2.ChoiceLoader(jinja2_loaders)
+        self.jinja_loader = LocaleTemplateLoader(self._theme_folders)
 
     def _setup_limiter(self):
         limiter.init_app(self)

--- a/tests/core/test_template_loaders.py
+++ b/tests/core/test_template_loaders.py
@@ -1,0 +1,58 @@
+import pytest
+import jinja2
+import pathlib
+import tempfile
+
+from newsroom.template_loaders import LocaleTemplateLoader, set_template_locale
+
+
+def test_load_template_with_locale():
+    template_data = {
+        "test.html": "default template",
+        "test.fr.html": "fr template",
+        "test.en.html": "en template",
+        "with_layout.fr.html": "{% extends 'test.html' %}",
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for filename, data in template_data.items():
+            with open(pathlib.Path(tmpdir).joinpath(filename), "wt") as template:
+                template.write(data)
+
+        loader = LocaleTemplateLoader(tmpdir)
+        env = jinja2.Environment(loader=loader)
+
+        assert "default template" == env.get_template("test.html").render()
+
+        assert "fr template" == env.get_template("test.fr.html").render()
+
+        assert "en template" == env.get_template("test.en.html").render()
+
+        set_template_locale("en")
+
+        assert "en template" == env.get_template("test.html").render()
+
+        assert "fr template" == env.get_template("test.fr.html").render()
+
+        set_template_locale("fr")
+
+        assert "fr template" == env.get_template("test.html").render()
+
+        assert "en template" == env.get_template("test.en.html").render()
+
+        assert "fr template" == env.get_template("with_layout.html").render()
+
+        set_template_locale("en")
+
+        assert "en template" == env.get_template("test.html").render()
+
+        set_template_locale("fi")
+
+        assert "default template" == env.get_template("test.html").render()
+
+        set_template_locale()
+
+        assert "default template" == env.get_template("test.html").render()
+
+        with pytest.raises(jinja2.TemplateNotFound):
+            env.get_template("missing.html").render()


### PR DESCRIPTION
so when using template eg. `layout.html` it will pick `layout.fr_ca.html` if locale is set and file exists.

it will also use selected locale for time formats.

CPCN-359

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
