### PR TITLE
Fix : Coverage status shown wrong in pre and full view and in the list view tooltips [NHUB-480]

### DIFF
--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -48,7 +48,7 @@ const Groupers: any = {
 };
 
 export function getCoverageStatusText(coverage: any) {
-    if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
+    if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT || coverage.coverage_status !== 'coverage intended') {
         return get(DRAFT_STATUS_TEXTS, coverage.coverage_status, '');
     }
 
@@ -1033,7 +1033,10 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
         assignee ? gettext('assignee: {{name}}', {name: assignee}) : '',
         desk ? gettext('desk: {{name}}', {name: desk}) : '',
     ].filter((x) => x !== '').join(', ');
-    if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
+
+    if (coverage.coverage_status !== 'coverage intended') {
+        return get(DRAFT_STATUS_TEXTS, coverage.coverage_status, '');
+    } else if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
         return gettext('{{ type }} coverage {{ slugline }} {{ status_text }} {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,


### PR DESCRIPTION
https://github.com/superdesk/newsroom-core/pull/736

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
