### PR TITLE
fix empty dashboard cards

### DIFF
--- a/newsroom/cards/cards.py
+++ b/newsroom/cards/cards.py
@@ -1,4 +1,7 @@
+import typing
 import newsroom
+
+from newsroom.types import DashboardCardType
 
 
 class CardsResource(newsroom.Resource):
@@ -12,20 +15,7 @@ class CardsResource(newsroom.Resource):
             "type": "string",
             "required": True,
             "nullable": False,
-            "allowed": [
-                "6-text-only",
-                "4-picture-text",
-                "4-text-only",
-                "4-media-gallery",
-                "4-photo-gallery",
-                "1x1-top-news",
-                "2x2-top-news",
-                "3-text-only",
-                "3-picture-text",
-                "2x2-events",
-                "6-navigation-row",
-                "wire-list",
-            ],
+            "allowed": list(typing.get_args(DashboardCardType)),
         },
         "config": {
             "type": "dict",

--- a/newsroom/public/views.py
+++ b/newsroom/public/views.py
@@ -4,6 +4,7 @@ from werkzeug.utils import secure_filename
 from flask import render_template, current_app as app
 
 from superdesk import get_resource_service
+from newsroom.auth.utils import is_valid_session
 
 from newsroom.types import DashboardCard, Article
 from newsroom.public import blueprint
@@ -66,4 +67,6 @@ def render_public_dashboard():
 
 @blueprint.route("/public/card_items")
 def public_card_items():
+    if not is_valid_session() and not app.config.get("PUBLIC_DASHBOARD"):
+        return {"_items": []}
     return {"_items": get_public_items_by_cards()}

--- a/newsroom/types.py
+++ b/newsroom/types.py
@@ -1,5 +1,5 @@
 from bson import ObjectId
-from typing import Dict, List, Optional, TypedDict, Any, Union, NoReturn
+from typing import Dict, List, Literal, Optional, TypedDict, Any, Union, NoReturn
 from datetime import datetime
 from enum import Enum
 from flask_babel import LazyString
@@ -215,10 +215,26 @@ class DashboardCardConfig(TypedDict, total=False):
     size: int
 
 
+DashboardCardType = Literal[
+    "6-text-only",
+    "4-picture-text",
+    "4-text-only",
+    "4-media-gallery",
+    "4-photo-gallery",
+    "1x1-top-news",
+    "2x2-top-news",
+    "3-text-only",
+    "3-picture-text",
+    "2x2-events",
+    "6-navigation-row",
+    "wire-list",
+]
+
+
 class DashboardCard(TypedDict, total=False):
     _id: ObjectId
     label: str
-    type: str
+    type: DashboardCardType
     config: DashboardCardConfig
     order: int
     dashboard: str

--- a/newsroom/wire/items.py
+++ b/newsroom/wire/items.py
@@ -1,4 +1,5 @@
 from typing import List, Dict
+from typing_extensions import assert_never
 from copy import deepcopy
 
 from flask import current_app as app
@@ -85,7 +86,9 @@ def get_items_for_dashboard(
             items_by_card[card["label"]] = [
                 filter_fields(item) if filter_public_fields else item
                 for item in superdesk.get_resource_service("wire_search").get_product_items(
-                    ObjectId(card["config"]["product"]), card["config"]["size"], exclude_embargoed=exclude_embargoed
+                    ObjectId(card["config"]["product"]),
+                    card["config"]["size"] or get_default_size(card),
+                    exclude_embargoed=exclude_embargoed,
                 )
             ]
         elif card["type"] == "4-photo-gallery":
@@ -94,3 +97,33 @@ def get_items_for_dashboard(
             items_by_card[card["label"]] = []
 
     return items_by_card
+
+
+def get_default_size(card: DashboardCard) -> int:
+    if not card.get("type"):
+        return 0
+    if card["type"] == "1x1-top-news":
+        return 1
+    if card["type"] == "2x2-events":
+        return 4
+    if card["type"] == "2x2-top-news":
+        return 4
+    if card["type"] == "3-picture-text":
+        return 3
+    if card["type"] == "3-text-only":
+        return 3
+    if card["type"] == "4-media-gallery":
+        return 4
+    if card["type"] == "4-photo-gallery":
+        return 4
+    if card["type"] == "4-picture-text":
+        return 4
+    if card["type"] == "4-text-only":
+        return 4
+    if card["type"] == "6-navigation-row":
+        return 6
+    if card["type"] == "6-text-only":
+        return 6
+    if card["type"] == "wire-list":
+        return 5
+    assert_never(card["type"])

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -182,6 +182,7 @@ class WireSearchService(BaseSearchService):
 
         self.gen_source_from_search(search)
         search.source["post_filter"] = {"bool": {"filter": []}}
+        search.source.pop("aggs", None)
         internal_req = self.get_internal_request(search)
 
         return list(self.internal_get(internal_req, None))


### PR DESCRIPTION
we have only size config for wire list,
for the other cards it would be set to 0.
also disable the card items endpoint when
public dashboards are not enabled.

CPCN-594

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
