### PR TITLE
fix search on event metadata together with coverages filter

### DIFF
--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -766,7 +766,8 @@ export function groupItems(
         .filter((item) => (
             (item.planning_items?.length ?? 0) === 0 ||
             item._hits?.matched_planning_items == null ||
-            item._hits?.matched_planning_items.length > 0
+            item._hits?.matched_planning_items.length > 0 ||
+            item._hits?.matched_coverages?.length
         ))
         .forEach((item) => {
             const itemExtraDates = getExtraDates(item);


### PR DESCRIPTION
there are no planning items matching only coverages

CPCN-671

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
