### PR TITLE
[CPCN-414] fix: Send notification schedule date in utc for templates

### DIFF
--- a/newsroom/notifications/send_scheduled_notifications.py
+++ b/newsroom/notifications/send_scheduled_notifications.py
@@ -143,7 +143,7 @@ class SendScheduledNotificationEmails(Command):
             app_name=app.config["SITE_NAME"],
             entries=topic_entries,
             topic_match_table=topic_match_table,
-            date=now_local,
+            date=now_utc,
         )
 
         if not len(topic_entries["wire"]) and not len(topic_entries["agenda"]):


### PR DESCRIPTION
This was due to `flask_babel.format_datetime` expects UTC and rebases for us to the configured timezone for the session (set in the `send_scheduled_notifications` command).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
