### PR TITLE
If updates to Planning items are pushed to NH they should be visible in the Agenda list views immediately [NHUB-494]

### DIFF
--- a/assets/agenda/components/AgendaListItemIcons.tsx
+++ b/assets/agenda/components/AgendaListItemIcons.tsx
@@ -94,7 +94,7 @@ class AgendaListItemIcons extends React.Component<IProps, IState> {
 
     render() {
         const props = this.props;
-        const state = this.state;
+        const state = this.getUpdatedState();
         const className = bem('wire-articles', 'item__meta', {row: props.row});
         const subject = this.getItemByschema(props);
 

--- a/assets/agenda/components/AgendaListItemIcons.tsx
+++ b/assets/agenda/components/AgendaListItemIcons.tsx
@@ -52,10 +52,6 @@ class AgendaListItemIcons extends React.Component<IProps, IState> {
             !isEqual(this.props.item.coverages, nextProps.item.coverages);
     }
 
-    shouldComponentUpdate(props: Readonly<IProps>) {
-        return this.itemChanged(props);
-    }
-
     componentDidUpdate(prevProps: Readonly<IProps>) {
         if (this.itemChanged(prevProps)) {
             this.setState(this.getUpdatedState());
@@ -94,7 +90,7 @@ class AgendaListItemIcons extends React.Component<IProps, IState> {
 
     render() {
         const props = this.props;
-        const state = this.getUpdatedState();
+        const state = this.state;
         const className = bem('wire-articles', 'item__meta', {row: props.row});
         const subject = this.getItemByschema(props);
 


### PR DESCRIPTION


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
