### PR TITLE
<p> tags appearing in the planning block of event items in both preview and full view

### DIFF
--- a/assets/agenda/components/AgendaPreviewCoverages.tsx
+++ b/assets/agenda/components/AgendaPreviewCoverages.tsx
@@ -10,6 +10,7 @@ import PreviewBox from 'ui/components/PreviewBox';
 import AgendaCoverages from './AgendaCoverages';
 import AgendaInternalNote from './AgendaInternalNote';
 import AgendaEdNote from './AgendaEdNote';
+import AgendaLongDescription from './AgendaLongDescription';
 
 class AgendaPreviewCoverages extends React.Component<any, any> {
     static propTypes: any;
@@ -95,9 +96,8 @@ class AgendaPreviewCoverages extends React.Component<any, any> {
                                     <span>{agendaNames}</span>
                                 </div>
                             )}
-                            <p>
-                                {plan.description_text}
-                            </p>
+
+                            <AgendaLongDescription item={item} plan={plan}/>
 
                             {!plan.ednote ? null : (
                                 <AgendaEdNote
@@ -105,6 +105,7 @@ class AgendaPreviewCoverages extends React.Component<any, any> {
                                     noMargin={true}
                                 />
                             )}
+
                             {!plan.internal_note ? null : (
                                 <AgendaInternalNote
                                     internalNote={plan.internal_note}


### PR DESCRIPTION
STTNHUB-304

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments
