### PR TITLE
Refresh widget - new items indicator is missing when new items arrive to Newshub

### DIFF
--- a/assets/reducers.ts
+++ b/assets/reducers.ts
@@ -354,7 +354,7 @@ export function defaultReducer(state: any = {}, action: any) {
     }
 
     case SET_NEW_ITEM: {
-        const item = state.data || {};
+        const item = action.data || {};
 
         if (!item.nextversion && !state.itemsById[item._id]) {
             return {


### PR DESCRIPTION
NHUB-445

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments
