### PR TITLE
[NHUB-474] improve: Add new 'Not Intended' coverage status filter

### DIFF
--- a/assets/agenda/components/AgendaCoverageExistsFilter.tsx
+++ b/assets/agenda/components/AgendaCoverageExistsFilter.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import {get} from 'lodash';
 
-import {gettext} from 'utils';
+import {gettext, getConfig} from 'utils';
 import {AgendaDropdown} from './AgendaDropdown';
+
+type ICoverageStatusOptionValue = 'planned' | 'not planned' | 'may be' | 'not intended' | 'completed';
+
+interface IProps {
+    toggleFilter(field: string, value?: ICoverageStatusOptionValue): void;
+    activeFilter: {coverage_status?: Array<ICoverageStatusOptionValue>};
+}
+
+interface ICoverageStatusOptionConfig {
+    enabled: boolean;
+    option_label: string;
+    button_label: string;
+}
+
+type ICoverageStatusFilterConfig = {[value in ICoverageStatusOptionValue]: ICoverageStatusOptionConfig};
 
 export const agendaCoverageStatusFilter = {
     label: gettext('Any coverage status'),
@@ -11,31 +24,32 @@ export const agendaCoverageStatusFilter = {
     nestedField: 'coverage_status',
 };
 
-const FILTER_VALUES = {
-    PLANNED: 'planned',
-    NOT_PLANNED: 'not planned',
-    MAY_BE: 'may be',
-    COMPLETED: 'completed'
-};
-
-export function getActiveFilterLabel(filter: any, activeFilter: any) {
-    const filterValue = get(activeFilter, `${filter.field}[0]`);
-
-    switch (filterValue) {
-    case FILTER_VALUES.PLANNED:
-        return gettext('Planned');
-    case FILTER_VALUES.NOT_PLANNED:
-        return gettext('Not Planned');
-    case FILTER_VALUES.MAY_BE:
-        return gettext('Not Decided');
-    case FILTER_VALUES.COMPLETED:
-        return gettext('Completed');
+export function getActiveFilterLabel(
+    filter: {label: string; field: string},
+    activeFilter?: {
+        coverage_status?: Array<ICoverageStatusOptionValue>;
+        [field: string]: any;
     }
+) {
+    const config: ICoverageStatusFilterConfig = getConfig('coverage_status_filter');
 
-    return filter.label;
+    return activeFilter?.coverage_status?.[0] != null ?
+        config[activeFilter.coverage_status[0]].button_label :
+        filter.label;
 }
 
-function AgendaCoverageExistsFilter ({toggleFilter, activeFilter}: any) {
+function AgendaCoverageExistsFilter({toggleFilter, activeFilter}: IProps) {
+    const config: ICoverageStatusFilterConfig = getConfig('coverage_status_filter');
+    const enabledOptions= ([
+        'planned',
+        'may be',
+        'not intended',
+        'not planned',
+        'completed',
+    ]
+        .filter((option) => (config[option as ICoverageStatusOptionValue]?.enabled === true))
+    ) as Array<ICoverageStatusOptionValue>;
+
     return (
         <AgendaDropdown
             filter={agendaCoverageStatusFilter}
@@ -47,37 +61,19 @@ function AgendaCoverageExistsFilter ({toggleFilter, activeFilter}: any) {
             resetOptionLabel={gettext('Clear selection')}
             dropdownMenuHeader={gettext('Coverage status')}
         >
-            <button
-                key='coverage-planned'
-                className='dropdown-item'
-                onClick={() => toggleFilter(agendaCoverageStatusFilter.field, FILTER_VALUES.PLANNED)}
-            >{gettext('Coverage is planned')}
-            </button>
-            <button
-                key='coverage-not-planned'
-                className='dropdown-item'
-                onClick={() => toggleFilter(agendaCoverageStatusFilter.field, FILTER_VALUES.NOT_PLANNED)}
-            >{gettext('Coverage not planned')}
-            </button>
-            <button
-                key='coverage-not-decided'
-                className='dropdown-item'
-                onClick={() => toggleFilter(agendaCoverageStatusFilter.field, FILTER_VALUES.MAY_BE)}
-            >{gettext('Coverage not decided')}
-            </button>
-            <button
-                key='coverage-completed'
-                className='dropdown-item'
-                onClick={() => toggleFilter(agendaCoverageStatusFilter.field, FILTER_VALUES.COMPLETED)}
-            >{gettext('Coverage completed')}
-            </button>
+            {enabledOptions.map((option) => (
+                config[option]?.enabled !== true ? null : (
+                    <button
+                        key={`coverage-${option}`}
+                        className="dropdown-item"
+                        onClick={() => toggleFilter(agendaCoverageStatusFilter.field, option)}
+                    >
+                        {config[option].option_label}
+                    </button>
+                )
+            ))}
         </AgendaDropdown>
     );
 }
-
-AgendaCoverageExistsFilter.propTypes = {
-    toggleFilter: PropTypes.func,
-    activeFilter: PropTypes.object,
-};
 
 export default AgendaCoverageExistsFilter;

--- a/assets/agenda/components/AgendaDropdown.tsx
+++ b/assets/agenda/components/AgendaDropdown.tsx
@@ -8,7 +8,7 @@ interface IProps {
     label?: string;
     activeFilter?: any;
     toggleFilter: (filedName: string, value: any) => void;
-    getFilterLabel?: (filter: string, activeFilter: string, isActive: boolean) => string;
+    getFilterLabel?: (filter: {field: string; label: string}, activeFilter: {[field: string]: any}, isActive: boolean) => string;
     children?: any;
     borderless?: boolean;
     dropdownMenuHeader?: string;

--- a/assets/tests.ts
+++ b/assets/tests.ts
@@ -22,6 +22,33 @@ window.newsroom = {
             live_blog: {name: 'Live Blog', icon: 'live-blog'},
             video_explainer: {name: 'Video Explainer', icon: 'explainer'},
         },
+        coverage_status_filter: {
+            planned: {
+                enabled: true,
+                option_label: 'Coverage is planned',
+                button_label: 'Planned',
+            },
+            'may be': {
+                enabled: true,
+                option_label: 'Coverage not decided',
+                button_label: 'Not Decided',
+            },
+            'not intended': {
+                enabled: true,
+                option_label: 'Coverage not intended',
+                button_label: 'Not Intended',
+            },
+            'not planned': {
+                enabled: true,
+                option_label: 'Coverage not planned',
+                button_label: 'Not Planned',
+            },
+            'completed': {
+                enabled: true,
+                option_label: 'Coverage completed',
+                button_label: 'Completed',
+            },
+        },
         debug: true,
         default_language: 'en',
         default_timezone: 'Australia/Sydney',

--- a/data_updates/00013_20240109-164049_topics.py
+++ b/data_updates/00013_20240109-164049_topics.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Mark Pittaway
+# Creation: 2024-01-09 16:40
+
+from superdesk.commands.data_updates import DataUpdate as _DataUpdate
+
+
+class DataUpdate(_DataUpdate):
+    resource = "topics"
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        for topic in mongodb_collection.find({}):
+            if not len((topic.get("filter") or {}).get("coverage_status") or []):
+                continue
+
+            topic["filter"]["coverage_status"] = [
+                "not intended" if value == "not planned" else value for value in topic["filter"]["coverage_status"]
+            ]
+            mongodb_collection.update_one({"_id": topic["_id"]}, {"$set": {"filter": topic["filter"]}})
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        for topic in mongodb_collection.find({}):
+            if not len((topic.get("filter") or {}).get("coverage_status") or []):
+                continue
+
+            topic["filter"]["coverage_status"] = [
+                "not planned" if value == "not intended" else value for value in topic["filter"]["coverage_status"]
+            ]
+            mongodb_collection.update_one({"_id": topic["_id"]}, {"$set": {"filter": topic["filter"]}})

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -567,12 +567,10 @@ def _filter_terms(filters, item_type):
                     )
                 )
             elif val == ["not planned"]:
-                must_term_filters.append(
+                must_not_term_filters.append(
                     nested_query(
                         path="coverages",
-                        query={
-                            "bool": {"filter": [{"terms": {"coverages.coverage_status": ["coverage not intended"]}}]}
-                        },
+                        query={"bool": {"must": [{"exists": {"field": "coverages"}}]}},
                         name="coverage_status",
                     )
                 )
@@ -581,6 +579,16 @@ def _filter_terms(filters, item_type):
                     nested_query(
                         path="coverages",
                         query={"bool": {"must": [{"exists": {"field": "coverages.delivery_id"}}]}},
+                    )
+                )
+            elif val == ["not intended"]:
+                must_term_filters.append(
+                    nested_query(
+                        path="coverages",
+                        query={
+                            "bool": {"filter": [{"terms": {"coverages.coverage_status": ["coverage not intended"]}}]}
+                        },
+                        name="coverage_status",
                     )
                 )
         elif key == "agendas":

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -361,6 +361,33 @@ CLIENT_CONFIG = {
         },
     },
     "scheduled_notifications": {"default_times": DEFAULT_SCHEDULED_NOTIFICATION_TIMES},
+    "coverage_status_filter": {
+        "planned": {
+            "enabled": True,
+            "option_label": lazy_gettext("Coverage is planned"),
+            "button_label": lazy_gettext("Planned"),
+        },
+        "may be": {
+            "enabled": True,
+            "option_label": lazy_gettext("Coverage not decided"),
+            "button_label": lazy_gettext("Not Decided"),
+        },
+        "not intended": {
+            "enabled": True,
+            "option_label": lazy_gettext("Coverage not intended"),
+            "button_label": lazy_gettext("Not Intended"),
+        },
+        "not planned": {
+            "enabled": True,
+            "option_label": lazy_gettext("Coverage not planned"),
+            "button_label": lazy_gettext("Not Planned"),
+        },
+        "completed": {
+            "enabled": True,
+            "option_label": lazy_gettext("Coverage completed"),
+            "button_label": lazy_gettext("Completed"),
+        },
+    },
 }
 
 # Enable rendering of the date in the base view

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -628,13 +628,17 @@ def test_filter_agenda_by_coverage_status(client):
     assert 1 == data["_meta"]["total"]
     assert "foo" == data["_items"][0]["_id"]
 
-    data = get_json(client, '/agenda/search?filter={"coverage_status":["not planned"]}')
+    data = get_json(client, '/agenda/search?filter={"coverage_status":["not intended"]}')
     assert 1 == data["_meta"]["total"]
     assert "bar" == data["_items"][0]["_id"]
 
     data = get_json(client, '/agenda/search?filter={"coverage_status":["may be"]}')
     assert 1 == data["_meta"]["total"]
     assert "123foo" == data["_items"][0]["_id"]
+
+    data = get_json(client, '/agenda/search?filter={"coverage_status":["not planned"]}')
+    assert 1 == data["_meta"]["total"]
+    assert "baz" == data["_items"][0]["_id"]
 
 
 def test_filter_events_only(client):


### PR DESCRIPTION
Additionally, adds new config to control which coverage status filters are available and what wording is to be used

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

@petrjasek This one is for v2.6+ as there was an additional requirements for the filters row here