### PR TITLE
make sure there is just 1 worker sending notifications for a single item

### DIFF
--- a/newsroom/celery_app.py
+++ b/newsroom/celery_app.py
@@ -33,6 +33,7 @@ from superdesk.celery_app import (  # noqa
 )
 
 import newsroom
+from newsroom.errors import LockedError
 
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,8 @@ class AppContextTask(TaskBase):  # type: ignore
         with newsroom.flask_app.app_context():
             try:
                 return super().__call__(*args, **kwargs)
+            except LockedError as e:  # workaround to skip with block body without error logged
+                logger.debug("Lock conflict on %s", e)
             except Exception as e:
                 logger.warning("Error when calling task %s", self.name)
                 handle_exception(e)

--- a/newsroom/errors.py
+++ b/newsroom/errors.py
@@ -1,0 +1,2 @@
+class LockedError(RuntimeError):
+    pass


### PR DESCRIPTION
not sure this could actually happen due to redis or so,
but shouldn't hurt in general and I'm running out of ideas

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
