### PR TITLE
Bring back the code to show all images added to the media gallery field 'one below each other' [NHUB-499]

### DIFF
--- a/assets/wire/components/ItemDetails.tsx
+++ b/assets/wire/components/ItemDetails.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import PreviewMeta from './PreviewMeta';
 import PreviewTags from './PreviewTags';
 import AgendaLinks from './AgendaLinks';
-import {isDisplayed, gettext, formatDate, formatTime, getConfig} from 'utils';
+import {isDisplayed, gettext, formatDate, formatTime} from 'utils';
 import ListItemPreviousVersions from './ListItemPreviousVersions';
 import ListItemNextVersion from './ListItemNextVersion';
 import {
@@ -12,10 +12,7 @@ import {
     isKilled,
     DISPLAY_ABSTRACT,
     isPreformatted,
-    isCustomRendition,
     getFeatureMedia,
-    getMediaGalleryPictureList,
-    notNullOrUndefined,
     getGalleryMedia,
 } from 'wire/utils';
 import types from 'wire/types';

--- a/assets/wire/components/ItemDetails.tsx
+++ b/assets/wire/components/ItemDetails.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import PreviewMeta from './PreviewMeta';
 import PreviewTags from './PreviewTags';
 import AgendaLinks from './AgendaLinks';
-import {isDisplayed, gettext, formatDate, formatTime} from 'utils';
+import {isDisplayed, gettext, formatDate, formatTime, getConfig} from 'utils';
 import ListItemPreviousVersions from './ListItemPreviousVersions';
 import ListItemNextVersion from './ListItemNextVersion';
 import {
@@ -16,6 +16,7 @@ import {
     getFeatureMedia,
     getMediaGalleryPictureList,
     notNullOrUndefined,
+    getGalleryMedia,
 } from 'wire/utils';
 import types from 'wire/types';
 import Content from 'ui/components/Content';
@@ -23,7 +24,6 @@ import ContentHeader from 'ui/components/ContentHeader';
 import ContentBar from 'ui/components/ContentBar';
 import ArticleItemDetails from 'ui/components/ArticleItemDetails';
 import ArticleContent from 'ui/components/ArticleContent';
-import ArticlePicture from 'ui/components/ArticlePicture';
 import ArticleMedia from  'ui/components/ArticleMedia';
 import ArticleContentWrapper from 'ui/components/ArticleContentWrapper';
 import ArticleContentInfoWrapper from 'ui/components/ArticleContentInfoWrapper';
@@ -38,7 +38,7 @@ import WireActionButtons from './WireActionButtons';
 import {Authors} from './fields/Authors';
 import {Carousel} from '@superdesk/common';
 import {IArticle} from 'interfaces';
-
+import MediaPreview from './MediaPreview';
 interface IProps {
     item: IArticle;
     user: any;
@@ -66,19 +66,21 @@ function ItemDetails({
     const featureMedia = getFeatureMedia(item);
     const media = getOtherMedia(item);
     const itemType = isPreformatted(item) ? 'preformatted' : 'text';
-    const carousels = getMediaGalleryPictureList(item);
-    const imagesArray: Array<Array<{src: string}>> = carousels
-        .map((carousel) => {
-            return carousel.items.map((picture) => {
-                const imageHref = Object.values(item.associations ?? {}).find((association) => association?.guid === picture.guid);
+    const galleryMedia = getGalleryMedia(item);
 
-                if (imageHref?.renditions?.viewImage?.href == null) {
-                    return null;
-                } else {
-                    return {src: imageHref.renditions.viewImage.href};
-                }
-            }).filter(notNullOrUndefined);
-        });
+    // const carousels = getMediaGalleryPictureList(item);
+    // const imagesArray: Array<Array<{src: string}>> = carousels
+    //     .map((carousel) => {
+    //         return carousel.items.map((picture) => {
+    //             const imageHref = Object.values(item.associations ?? {}).find((association) => association?.guid === picture.guid);
+
+    //             if (imageHref?.renditions?.viewImage?.href == null) {
+    //                 return null;
+    //             } else {
+    //                 return {src: imageHref.renditions.viewImage.href};
+    //             }
+    //         }).filter(notNullOrUndefined);
+    //     });
 
     return (
         <Content type="item-detail">
@@ -95,28 +97,31 @@ function ItemDetails({
             </ContentHeader>
             <ArticleItemDetails disableTextSelection={detailsConfig.disable_text_selection}>
                 <ArticleContent>
-                    {
+                    {/* {
                         isDisplayed('gallery', detailsConfig) && (imagesArray.length > 0) && imagesArray.map((images) => (
                             <Carousel
                                 key={images[0].src}
                                 images={images}
                             />
                         ))
-                    }
-                    {featureMedia != null && (
-                        featureMedia.type === 'picture' ? (
-                            <ArticlePicture
-                                picture={featureMedia}
-                                isKilled={isKilled(item)}
-                                isCustomRendition={isCustomRendition(featureMedia)}
-                            />
-                        ) : (
-                            <ArticleMedia
-                                media={featureMedia}
-                                isKilled={isKilled(item)}
-                                download={downloadMedia}
-                            />
-                        )
+                    } */}
+                    {featureMedia && (
+                        <MediaPreview
+                            media={featureMedia}
+                            item={item}
+                            download={downloadMedia}
+                        />
+                    )}
+                    {galleryMedia && (
+                        galleryMedia
+                            .map((data) => (
+                                <MediaPreview
+                                    key={data?.guid}
+                                    media={data}
+                                    item={item}
+                                    download={downloadMedia}
+                                />
+                            ))
                     )}
                     <ArticleContentWrapper itemType={itemType}>
                         <ArticleBody itemType={itemType}>

--- a/assets/wire/components/ItemDetails.tsx
+++ b/assets/wire/components/ItemDetails.tsx
@@ -33,7 +33,6 @@ import ArticleEmbargoed from 'ui/components/ArticleEmbargoed';
 import PreviewEdnote from './PreviewEdnote';
 import WireActionButtons from './WireActionButtons';
 import {Authors} from './fields/Authors';
-import {Carousel} from '@superdesk/common';
 import {IArticle} from 'interfaces';
 import MediaPreview from './MediaPreview';
 interface IProps {
@@ -64,21 +63,6 @@ function ItemDetails({
     const media = getOtherMedia(item);
     const itemType = isPreformatted(item) ? 'preformatted' : 'text';
     const galleryMedia = getGalleryMedia(item);
-
-    // const carousels = getMediaGalleryPictureList(item);
-    // const imagesArray: Array<Array<{src: string}>> = carousels
-    //     .map((carousel) => {
-    //         return carousel.items.map((picture) => {
-    //             const imageHref = Object.values(item.associations ?? {}).find((association) => association?.guid === picture.guid);
-
-    //             if (imageHref?.renditions?.viewImage?.href == null) {
-    //                 return null;
-    //             } else {
-    //                 return {src: imageHref.renditions.viewImage.href};
-    //             }
-    //         }).filter(notNullOrUndefined);
-    //     });
-
     return (
         <Content type="item-detail">
             <ContentHeader>
@@ -94,14 +78,6 @@ function ItemDetails({
             </ContentHeader>
             <ArticleItemDetails disableTextSelection={detailsConfig.disable_text_selection}>
                 <ArticleContent>
-                    {/* {
-                        isDisplayed('gallery', detailsConfig) && (imagesArray.length > 0) && imagesArray.map((images) => (
-                            <Carousel
-                                key={images[0].src}
-                                images={images}
-                            />
-                        ))
-                    } */}
                     {featureMedia && (
                         <MediaPreview
                             media={featureMedia}

--- a/assets/wire/components/MediaPreview.tsx
+++ b/assets/wire/components/MediaPreview.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import ArticlePicture from 'ui/components/ArticlePicture';
+import ArticleMedia from 'ui/components/ArticleMedia';
+import {isCustomRendition, isKilled} from 'wire/utils';
+import {IArticle} from 'interfaces';
+
+interface IProps {
+    media: IArticle;
+    item: IArticle;
+    download: () => void;
+}
+
+export default function MediaPreview({media, item, download}: IProps) {
+    const key = media?.guid || '';
+    if (media?.type === 'picture') {
+        return (
+            <ArticlePicture
+                key={key}
+                picture={media}
+                isKilled={isKilled(item)}
+                isCustomRendition={isCustomRendition(media)}
+            />
+        );
+    }
+
+    return (
+        <ArticleMedia
+            key={key}
+            media={media}
+            isKilled={isKilled(item)}
+            download={download}
+        />
+    );
+}

--- a/assets/wire/components/WirePreview.tsx
+++ b/assets/wire/components/WirePreview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import {isDisplayed} from 'utils';
+import {getConfig, isDisplayed} from 'utils';
 import {
     getFeatureMedia,
     getOtherMedia,
@@ -11,6 +11,7 @@ import {
     isKilled,
     DISPLAY_ABSTRACT,
     isCustomRendition,
+    getGalleryMedia,
 } from 'wire/utils';
 import types from 'wire/types';
 
@@ -32,6 +33,7 @@ import AgendaLinks from './AgendaLinks';
 import PreviewEdnote from './PreviewEdnote';
 import WireActionButtons from './WireActionButtons';
 import {Authors} from './fields/Authors';
+import MediaPreview from './MediaPreview';
 
 class WirePreview extends React.PureComponent<any, any> {
     static propTypes: any;
@@ -50,6 +52,7 @@ class WirePreview extends React.PureComponent<any, any> {
         const {item, user, actions, followStory, topics, previewConfig, downloadMedia, listConfig, filterGroupLabels} = this.props;
         const featureMedia = getFeatureMedia(item);
         const media = getOtherMedia(item);
+        const galleryMedia = getGalleryMedia(item);
         const previousVersions = 'preview_versions';
 
         return (
@@ -77,20 +80,23 @@ class WirePreview extends React.PureComponent<any, any> {
                     {isDisplayed('headline', previewConfig) && <ArticleHeadline item={item}/>}
                     {(isDisplayed('byline', previewConfig) || isDisplayed('located', previewConfig)) &&
                         <ArticleAuthor item={item} displayConfig={previewConfig} />}
-                    {featureMedia == null ? null : (
-                        featureMedia.type === 'picture' ? (
-                            <ArticlePicture
-                                picture={featureMedia}
-                                isKilled={isKilled(item)}
-                                isCustomRendition={isCustomRendition(featureMedia)}
-                            />
-                        ) : (
-                            <ArticleMedia
-                                media={featureMedia}
-                                isKilled={isKilled(item)}
-                                download={downloadMedia}
-                            />
-                        )
+                    {featureMedia && (
+                        <MediaPreview
+                            media={featureMedia}
+                            item={item}
+                            download={downloadMedia}
+                        />
+                    )}
+                    {galleryMedia && (
+                        galleryMedia
+                            .map((data) => (
+                                <MediaPreview
+                                    key={data.guid}
+                                    media={data}
+                                    item={item}
+                                    download={downloadMedia}
+                                />
+                            ))
                     )}
                     {isDisplayed('metadata_section', previewConfig) &&
                     <PreviewMeta item={item} isItemDetail={false} inputRef={previousVersions} displayConfig={previewConfig} listConfig={listConfig}

--- a/assets/wire/components/WirePreview.tsx
+++ b/assets/wire/components/WirePreview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import {getConfig, isDisplayed} from 'utils';
+import {isDisplayed} from 'utils';
 import {
     getFeatureMedia,
     getOtherMedia,
@@ -10,7 +10,6 @@ import {
     isEqualItem,
     isKilled,
     DISPLAY_ABSTRACT,
-    isCustomRendition,
     getGalleryMedia,
 } from 'wire/utils';
 import types from 'wire/types';
@@ -18,7 +17,6 @@ import types from 'wire/types';
 import Preview from 'ui/components/Preview';
 import ArticleSlugline from 'ui/components/ArticleSlugline';
 import ArticleAuthor from  'ui/components/ArticleAuthor';
-import ArticlePicture from  'ui/components/ArticlePicture';
 import ArticleMedia from  'ui/components/ArticleMedia';
 import ArticleHeadline from 'ui/components/ArticleHeadline';
 import ArticleAbstract from 'ui/components/ArticleAbstract';

--- a/assets/wire/utils.ts
+++ b/assets/wire/utils.ts
@@ -115,10 +115,35 @@ export function getMediaGalleryPictureList(item: IArticle) {
         .filter((value) => value?.type === 'media');
 }
 
-export function getPictureList(item: IArticle): Array<IArticle> {
+export function getPictureList(item: IArticle, {includeFeatured = false, includeEditor = false} = {}): IArticle[] {
     const pictures = Object.values(item.associations ?? {})
         .filter((association) => association?.type === 'picture') as IArticle[];
-    return pictures.length ? pictures : [];
+
+    let filteredPictures = pictures;
+
+    if (!includeFeatured) {
+        const featureMedia = getFeatureMedia(item);
+        filteredPictures = featureMedia ? filteredPictures.filter((mediaItem) => mediaItem.guid !== featureMedia.guid) : filteredPictures;
+    }
+
+    if (!includeEditor) {
+        const bodyMedia = getBodyPictureList(item);
+        filteredPictures = filteredPictures.filter((mediaItem) => bodyMedia.includes(mediaItem));
+    }
+
+    return filteredPictures;
+}
+
+export function getBodyPictureList(item: IArticle): Array<IArticle> {
+    return Object.entries(item.associations || {})
+        .filter(([key, item]) => (
+            !key.startsWith('editor_')))
+        .map(([key, item]) => item) as IArticle[];
+
+}
+
+export function getGalleryMedia(item: IArticle): IArticle[] {
+    return getPictureList(item, {includeFeatured: false, includeEditor: false});
 }
 
 /**
@@ -140,13 +165,20 @@ export function notNullOrUndefined<T>(x: null | undefined | T): x is T {
 
 export function getImageForList(item: IArticle): {item: IArticle, href: string} | undefined {
     const pictures = getPictureList(item);
+    const feature = getFeatureMedia(item);
     let thumbnail: IRendition | undefined;
 
-    for (let i = 0; i < pictures.length; i++) {
-        thumbnail = getThumbnailRendition(pictures[i]);
-
+    if (feature) {
+        thumbnail = getThumbnailRendition(feature);
         if (thumbnail != null && thumbnail.href != null) {
-            return {item: pictures[i], href: thumbnail.href};
+            return {item: feature, href: thumbnail.href};
+        }
+    } else {
+        for (let i = 0; i < pictures.length; i++) {
+            thumbnail = getThumbnailRendition(pictures[i]);
+            if (thumbnail != null && thumbnail.href != null) {
+                return {item: pictures[i], href: thumbnail.href};
+            }
         }
     }
 


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
