### PR TITLE
The language config for the date picker calendar in the Agenda section is not picked up anymore

### DIFF
--- a/assets/components/CalendarButton.tsx
+++ b/assets/components/CalendarButton.tsx
@@ -31,7 +31,7 @@ class CalendarButton extends React.Component<any, any> {
         const rootLocale = locale.substring(0, 2);
         const allLocales = locales as any;
 
-        return allLocales[locale] || allLocales[rootLocale];
+        return allLocales[locale] ?? allLocales[rootLocale];
     };
 
     render() {

--- a/assets/components/CalendarButton.tsx
+++ b/assets/components/CalendarButton.tsx
@@ -5,6 +5,8 @@ import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import CalendarButtonWrapper from './CalendarButtonWrapper';
 import {EARLIEST_DATE} from '../agenda/utils';
+import {registerLocale} from  'react-datepicker';
+import * as locales from 'date-fns/locale';
 
 class CalendarButton extends React.Component<any, any> {
     static propTypes: any;
@@ -24,7 +26,21 @@ class CalendarButton extends React.Component<any, any> {
         prevProps.activeDate === EARLIEST_DATE && this.setState({startDate: moment(this.props.activeDate)});
     }
 
+    getLocale = () => {
+        const locale = window.locale.replace('_', '');
+        const rootLocale = locale.substring(0, 2);
+        const allLocales = locales as any;
+
+        return allLocales[locale] || allLocales[rootLocale];
+    };
+
     render() {
+        const locale = this.getLocale();
+
+        if (locale != undefined) {
+            registerLocale(locale.code, locale);
+        }
+
         const isStartDateToday = moment.isMoment(this.state.startDate) && !this.state.startDate.isSame(moment(), 'day');
         const datePicker = (
             <DatePicker
@@ -34,7 +50,7 @@ class CalendarButton extends React.Component<any, any> {
                 selected={this.state.startDate}
                 onChange={this.handleChange}
                 highlightDates={[moment().toDate()]}
-                locale={window.locale || 'en'}
+                locale={locale?.code ?? 'en'}
                 popperModifiers={[
                     {
                         name: 'offset',


### PR DESCRIPTION
NHUB-472

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments
