### PR TITLE
fix picture download when picture was removed

### DIFF
--- a/newsroom/wire/utils.py
+++ b/newsroom/wire/utils.py
@@ -5,11 +5,11 @@ from newsroom.auth import get_user_id
 def get_picture(item):
     if item["type"] == "picture":
         return item
-    return item.get("associations", {}).get("featuremedia", get_body_picture(item))
+    return item.get("associations", {}).get("featuremedia") or get_body_picture(item)
 
 
 def get_body_picture(item):
-    pictures = [assoc for assoc in item.get("associations", {}).values() if assoc.get("type") == "picture"]
+    pictures = [assoc for assoc in item.get("associations", {}).values() if assoc and assoc.get("type") == "picture"]
     if pictures:
         return pictures[0]
 

--- a/tests/core/test_wire_utils.py
+++ b/tests/core/test_wire_utils.py
@@ -1,0 +1,7 @@
+import newsroom.wire.utils as utils
+
+
+def test_get_picture():
+    item = {"type": "text", "associations": {"first": None, "second": {"type": "text"}, "third": {"type": "picture"}}}
+    picture = utils.get_picture(item)
+    assert picture == item["associations"]["third"]


### PR DESCRIPTION
fix an error on download when picture was removed
and there is None in associations.

CPCN-649

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
