### PR TITLE
require replacing `lodash.get` with optional chaining for modified code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,4 @@
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [ ] This pull request is not adding new forms that use redux
 - [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
+- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments


### PR DESCRIPTION
When using `lodash.get`, typescript sees fields as strings and can't provide support for finding usages, renaming and validation of types in general.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
