### PR TITLE
Images downloaded from NewsPro have low resolution and small size comparing to CP's legacy system [CPCN-514]

### DIFF
--- a/newsroom/wire/formatters/picture.py
+++ b/newsroom/wire/formatters/picture.py
@@ -2,6 +2,7 @@ import mimetypes
 
 from newsroom.wire.formatters.base import BaseFormatter
 from newsroom.wire.utils import get_picture
+from flask import current_app as app
 
 
 class PictureFormatter(BaseFormatter):
@@ -28,7 +29,7 @@ class PictureFormatter(BaseFormatter):
             raise ValueError("Undefined picture")
 
         renditions = picture.get("renditions", {})
-        picture_details = renditions.get("original") or renditions.get("baseImage", {})
+        picture_details = renditions.get(app.config.get("DOWNLOAD_RENDITION")) or renditions.get("baseImage")
         self.MIMETYPE = picture_details.get("mimetype", "image/jpeg")
         picture_details["file_extension"] = self.update_extension()
 

--- a/newsroom/wire/formatters/picture.py
+++ b/newsroom/wire/formatters/picture.py
@@ -30,6 +30,10 @@ class PictureFormatter(BaseFormatter):
 
         renditions = picture.get("renditions", {})
         picture_details = renditions.get(app.config.get("DOWNLOAD_RENDITION")) or renditions.get("baseImage", {})
+
+        if picture_details is None:
+            raise ValueError("Unable to find picture renditions")
+
         self.MIMETYPE = picture_details.get("mimetype", "image/jpeg")
         picture_details["file_extension"] = self.update_extension()
 

--- a/newsroom/wire/formatters/picture.py
+++ b/newsroom/wire/formatters/picture.py
@@ -27,7 +27,7 @@ class PictureFormatter(BaseFormatter):
         if not picture:
             raise ValueError("Undefined picture")
 
-        picture_details = picture.get("renditions", {}).get("baseImage", {})
+        picture_details = picture.get("renditions", {}).get("original", {})
         self.MIMETYPE = picture_details.get("mimetype", "image/jpeg")
         picture_details["file_extension"] = self.update_extension()
 

--- a/newsroom/wire/formatters/picture.py
+++ b/newsroom/wire/formatters/picture.py
@@ -27,7 +27,8 @@ class PictureFormatter(BaseFormatter):
         if not picture:
             raise ValueError("Undefined picture")
 
-        picture_details = picture.get("renditions", {}).get("original", {})
+        renditions = picture.get("renditions", {})
+        picture_details = renditions.get("original") or renditions.get("baseImage", {})
         self.MIMETYPE = picture_details.get("mimetype", "image/jpeg")
         picture_details["file_extension"] = self.update_extension()
 

--- a/newsroom/wire/formatters/picture.py
+++ b/newsroom/wire/formatters/picture.py
@@ -29,7 +29,7 @@ class PictureFormatter(BaseFormatter):
             raise ValueError("Undefined picture")
 
         renditions = picture.get("renditions", {})
-        picture_details = renditions.get(app.config.get("DOWNLOAD_RENDITION")) or renditions.get("baseImage")
+        picture_details = renditions.get(app.config.get("DOWNLOAD_RENDITION")) or renditions.get("baseImage", {})
         self.MIMETYPE = picture_details.get("mimetype", "image/jpeg")
         picture_details["file_extension"] = self.update_extension()
 


### PR DESCRIPTION
first use `original` rendition if it is present instead of `baseImage` in story_image downloads.

https://github.com/superdesk/newsroom-app-cp/pull/160


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments



