### PR TITLE
when looking for matching topics run a query per user

### DIFF
--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -781,7 +781,7 @@ def notify_new_item(item, check_topics=True):
         )
     except Exception as e:
         logger.exception(e)
-        logger.error(f"Failed to notify users for new {item_type} item {item['_id']}")
+        logger.error(f"Failed to notify users for new {item_type} item", extra={"_id": item["_id"]})
 
 
 def notify_user_matches(item, users_dict, companies_dict, user_ids, company_ids, users_with_realtime_subscription):

--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -416,7 +416,8 @@ class BaseSearchService(Service):
             return
 
         current_user = get_user(required=False)
-        search.is_admin = is_admin(current_user)
+        if current_user:
+            search.is_admin = is_admin(current_user)
 
         if search.is_admin and search.args.get("user"):
             search.user = get_resource_service("users").find_one(req=None, _id=search.args["user"])
@@ -842,56 +843,60 @@ class BaseSearchService(Service):
             response.hits["hits"]["total"] = response.count() + embargoed_response.count()
 
     def get_matching_topics_for_item(self, topics, users, companies, query):
-        aggs = {"topics": {"filters": {"filters": {}}}}
-        queried_topics = []
-
-        for topic in topics:
-            user = users.get(str(topic["user"]))
-            if not user:
-                continue
-
-            company = companies.get(str(user.get("company", "")))
-
-            topic_query = self.get_topic_query(topic, user, company, query)
-            if not topic_query:
-                continue
-
-            aggs["topics"]["filters"]["filters"][str(topic["_id"])] = topic_query.query
-
-            queried_topics.append(topic)
-
-        source = {"query": query}
-        source["aggs"] = aggs if aggs["topics"]["filters"]["filters"] else {}
-        source["size"] = 0
-
-        req = ParsedRequest()
-        req.args = {"source": json.dumps(source)}
         topic_matches = []
+        topics_checked = set()
 
-        try:
-            search_results = self.internal_get(req, None)
+        for user in users.values():
+            aggs = {"topics": {"filters": {"filters": {}}}}
+            company = companies.get(str(user.get("company", "")))
+            # there will be one base search for a user with aggs for user topics
+            search = self.get_topic_query(None, user, company, query=query)
+            if not search:
+                continue
+            queried_topics = []
+            for topic in topics:
+                user_id = str(topic["user"])
+                if not user_id or str(user["_id"]) != user_id:
+                    continue
+                if topic["_id"] in topics_checked:
+                    continue
+                topics_checked.add(topic["_id"])
 
-            for topic in queried_topics:
-                if search_results.hits["aggregations"]["topics"]["buckets"][str(topic["_id"])]["doc_count"] > 0:
-                    topic_matches.append(topic["_id"])
+                topic_query = self.get_topic_query(topic, None, None)
+                if not topic_query:
+                    continue
 
-        except Exception as exc:
-            logger.error(
-                "Error in get_matching_topics for query: {}".format(json.dumps(source)),
-                exc,
-                exc_info=True,
-            )
-            raise
+                aggs["topics"]["filters"]["filters"][str(topic["_id"])] = topic_query.query
+                queried_topics.append(topic)
+            if not queried_topics:
+                continue
+            source = {"query": search.query}
+            source["aggs"] = aggs if aggs["topics"]["filters"]["filters"] else {}
+            source["size"] = 0
+
+            req = ParsedRequest()
+            req.args = {"source": json.dumps(source)}
+
+            try:
+                search_results = self.internal_get(req, None)
+
+                for topic in queried_topics:
+                    if search_results.hits["aggregations"]["topics"]["buckets"][str(topic["_id"])]["doc_count"] > 0:
+                        topic_matches.append(topic["_id"])
+
+            except Exception:
+                logger.exception(
+                    "Error in get_matching_topics",
+                    extra=dict(
+                        query=source,
+                        user=user_id,
+                    ),
+                )
+                continue
 
         return topic_matches
 
-    def get_topic_query(self, topic, user, company, section_filters=None, query=None, args=None):
-        search = SearchQuery()
-
-        search.user = user
-        search.company = company
-        search.section = topic.get("topic_type") or "wire"
-
+    def apply_topic_args(self, topic, args=None):
         if args is None:
             args = {}
 
@@ -916,20 +921,36 @@ class BaseSearchService(Service):
         if topic.get("navigation"):
             args["navigation"] = topic["navigation"]
 
-        search.args = args
+        return args
+
+    def get_topic_query(self, topic, user, company, section_filters=None, query=None, args=None):
+        search = SearchQuery()
+        search.user = user
+        search.company = company
+        search.section = self.section
+
+        if not args:
+            args = {}
+
+        if topic:
+            search.args = self.apply_topic_args(topic, args)
+        elif args:
+            search.args = args
 
         if query is not None:
             search.query = deepcopy(query)
 
         try:
             self.prefill_search_query(search)
-            self.validate_request(search)
+            if user:
+                self.validate_request(search)
             self.apply_filters(search, section_filters)
         except Forbidden as exc:
-            logger.info(
-                "Notification for user:{} and topic:{} is skipped".format(user.get("_id"), topic.get("_id")),
-                exc_info=exc,
-            )
+            if user and topic:
+                logger.info(
+                    "Notification for user:{} and topic:{} is skipped".format(user.get("_id"), topic.get("_id")),
+                    exc_info=exc,
+                )
             return
 
         return search

--- a/tests/core/test_push.py
+++ b/tests/core/test_push.py
@@ -728,7 +728,7 @@ def test_matching_topics(client, app):
     client.post("/push", data=json.dumps(item), content_type="application/json")
     search = get_resource_service("wire_search")
 
-    users = {"foo": {"company": "1", "user_type": "administrator"}}
+    users = {"foo": {"company": "1", "user_type": "administrator", "_id": "foo"}}
     companies = {"1": {"_id": 1, "name": "test-comp"}}
     topics = [
         {"_id": "created_to_old", "created": {"to": "2017-01-01"}, "user": "foo"},
@@ -766,7 +766,7 @@ def test_matching_topics_for_public_user(client, app):
     client.post("/push", json=item)
     search = get_resource_service("wire_search")
 
-    users = {"foo": {"company": COMPANY_1_ID, "user_type": "public"}}
+    users = {"foo": {"company": COMPANY_1_ID, "user_type": "public", "_id": "foo"}}
     companies = {str(COMPANY_1_ID): {"_id": COMPANY_1_ID, "name": "test-comp"}}
     topics = [
         {"_id": "created_to_old", "created": {"to": "2017-01-01"}, "user": "foo"},
@@ -805,8 +805,8 @@ def test_matching_topics_for_user_with_inactive_company(client, app):
     search = get_resource_service("wire_search")
 
     users = {
-        "foo": {"company": COMPANY_1_ID, "user_type": "public"},
-        "bar": {"company": COMPANY_2_ID, "user_type": "public"},
+        "foo": {"company": COMPANY_1_ID, "user_type": "public", "_id": "foo"},
+        "bar": {"company": COMPANY_2_ID, "user_type": "public", "_id": "bar"},
     }
     companies = {str(COMPANY_1_ID): {"_id": COMPANY_1_ID, "name": "test-comp"}}
     topics = [
@@ -867,3 +867,37 @@ def test_push_custom_expiry(client, app):
     now = datetime.utcnow().replace(second=0, microsecond=0)
     expiry: datetime = parsed["expiry"].replace(tzinfo=None)
     assert now + timedelta(days=49) < expiry < now + timedelta(days=51)
+
+
+def test_matching_topics_with_mallformed_query(client, app):
+    app.data.insert(
+        "products",
+        [
+            {
+                "_id": ObjectId("59b4c5c61d41c8d736852fbf"),
+                "name": "Sport",
+                "description": "Top level sport product",
+                "sd_product_id": "p-1",
+                "is_enabled": True,
+                "companies": [COMPANY_1_ID],
+                "product_type": "wire",
+            }
+        ],
+    )
+
+    item["products"] = [{"code": "p-1"}]
+    client.post("/push", json=item)
+    search = get_resource_service("wire_search")
+
+    users = {
+        "foo": {"company": COMPANY_1_ID, "user_type": "public", "_id": "foo"},
+        "bar": {"company": COMPANY_1_ID, "user_type": "public", "_id": "bar"},
+    }
+    companies = {str(COMPANY_1_ID): {"_id": COMPANY_1_ID, "name": "test-comp"}}
+    topics = [
+        {"_id": "good", "query": "*:*", "user": "bar"},
+        {"_id": "bad", "query": "AND Foo", "user": "foo"},
+    ]
+    with app.test_request_context():
+        matching = search.get_matching_topics(item["guid"], topics, users, companies)
+        assert ["good"] == matching


### PR DESCRIPTION
so it won't fail for other users when there is a bad topic, should also avoid timeouts when checking too many products at the same time.

NHUB-479

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
