### PR TITLE
Fix: If a topic is saved based on a side panel filter search then the rest disappear once the user returns [CPCN-560]

### DIFF
--- a/assets/agenda/actions.ts
+++ b/assets/agenda/actions.ts
@@ -254,6 +254,10 @@ function search(state: IAgendaState, fetchFrom: number): Promise<IRestApiRespons
     return server.get(`/agenda/search?${queryString}&tick=${Date.now().toString()}`);
 }
 
+export const LOADING_AGGREGATIONS = 'LOADING_AGGREGATIONS';
+function loadingAggregations() {
+    return {type: LOADING_AGGREGATIONS};
+}
 /**
  * Fetch items for current query
  */
@@ -261,6 +265,7 @@ export function fetchItems(): AgendaThunkAction {
     return (dispatch, getState) => {
         const start = Date.now();
         dispatch(queryItems());
+        dispatch(loadingAggregations());
         return search(getState(), 0)
             .then((data) => {
                 dispatch(recieveItems(data));

--- a/assets/agenda/reducers.ts
+++ b/assets/agenda/reducers.ts
@@ -23,6 +23,7 @@ import {
     STOP_WATCHING_COVERAGE,
     SET_ERROR,
     RECIEVE_NEXT_ITEMS,
+    LOADING_AGGREGATIONS,
 } from './actions';
 
 import {EXTENDED_VIEW} from 'wire/defaults';
@@ -104,6 +105,7 @@ function recieveItems(state: IAgendaState, data: IRestApiResponse<IAgendaItem>):
         aggregations: data._aggregations || undefined,
         newItems: [],
         searchInitiated: false,
+        loadingAggregations: false,
     };
 }
 
@@ -345,6 +347,9 @@ export default function agendaReducer(state: IAgendaState = initialState, action
             isLoading: false,
             errors: action.errors};
     }
+    case LOADING_AGGREGATIONS:
+        return {...state, loadingAggregations: true};
+
     default:
         return runDefaultReducer(state, action);
     }

--- a/assets/interfaces/agenda.ts
+++ b/assets/interfaces/agenda.ts
@@ -201,6 +201,7 @@ export interface IAgendaState {
         }>;
     };
     errors?: {[field: string]: Array<string>};
+    loadingAggregations?: boolean;
 }
 
 export type AgendaGetState = () => IAgendaState;


### PR DESCRIPTION
in the agenda section's side filter panel is not fully functional due to a missing Loading Aggregations state;

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
