### PR TITLE
fix event date grouping with restricted coverage info enabled

### DIFF
--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -627,7 +627,7 @@ export function getHighlightedDescription(item: any, plan: any) {
  * @param {Object} item
  * @return {Array} list of dates
  */
-export function getExtraDates(item: any) {
+export function getExtraDates(item: any): Array<moment.Moment> {
     return getDisplayDates(item).map((ed: any) => moment(ed.date));
 }
 
@@ -636,7 +636,7 @@ export function getExtraDates(item: any) {
  * @param item: Event or Planning item
  * @returns {Array.<{date: moment.Moment}>}
  */
-export function getDisplayDates(item: any) {
+export function getDisplayDates(item: any): Array<{date: string}> {
     const matchedPlanning = get(item, '_hits.matched_planning_items');
 
     if (matchedPlanning == null) {
@@ -658,7 +658,7 @@ export function getDisplayDates(item: any) {
 
             const coverages = (get(plan, 'coverages') || []).filter((coverage: any) => coverage.scheduled);
 
-            if (!coverages.length) {
+            if (!coverages.length && plan.planning_date != null) {
                 dates.push({date: plan.planning_date});
                 return;
             }
@@ -668,7 +668,11 @@ export function getDisplayDates(item: any) {
                     return;
                 }
 
-                dates.push({date: coverage.planning.scheduled});
+                if (coverage.planning?.scheduled != null) {
+                    // when restricted coverage is enabled
+                    // there might be no date
+                    dates.push({date: coverage.planning.scheduled});
+                }
             });
         });
 
@@ -763,7 +767,7 @@ export function groupItems(items: any, activeDate: any, activeGrouping: any, fea
             for (const day = start.clone(); day.isSameOrBefore(end, 'day'); day.add(1, 'd')) {
                 const isBetween = isBetweenDay(day, itemStartDate, itemEndDate, item.dates.all_day, item.dates.no_end_time);
                 const containsExtra = containsExtraDate(item, day);
-                const addGroupItem = (item.event == null || get(item, '_hits.matched_planning_items') != null) ?
+                const addGroupItem = (item.event == null || get(item, '_hits.matched_planning_items') != null) && itemExtraDates.length ?
                     containsExtra :
                     isBetween || containsExtra;
 


### PR DESCRIPTION
the coverage date info is removed when restricted coverage is enabled but then it gets `undefined` which adds a current date to the list of item extra dates and make each event with planning data show up as starting today.

STTNHUB-305

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
