### PR TITLE
Fix : Coverage status shown wrong in pre and full view and in the list view tooltips [NHUB-480]

### DIFF
--- a/assets/agenda/components/CoverageItemStatus.tsx
+++ b/assets/agenda/components/CoverageItemStatus.tsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import {get} from 'lodash';
 import {gettext} from 'utils';
 import {
+    getCoverageStatusText,
     WORKFLOW_STATUS,
     isCoverageBeingUpdated,
     isWatched,
-    formattedCoverageStatusText,
 } from '../utils';
 
 import AgendaInternalNote from './AgendaInternalNote';
@@ -192,7 +192,7 @@ export default class CoverageItemStatus extends React.Component<any, any> {
                 <div className='coverage-item__row'>
                     <span key="topRow">
                         <span key="label" className='coverage-item__text-label me-1'>{gettext('status')}:</span>
-                        <span key="value">{formattedCoverageStatusText(coverage)}</span>
+                        <span key="value">{getCoverageStatusText(coverage)}</span>
                     </span>
                 </div>
 

--- a/assets/agenda/components/CoverageItemStatus.tsx
+++ b/assets/agenda/components/CoverageItemStatus.tsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import {get} from 'lodash';
 import {gettext} from 'utils';
 import {
-    getCoverageStatusText,
     WORKFLOW_STATUS,
     isCoverageBeingUpdated,
     isWatched,
+    formattedCoverageStatusText,
 } from '../utils';
 
 import AgendaInternalNote from './AgendaInternalNote';
@@ -192,7 +192,7 @@ export default class CoverageItemStatus extends React.Component<any, any> {
                 <div className='coverage-item__row'>
                     <span key="topRow">
                         <span key="label" className='coverage-item__text-label me-1'>{gettext('status')}:</span>
-                        <span key="value">{getCoverageStatusText(coverage)}</span>
+                        <span key="value">{formattedCoverageStatusText(coverage)}</span>
                     </span>
                 </div>
 

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -1023,13 +1023,18 @@ export function formatCoverageDate(coverage: ICoverage) {
         parseDate(coverage.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
 }
 
+export function formattedCoverageStatusText(coverage: ICoverage) {
+    const statusText = getCoverageStatusText(coverage).replace('Coverage ', '');
+    return statusText.charAt(0).toUpperCase() + statusText.slice(1);
+}
+
 export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
     const slugline = coverage.item_slugline || coverage.slugline;
     const coverageType = getCoverageDisplayName(coverage.coverage_type);
     const coverageScheduled = moment(coverage.scheduled);
     const assignee = getCoverageAsigneeName(coverage);
     const desk = getCoverageDeskName(coverage);
-    const status =  getCoverageStatusText(coverage);
+    const status =  formattedCoverageStatusText(coverage);
     const assignedDetails = [
         assignee ? gettext('assignee: {{name}}', {name: assignee}) : '',
         desk ? gettext('desk: {{name}}', {name: desk}) : '',

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -48,7 +48,7 @@ const Groupers: any = {
 };
 
 export function getCoverageStatusText(coverage: any) {
-    if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
+    if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT || coverage.coverage_status !== 'coverage intended') {
         return get(DRAFT_STATUS_TEXTS, coverage.coverage_status, '');
     }
 
@@ -1029,6 +1029,7 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
     const coverageScheduled = moment(coverage.scheduled);
     const assignee = getCoverageAsigneeName(coverage);
     const desk = getCoverageDeskName(coverage);
+    const status =  getCoverageStatusText(coverage);
     const assignedDetails = [
         assignee ? gettext('assignee: {{name}}', {name: assignee}) : '',
         desk ? gettext('desk: {{name}}', {name: desk}) : '',
@@ -1041,12 +1042,13 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
             assignedDetails,
         });
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ASSIGNED) {
-        return gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
+        return gettext('{{ status }} {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,
             date: formatDate(coverageScheduled),
             time: formatTime(coverageScheduled),
             assignedDetails,
+            status,
         });
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ACTIVE) {
         return gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -15,7 +15,6 @@ import {
     AGENDA_DATE_FORMAT_SHORT,
     formatTime,
     DAY_IN_MINUTES,
-    upperCaseFirstCharacter,
 } from '../utils';
 
 export const STATUS_KILLED = 'killed';
@@ -1024,10 +1023,6 @@ export function formatCoverageDate(coverage: ICoverage) {
         parseDate(coverage.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
 }
 
-export function formattedCoverageStatusText(coverage: ICoverage) {
-    const statusText = getCoverageStatusText(coverage).replace('Coverage ', '');
-    return upperCaseFirstCharacter(statusText);
-}
 
 export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
     const slugline = coverage.item_slugline || coverage.slugline;
@@ -1035,12 +1030,14 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
     const coverageScheduled = moment(coverage.scheduled);
     const assignee = getCoverageAsigneeName(coverage);
     const desk = getCoverageDeskName(coverage);
-    const status =  formattedCoverageStatusText(coverage);
     const assignedDetails = [
         assignee ? gettext('assignee: {{name}}', {name: assignee}) : '',
         desk ? gettext('desk: {{name}}', {name: desk}) : '',
     ].filter((x) => x !== '').join(', ');
-    if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
+
+    if (coverage.coverage_status !== 'coverage intended') {
+        return get(DRAFT_STATUS_TEXTS, coverage.coverage_status, '');
+    } else if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
         return gettext('{{ type }} coverage {{ slugline }} {{ status_text }} {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,
@@ -1048,13 +1045,12 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
             assignedDetails,
         });
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ASSIGNED) {
-        return gettext('{{ status }} {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
+        return gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,
             date: formatDate(coverageScheduled),
             time: formatTime(coverageScheduled),
             assignedDetails,
-            status,
         });
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ACTIVE) {
         return gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -15,6 +15,7 @@ import {
     AGENDA_DATE_FORMAT_SHORT,
     formatTime,
     DAY_IN_MINUTES,
+    upperCaseFirstCharacter,
 } from '../utils';
 
 export const STATUS_KILLED = 'killed';
@@ -1025,7 +1026,7 @@ export function formatCoverageDate(coverage: ICoverage) {
 
 export function formattedCoverageStatusText(coverage: ICoverage) {
     const statusText = getCoverageStatusText(coverage).replace('Coverage ', '');
-    return statusText.charAt(0).toUpperCase() + statusText.slice(1);
+    return upperCaseFirstCharacter(statusText);
 }
 
 export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {


### PR DESCRIPTION


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
