### PR TITLE
fix events not visible in the agenda

### DIFF
--- a/assets/agenda/tests/utils.spec.ts
+++ b/assets/agenda/tests/utils.spec.ts
@@ -132,7 +132,7 @@ describe('utils', () => {
             const groupedItems = keyBy(utils.groupItems(items, moment('2018-10-15'), undefined, 'day'), 'date');
 
             expect(groupedItems.hasOwnProperty('15-10-2018')).toBe(false);
-            expect(groupedItems.hasOwnProperty('17-10-2018')).toBe(false);
+            expect(groupedItems.hasOwnProperty('17-10-2018')).toBe(true);
             expect(groupedItems.hasOwnProperty('16-10-2018')).toBe(true);
             expect(groupedItems.hasOwnProperty('18-10-2018')).toBe(true);
             expect(groupedItems['16-10-2018'].items).toEqual(['foo']);


### PR DESCRIPTION
always display event when it's happening and also on days when there is a coverage instead of filtering it out based on specific filtering.

CPCN-671

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
