### PR TITLE
Fix: when filter 'planned' coverage status, 'completed' coverages also show up in the results [CPCN-652]

### DIFF
--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -545,6 +545,13 @@ def _filter_terms(filters, item_type):
                         query={"exists": {"field": "coverages.delivery_id"}},
                     )
                 )
+                must_not_term_filters.append(
+                    nested_query(
+                        path="coverages",
+                        query={"terms": {"coverages.workflow_status": ["completed"]}},
+                        name="workflow_status",
+                    )
+                )
             elif val == ["may be"]:
                 must_term_filters.append(
                     nested_query(
@@ -569,12 +576,24 @@ def _filter_terms(filters, item_type):
                     )
                 )
             elif val == ["completed"]:
-                must_term_filters.append(
+                should_term_filters = []
+                # Check if "delivery_id" is present
+                should_term_filters.append(
                     nested_query(
                         path="coverages",
                         query={"exists": {"field": "coverages.delivery_id"}},
                     )
                 )
+
+                # If "delivery_id" is not present, check "workflow_status"
+                should_term_filters.append(
+                    nested_query(
+                        path="coverages",
+                        query={"terms": {"coverages.workflow_status": ["completed"]}},
+                        name="workflow_status",
+                    )
+                )
+                must_term_filters.append({"bool": {"should": should_term_filters}})
             elif val == ["not intended"]:
                 must_term_filters.append(
                     nested_query(

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -616,6 +616,27 @@ def test_filter_agenda_by_coverage_status(client):
                 "qcode": "ncostat:notdec",
             },
         },
+        {
+            "planning": {
+                "g2_content_type": "audio",
+                "slugline": "Vivid planning item",
+                "scheduled": "2018-05-28T10:51:52+0000",
+            },
+            "news_coverage_status": {
+                "name": "coverage intended",
+                "label": "Planned",
+                "qcode": "ncostat:int",
+            },
+            "workflow_status": "completed",
+            "firstcreated": "2018-05-28T10:55:00+0000",
+            "coverage_id": "placeholder_urn:newsml:stt.fi:20230529:620123",
+            "deliveries": [
+                {
+                    "publish_time": "2018-05-30T10:55:00+0000",
+                    "delivery_state": "published",
+                }
+            ],
+        },
     )
     client.post("/push", data=json.dumps(test_planning), content_type="application/json")
 
@@ -634,6 +655,10 @@ def test_filter_agenda_by_coverage_status(client):
     data = get_json(client, '/agenda/search?filter={"coverage_status":["not planned"]}')
     assert 1 == data["_meta"]["total"]
     assert "baz" == data["_items"][0]["_id"]
+
+    data = get_json(client, '/agenda/search?filter={"coverage_status":["completed"]}')
+    assert 1 == data["_meta"]["total"]
+    assert "123foo" == data["_items"][0]["_id"]
 
 
 def test_filter_events_only(client):


### PR DESCRIPTION
Only `text` coverages include `delivery_id`. That is why in the `Planned` filter, we are seeing coverages with `workflow status` being `completed` and not having `delivery_id`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
