### PR TITLE
remove top level jasmine-core dependency

### DIFF
--- a/assets/search/tests/actions.spec.ts
+++ b/assets/search/tests/actions.spec.ts
@@ -10,6 +10,11 @@ describe('search actions', () => {
     let store: any;
     let params: any;
 
+    const resetWindowLocation = () => {
+        history.replaceState({}, '', '?');
+        expect(window.location.search).toBe('');
+    };
+
     const updateParams = (search?: any) => {
         params = {
             state: store.getState(),
@@ -18,7 +23,7 @@ describe('search actions', () => {
     };
 
     beforeEach(() => {
-        (history as any).pushState({}, null, ''); // reset window.location.search
+        resetWindowLocation();
         store = createStore(wireReducer, applyMiddleware(thunk));
         updateParams('');
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5150,6 +5150,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       }
@@ -7215,6 +7216,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -7765,15 +7767,6 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         }
-      }
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "jasmine-core": {
@@ -8987,15 +8980,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "file-loader": "^6.2.0",
     "firebase": "^9.6.11",
     "html-webpack-plugin": "^5.6.0",
-    "isomorphic-fetch": "^2.2.1",
     "karma": "^6.4.2",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "firebase": "^9.6.11",
     "html-webpack-plugin": "^5.6.0",
     "isomorphic-fetch": "^2.2.1",
-    "jasmine-core": "3.3.0",
     "karma": "^6.4.2",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^2.0.0",


### PR DESCRIPTION
it's required via karma-jasmine

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments
