### PR TITLE
avoid auto logout on localhost

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -248,6 +248,9 @@ NEWS_ONLY_FILTERS = [
     {"match": {"source": "PMF"}},
 ]
 
+# avoid conflict with superdesk
+SESSION_COOKIE_NAME = "newsroom_session"
+
 # the lifetime of a permanent session in seconds
 PERMANENT_SESSION_LIFETIME = 604800  # 7 days
 


### PR DESCRIPTION
when running both newsroom and superdesk. both were using same default session cookie name and one would override the other.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
