### PR TITLE
fix email template import on init

### DIFF
--- a/newsroom/email_templates.py
+++ b/newsroom/email_templates.py
@@ -1,19 +1,20 @@
 from typing import Optional
 import logging
+import newsroom
 
 from flask import render_template_string, current_app
 from flask_babel import gettext
 from werkzeug.exceptions import BadRequest, NotFound
 from eve.utils import config
 
-from superdesk import Resource, register_resource
+from superdesk import register_resource
 from superdesk.services import CacheableService
 
 logger = logging.getLogger(__name__)
 RESOURCE = "email_templates"
 
 
-class EmailTemplatesResource(Resource):
+class EmailTemplatesResource(newsroom.Resource):
     endpoint_name = RESOURCE
     item_methods = ["GET"]
     resource_methods = ["GET"]
@@ -89,12 +90,11 @@ class EmailTemplatesService(CacheableService):
     def on_fetched_item(self, doc):
         self.enhance_items([doc])
 
-    def get_from_mongo(self, req, lookup, projection=None):
+    def get_cached_by_id(self, _id):
         """Make sure to enhance the item when fetching from mongo"""
-
-        items = super().get_from_mongo(req, lookup, projection)
-        self.enhance_items(items)
-        return items
+        item = super().get_cached_by_id(_id)
+        self.enhance_items([item])
+        return item
 
     def enhance_items(self, docs):
         for email in docs:

--- a/tests/core/test_email_templates.py
+++ b/tests/core/test_email_templates.py
@@ -139,3 +139,22 @@ def test_get_subject_falls_back_to_default_on_render_error(app):
 
     subject = service.get_translated_subject("coverage_request_email", "fr_ca", item={"name": "Test Coverage"})
     assert subject == "Coverage inquiry: Test Coverage"
+
+
+def test_get_from_mongo_returns_working_cursor(app):
+    app.data.insert(
+        RESOURCE,
+        [
+            {
+                "_id": "coverage_request_email",
+                "subject": {
+                    "default": "Coverage inquiry: {{ item.name or item.slugline }}",
+                    "translations": {"fr_ca": "Canadian French Coverage inquiry: {{ 1 / 0 }}"},
+                },
+            }
+        ],
+    )
+    service = get_resource_service(RESOURCE)
+    items = service.get_from_mongo(None, {})
+    assert 1 == items.count()
+    assert 1 == len(list(items))


### PR DESCRIPTION
the cursor was already iterated over in `get_from_mongo` and then in the import task it wouldn't be able to read it again resulting in db conflicts if `email_templates` collection was already populated.

NHUB-440

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
