### PR TITLE
[TGA-86] fix: Only update user sections if they were changed

### DIFF
--- a/assets/users/actions.js
+++ b/assets/users/actions.js
@@ -119,10 +119,12 @@ export function postUser() {
         const user = cloneDeep(getState().userToEdit);
         const url = `/users/${user._id ? user._id : 'new'}`;
 
-        if (user.sections != null) {
+        if (Object.keys(user.sections || {}).length > 0) {
             user.sections = Object.keys(user.sections)
                 .filter((sectionId) => user.sections[sectionId] === true)
                 .join(',');
+        } else {
+            delete user.sections;
         }
         if (user.products != null) {
             user.products = user.products

--- a/assets/users/components/EditUser.jsx
+++ b/assets/users/components/EditUser.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {get} from 'lodash';
 
 import TextInput from 'components/TextInput';
 import SelectInput from 'components/SelectInput';
@@ -50,8 +49,13 @@ function EditUserComponent({
     const companySectionIds = sections.map((section) => section._id);
     const isAdmin = isUserAdmin(currentUser);
     const isCompanyAdmin = isUserCompanyAdmin(currentUser);
-
     let company = companies.map((value)=> value.name);
+
+    // If `user.sections` has value(s) then we use that dictionary, otherwise we will use `company.sections`
+    // This is the same logic as applied on the server side
+    const userSections = Object.keys(user.sections || {}).length > 0 ?
+        user.sections :
+        (companies.find((company) => company._id === companyId) || {}).sections || {};
 
     return (
         <div
@@ -199,7 +203,7 @@ function EditUserComponent({
                                             <CheckboxInput
                                                 name={`sections.${section._id}`}
                                                 label={section.name}
-                                                value={get(user, `sections.${section._id}`) === true}
+                                                value={userSections[section._id] === true}
                                                 onChange={onChange}
                                             />
                                         </div>
@@ -215,7 +219,7 @@ function EditUserComponent({
                             >
                                 {sections.filter((section) => (
                                     companySectionIds.includes(section._id) &&
-                                    get(user, `sections.${section._id}`) === true
+                                    userSections[section._id] === true
                                 )).map((section) => (
                                     <React.Fragment key={section._id}>
                                         <div className="list-item__preview-subheading">

--- a/assets/users/reducers.js
+++ b/assets/users/reducers.js
@@ -81,10 +81,19 @@ export default function userReducer(state = initialState, action) {
         let user = {...state.userToEdit};
         const value = target.type === 'checkbox' ? target.checked : target.value;
 
-        if (field.startsWith('sections.')) {
+        if (field === 'company') {
+            if ((value || '').length > 0) {
+                user.sections = {}; // Defaults to use `company.sections` for permissions
+                user.company = value;
+            } else {
+                user.company = null;
+            }
+        } else if (field.startsWith('sections.')) {
             const sectionId = field.replace('sections.', '');
+            const company = state.companies.find((company) => company._id === user.company);
 
             user.sections = {
+                ...company != null ? company.sections || {} : {},
                 ...user.sections || {},
                 [sectionId]: value,
             };

--- a/e2e/cypress/e2e/company_admin/company_settings.cy.js
+++ b/e2e/cypress/e2e/company_admin/company_settings.cy.js
@@ -94,17 +94,15 @@ describe('CompanySettings', function() {
             EditUserForm.type({company: companyId});
         });
 
-        // Make sure Wire section is available, and defaulted to false
-        EditUserForm.expectSections({wire: false});
+        // Make sure Wire section is available, and defaulted to true
+        EditUserForm.expectSections({wire: true});
         EditUserForm.expectSectionsMissing(['agenda']);
+        EditUserForm.expectProducts({wire: {[PRODUCTS.wire.sports._id]: false}});
         EditUserForm.expectProductsMissing({
-            wire: [PRODUCTS.wire.all._id, PRODUCTS.wire.sports._id],
+            wire: [PRODUCTS.wire.all._id],
             agenda: [PRODUCTS.agenda.sports._id],
         });
 
-        // Enable Wire section for this User
-        EditUserForm.typeSections({wire: true});
-        EditUserForm.expectProducts({wire: {[PRODUCTS.wire.sports._id]: false}});
         EditUserForm.typeProducts({wire: {[PRODUCTS.wire.sports._id]: true}});
         EditUserForm.expectProductsMissing({
             wire: [PRODUCTS.wire.all._id],
@@ -134,5 +132,168 @@ describe('CompanySettings', function() {
             wire: [PRODUCTS.wire.all._id],
             agenda: [PRODUCTS.agenda.sports._id],
         });
+    });
+
+    it('TGA-86: User section permissions are not lost when saving other metadata', function() {
+        // Login and navigate to Company settings page
+        NewshubLayout.login('admin@nistrator.org', 'admin');
+        NewshubLayout.getSidebarLink('settings').click();
+        SettingsNav.getNavLink('companies').click();
+
+        // Create a new Company
+        CompanySettingsPage.getNewCompanyButton().click();
+        EditCompanyForm.type({name: 'My New Company'});
+        EditCompanyForm.save(true);
+
+        // Open the newly created Company, and set permissions
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({
+            wire: true,
+            agenda: true,
+        });
+        EditCompanyForm.permissions.toggleProducts({
+            [PRODUCTS.wire.sports._id]: true,
+            [PRODUCTS.agenda.sports._id]: true,
+        });
+        EditCompanyForm.save();
+
+        // Navigate to the Users page and create a new user (assigned to newly created Company)
+        SettingsNav.getNavLink('users').click();
+        UserSettingsPage.getNewUserButton().click();
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.type({
+            first_name: 'Null',
+            last_name: 'Abore',
+            email: 'nullabore@bar.org',
+        });
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            EditUserForm.type({company: companyId});
+        });
+
+        // Make sure permissions are correct, and save
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+        EditUserForm.save(true);
+
+        // Make changes other than permissions to the user, and save
+        cy.reload();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.type({role: 'Tester'});
+        EditUserForm.save();
+
+        // Make sure this user has not lost their section permissions
+        cy.reload();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+    });
+
+    it('Section permissions use parent Company until changed on the user level', function() {
+        // Login and navigate to Company settings page
+        NewshubLayout.login('admin@nistrator.org', 'admin');
+        NewshubLayout.getSidebarLink('settings').click();
+        SettingsNav.getNavLink('companies').click();
+
+        // Create a new Company
+        CompanySettingsPage.getNewCompanyButton().click();
+        EditCompanyForm.type({name: 'My New Company'});
+        EditCompanyForm.save(true);
+
+        // Open the newly created Company, and test its metadata is correct
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+
+        // Change to Permissions tab, and test toggling permissions
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({
+            wire: true,
+            agenda: true,
+        });
+        EditCompanyForm.permissions.toggleProducts({
+            [PRODUCTS.wire.sports._id]: true,
+            [PRODUCTS.agenda.sports._id]: true,
+        });
+        EditCompanyForm.save();
+
+        // Navigate to the Users page and create a new user (assigned to newly created Company)
+        SettingsNav.getNavLink('users').click();
+        UserSettingsPage.getNewUserButton().click();
+        EditUserForm.openAllToggleBoxes();
+
+        EditUserForm.type({
+            first_name: 'Null',
+            last_name: 'Abore',
+            email: 'nullabore@bar.org',
+        });
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            EditUserForm.type({company: companyId});
+        });
+
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+        EditUserForm.save(true);
+
+        // Check the user has the correct permissions
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+
+        // Navigate back to the Company page and disable the Agenda section
+        SettingsNav.getNavLink('companies').click();
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({agenda: false});
+        EditCompanyForm.save();
+
+        // Navigate back to the users page and make sure Agenda is not shown
+        SettingsNav.getNavLink('users').click();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSectionsMissing(['agenda']);
+
+        // Navigate back to the Company page and re-enable the Agenda section
+        SettingsNav.getNavLink('companies').click();
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({agenda: true});
+        EditCompanyForm.save();
+
+        // Navigate back to the users page and make sure Agenda is shown again, and enabled
+        SettingsNav.getNavLink('users').click();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSections({wire: true, agenda: true});
     });
 });

--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -108,7 +108,9 @@ class CompaniesService(newsroom.Service):
             user_service = get_resource_service("users")
             for user in user_service.get(req=None, lookup={"company": original[config.ID_FIELD]}):
                 user_updates = {
-                    "sections": {
+                    "sections": {}
+                    if not user.get("sections")
+                    else {
                         section: (user.get("sections") or {}).get(section, False) for section in updated_section_names
                     },
                     "products": [

--- a/newsroom/users/forms.py
+++ b/newsroom/users/forms.py
@@ -16,12 +16,13 @@ class CommaSeparatedListField(Field):
             return ""
 
     def process_formdata(self, valuelist):
-        if len(valuelist) == 1 and not len(valuelist[0]):
+        if valuelist == [""]:  # An empty string from the client is equal to an empty array
             self.data = []
-        elif valuelist:
+        elif len(valuelist):
             self.data = [x.strip() for x in valuelist[0].split(",")]
         else:
-            self.data = []
+            # No data was provided by client, store `None` so we know not to process this field
+            self.data = None
 
 
 class UserForm(FlaskForm):

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -231,10 +231,10 @@ def get_updates_from_form(form: UserForm):
     updates = form.data
     if form.company.data:
         updates["company"] = ObjectId(form.company.data)
-    if "sections" in updates:
+    if updates.get("sections") is not None:
         updates["sections"] = {section["_id"]: section["_id"] in (form.sections.data or []) for section in app.sections}
 
-    if "products" in updates:
+    if updates.get("products") is not None:
         product_ids = [ObjectId(productId) for productId in updates["products"]]
         products = {
             product["_id"]: product for product in query_resource("products", lookup={"_id": {"$in": product_ids}})


### PR DESCRIPTION
If no changes to sections were done on the front end, then keep using the company sections for permissions.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments
