### PR TITLE
Fix: Event description in the CSV file shows blank when downloading from cpcn-uat [CPCN-552]

### DIFF
--- a/newsroom/agenda/formatters/csv_formatter.py
+++ b/newsroom/agenda/formatters/csv_formatter.py
@@ -43,7 +43,7 @@ class CSVFormatter(BaseFormatter):
         event = item.get("event", {})
         return {
             "Event name": item.get("name", ""),
-            "Description": item.get("definition_long", item.get("definition_short", "")),
+            "Description": item.get("definition_long") or item.get("definition_short", ""),
             "Language": item.get("language", ""),
             "Event start date": self.format_date(item, "start"),
             "Event end date": self.format_date(item, "end"),


### PR DESCRIPTION
handle case where `description_long` is `null`
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
