### PR TITLE
implement item level expiry based on source

### DIFF
--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -50,8 +50,7 @@ def query_resource(
 
 
 def find_one(resource, **lookup):
-    req = ParsedRequest()
-    return app.data.find_one(resource, req, **lookup)
+    return app.data.find_one(resource, req=None, **lookup)
 
 
 def get_random_string():

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -3,7 +3,7 @@ import pathlib
 import tzlocal
 import logging
 
-from typing import List
+from typing import Dict, List
 from kombu import Queue, Exchange
 from celery.schedules import crontab
 from superdesk.default_settings import strtobool, env, local_to_utc_hour
@@ -678,3 +678,9 @@ AGENDA_SHOW_MULTIDAY_ON_START_ONLY = True
 #: .. versionadded: 2.5.0
 #:
 WIRE_NOTIFICATIONS_ON_CORRECTIONS = False
+
+#: Set source specific expiry
+#:
+#: .. versionadded: 2.6
+#:
+SOURCE_EXPIRY_DAYS: Dict[str, int] = {}

--- a/tests/commands/test_remove_expired_items.py
+++ b/tests/commands/test_remove_expired_items.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timedelta
+from newsroom.commands.remove_expired import remove_expired
+from newsroom.utils import find_one
+
+
+def test_remove_expired_items(app):
+    items = [
+        {"_id": "expired", "versioncreated": datetime(2020, 10, 1), "expiry": datetime.utcnow() - timedelta(days=1)},
+    ]
+
+    app.data.insert("items", items)
+
+    remove_expired(1)
+
+    expired = find_one("items", _id="expired")
+    assert expired is None


### PR DESCRIPTION
add `SOURCE_EXPIRY_DAYS` config which is used
to set specific expiry for items and remove those
during expiry cleanup.

CPCN-29

uses https://github.com/superdesk/superdesk-core/pull/2499