### PR TITLE
[TGA-86] fix(2.5+): Only update user sections if they were changed

### DIFF
--- a/assets/users/actions.ts
+++ b/assets/users/actions.ts
@@ -147,10 +147,12 @@ export function postUser() {
         const user = cloneDeep(getState().userToEdit);
         const url = `/users/${user._id ? user._id : 'new'}`;
 
-        if (user.sections != null) {
+        if (Object.keys(user.sections || {}).length > 0) {
             user.sections = Object.keys(user.sections)
                 .filter((sectionId: any) => user.sections[sectionId] === true)
                 .join(',');
+        } else {
+            delete user.sections;
         }
         if (user.products != null) {
             user.products = user.products

--- a/assets/users/components/EditUser.tsx
+++ b/assets/users/components/EditUser.tsx
@@ -98,6 +98,11 @@ const EditUserComponent: React.ComponentType<IProps> = (props: IProps) => {
     const showResendInvite = (user._id == null || user.is_validated !== true) && (
         (company?.auth_provider ?? 'newshub') === 'newshub'
     );
+    // If `user.sections` has value(s) then we use that dictionary, otherwise we will use `company.sections`
+    // This is the same logic as applied on the server side
+    const userSections = Object.keys(user.sections || {}).length > 0 ?
+        user.sections :
+        company?.sections || {};
 
     const resendInviteButton = {
         name: gettext('Resend Invite'),
@@ -267,13 +272,13 @@ const EditUserComponent: React.ComponentType<IProps> = (props: IProps) => {
                                 title={gettext('Sections')}
                                 testId="toggle--sections"
                             >
-                                {sections.filter((section: any) => companySectionIds.includes(section._id)).map((section: any) => (
+                                {sections.filter((section) => companySectionIds.includes(section._id)).map((section) => (
                                     <div className="list-item__preview-row" key={section._id}>
                                         <div className="form-group">
                                             <CheckboxInput
                                                 name={`sections.${section._id}`}
                                                 label={section.name}
-                                                value={get(user, `sections.${section._id}`) === true}
+                                                value={userSections[section._id] === true}
                                                 onChange={props.onChange_DEPRECATED}
                                             />
                                         </div>
@@ -283,10 +288,8 @@ const EditUserComponent: React.ComponentType<IProps> = (props: IProps) => {
                         )}
 
                         {(userIsAdmin || hideFields.includes('products')) ? null : (() => {
-                            const filteredSections = sections.filter((section: any) => (
-                                companySectionIds.includes(section._id) && user.sections ?
-                                    get(user, `sections.${section._id}`
-                                    ) === true : company?.sections
+                            const filteredSections = sections.filter((section) => (
+                                companySectionIds.includes(section._id) && userSections[section._id] === true
                             ));
 
                             const filterProductsForSection = (product: IProduct, section: ISection) =>
@@ -336,7 +339,7 @@ const EditUserComponent: React.ComponentType<IProps> = (props: IProps) => {
                                                         </div>
                                                     )}
 
-                                                    {filteredSections.map((section: any) => (
+                                                    {filteredSections.map((section) => (
                                                         <React.Fragment key={section._id}>
                                                             <div className="list-item__preview-subheading">
                                                                 {section.name}

--- a/assets/users/reducers.ts
+++ b/assets/users/reducers.ts
@@ -1,3 +1,5 @@
+import {ICompany} from 'interfaces';
+
 import {
     INIT_VIEW_DATA,
     GET_USERS,
@@ -83,13 +85,18 @@ export default function userReducer(state: any = initialState, action: any) {
         const value = target.type === 'checkbox' ? target.checked : target.value;
 
         if (action.event?.changeType === 'company') {
-            const newCompanySelected = state.companies.find(({_id}: any) => value === _id);
-            user.company = newCompanySelected?._id;
-            user.sections = newCompanySelected?.sections;
+            if ((value || '').length > 0) {
+                user.sections = {}; // Defaults to use `company.sections` for permissions
+                user.company = value;
+            } else {
+                user.company = null;
+            }
         } else if (field.startsWith('sections.')) {
             const sectionId = field.replace('sections.', '');
+            const company = state.companies.find((company: ICompany) => company._id === user.company);
 
             user.sections = {
+                ...company?.sections || {},
                 ...user.sections || {},
                 [sectionId]: value,
             };

--- a/e2e/cypress/e2e/company_admin/company_settings.cy.js
+++ b/e2e/cypress/e2e/company_admin/company_settings.cy.js
@@ -94,7 +94,8 @@ describe('CompanySettings', function() {
             EditUserForm.type({company: companyId});
         });
 
-        // Make sure Wire section is available, and defaulted to false
+        // Make sure Wire section is available, and defaulted to true
+        EditUserForm.expectSections({wire: true});
         EditUserForm.expectSectionsMissing(['agenda']);
 
         // Enable Wire section for this User
@@ -127,5 +128,168 @@ describe('CompanySettings', function() {
             wire: [PRODUCTS.wire.all._id],
             agenda: [PRODUCTS.agenda.sports._id],
         });
+    });
+
+    it('TGA-86: User section permissions are not lost when saving other metadata', function() {
+        // Login and navigate to Company settings page
+        NewshubLayout.login('admin@nistrator.org', 'admin');
+        NewshubLayout.getSidebarLink('settings').click();
+        SettingsNav.getNavLink('companies').click();
+
+        // Create a new Company
+        CompanySettingsPage.getNewCompanyButton().click();
+        EditCompanyForm.type({name: 'My New Company'});
+        EditCompanyForm.save(true);
+
+        // Open the newly created Company, and set permissions
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({
+            wire: true,
+            agenda: true,
+        });
+        EditCompanyForm.permissions.toggleProducts({
+            [PRODUCTS.wire.sports._id]: true,
+            [PRODUCTS.agenda.sports._id]: true,
+        });
+        EditCompanyForm.save();
+
+        // Navigate to the Users page and create a new user (assigned to newly created Company)
+        SettingsNav.getNavLink('users').click();
+        UserSettingsPage.getNewUserButton().click();
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.type({
+            first_name: 'Null',
+            last_name: 'Abore',
+            email: 'nullabore@bar.org',
+        });
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            EditUserForm.type({company: companyId});
+        });
+
+        // Make sure permissions are correct, and save
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+        EditUserForm.save(true);
+
+        // Make changes other than permissions to the user, and save
+        cy.reload();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.type({role: 'Tester'});
+        EditUserForm.save();
+
+        // Make sure this user has not lost their section permissions
+        cy.reload();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+    });
+
+    it('Section permissions use parent Company until changed on the user level', function() {
+        // Login and navigate to Company settings page
+        NewshubLayout.login('admin@nistrator.org', 'admin');
+        NewshubLayout.getSidebarLink('settings').click();
+        SettingsNav.getNavLink('companies').click();
+
+        // Create a new Company
+        CompanySettingsPage.getNewCompanyButton().click();
+        EditCompanyForm.type({name: 'My New Company'});
+        EditCompanyForm.save(true);
+
+        // Open the newly created Company, and test its metadata is correct
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+
+        // Change to Permissions tab, and test toggling permissions
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({
+            wire: true,
+            agenda: true,
+        });
+        EditCompanyForm.permissions.toggleProducts({
+            [PRODUCTS.wire.sports._id]: true,
+            [PRODUCTS.agenda.sports._id]: true,
+        });
+        EditCompanyForm.save();
+
+        // Navigate to the Users page and create a new user (assigned to newly created Company)
+        SettingsNav.getNavLink('users').click();
+        UserSettingsPage.getNewUserButton().click();
+        EditUserForm.openAllToggleBoxes();
+
+        EditUserForm.type({
+            first_name: 'Null',
+            last_name: 'Abore',
+            email: 'nullabore@bar.org',
+        });
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            EditUserForm.type({company: companyId});
+        });
+
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+        EditUserForm.save(true);
+
+        // Check the user has the correct permissions
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSections({wire: true, agenda: true});
+        EditUserForm.expectProducts({
+            wire: {[PRODUCTS.wire.sports._id]: true},
+            agenda: {[PRODUCTS.agenda.sports._id]: true},
+        });
+
+        // Navigate back to the Company page and disable the Agenda section
+        SettingsNav.getNavLink('companies').click();
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({agenda: false});
+        EditCompanyForm.save();
+
+        // Navigate back to the users page and make sure Agenda is not shown
+        SettingsNav.getNavLink('users').click();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSectionsMissing(['agenda']);
+
+        // Navigate back to the Company page and re-enable the Agenda section
+        SettingsNav.getNavLink('companies').click();
+        EditCompanyForm.getNewlyCreatedCompanyId((companyId) => {
+            CompanySettingsPage.getCompanyListItem(companyId).click();
+        });
+        EditCompanyForm.changeTab('permissions');
+        EditCompanyForm.permissions.type({agenda: true});
+        EditCompanyForm.save();
+
+        // Navigate back to the users page and make sure Agenda is shown again, and enabled
+        SettingsNav.getNavLink('users').click();
+        EditUserForm.getNewlyCreatedUserId((userId) => {
+            UserSettingsPage.getUserListItem(userId).click();
+        });
+        EditUserForm.openAllToggleBoxes();
+        EditUserForm.expectSections({wire: true, agenda: true});
     });
 });

--- a/e2e/cypress/e2e/company_admin/product_seats.cy.js
+++ b/e2e/cypress/e2e/company_admin/product_seats.cy.js
@@ -28,7 +28,7 @@ describe('CompanyAdmin - Product Seats', function () {
             .click();
 
         // Make sure the form has all the appropriate values & permissions
-        EditUserForm.openAllToggleBoxes();
+        EditUserForm.openAllToggleBoxes(false);
         EditUserForm.expect({
             first_name: USERS.foobar.monkey.first_name,
             last_name: USERS.foobar.monkey.last_name,
@@ -106,7 +106,7 @@ describe('CompanyAdmin - Product Seats', function () {
         EditUserForm
             .getFormElement()
             .should('be.visible');
-        EditUserForm.openAllToggleBoxes();
+        EditUserForm.openAllToggleBoxes(false);
         expectUpdatedUser();
 
         // Reload the page, re-open it, and make sure the form has all the appropriate values & permissions
@@ -115,7 +115,7 @@ describe('CompanyAdmin - Product Seats', function () {
         CompanyAdminPage
             .getUserListItem(USERS.foobar.monkey._id)
             .click();
-        EditUserForm.openAllToggleBoxes();
+        EditUserForm.openAllToggleBoxes(false);
         expectUpdatedUser();
     });
 
@@ -131,7 +131,7 @@ describe('CompanyAdmin - Product Seats', function () {
             .click();
 
         // Make sure the form has all the appropriate values & permissions
-        EditUserForm.openAllToggleBoxes();
+        EditUserForm.openAllToggleBoxes(false);
         EditUserForm.expectProducts({
             wire: {
                 [PRODUCTS.wire.all._id]: false,
@@ -180,7 +180,7 @@ describe('CompanyAdmin - Product Seats', function () {
         EditUserForm
             .getFormElement()
             .should('be.visible');
-        EditUserForm.openAllToggleBoxes();
+        EditUserForm.openAllToggleBoxes(false);
         EditUserForm.expectProducts({
             wire: {
                 [PRODUCTS.wire.all._id]: false,
@@ -197,7 +197,7 @@ describe('CompanyAdmin - Product Seats', function () {
         CompanyAdminPage
             .getUserListItem(USERS.foobar.monkey._id)
             .click();
-        EditUserForm.openAllToggleBoxes();
+        EditUserForm.openAllToggleBoxes(false);
         EditUserForm.expectProducts({
             wire: {
                 [PRODUCTS.wire.all._id]: false,

--- a/e2e/cypress/support/forms/editUser.js
+++ b/e2e/cypress/support/forms/editUser.js
@@ -36,7 +36,10 @@ class EditUserFormWrapper extends BaseForm {
         cy.get('@newUserId').then(callback);
     }
 
-    openAllToggleBoxes() {
+    openAllToggleBoxes(includeSections = true) {
+        if (includeSections === true) {
+            this.getFormElement('[data-test-id="toggle--sections"]').click();
+        }
         this.getFormElement('[data-test-id="toggle--products"]').click();
         this.getFormElement('[data-test-id="toggle--user-settings"]').click();
     }

--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -125,7 +125,9 @@ class CompaniesService(newsroom.Service):
             user_service = get_resource_service("users")
             for user in user_service.get(req=None, lookup={"company": original[config.ID_FIELD]}):
                 user_updates = {
-                    "sections": {
+                    "sections": {}
+                    if not user.get("sections")
+                    else {
                         section: (user.get("sections") or {}).get(section, False) for section in updated_section_names
                     },
                     "products": [

--- a/newsroom/users/forms.py
+++ b/newsroom/users/forms.py
@@ -16,12 +16,13 @@ class CommaSeparatedListField(Field):
             return ""
 
     def process_formdata(self, valuelist):
-        if len(valuelist) == 1 and not len(valuelist[0]):
+        if valuelist == [""]:  # An empty string from the client is equal to an empty array
             self.data = []
-        elif valuelist:
+        elif len(valuelist):
             self.data = [x.strip() for x in valuelist[0].split(",")]
         else:
-            self.data = []
+            # No data was provided by client, store `None` so we know not to process this field
+            self.data = None
 
 
 BooleanField.false_values = {False, "false", "", "False"}

--- a/newsroom/users/users.py
+++ b/newsroom/users/users.py
@@ -266,14 +266,6 @@ class UsersService(newsroom.Service):
             if doc.get("password", None) and not is_hashed(doc.get("password")):
                 doc["password"] = self._get_password_hash(doc["password"])
 
-    def create(self, docs):
-        for doc in docs:
-            if "sections" not in doc and doc.get("company"):
-                company = get_company_from_user(doc)
-                if company and company.get("sections"):
-                    doc["sections"] = company.get("sections")
-        return super().create(docs)
-
     def on_created(self, docs):
         super().on_created(docs)
         for doc in docs:

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -258,12 +258,12 @@ def get_updates_from_form(form: UserForm, on_create=False):
     if "sections" in updates:
         if on_create and not updates.get("sections"):
             updates.pop("sections")  # will be populated later based on company
-        else:
+        elif updates.get("sections") is not None:
             updates["sections"] = {
                 section["_id"]: section["_id"] in (form.sections.data or []) for section in app.sections
             }
 
-    if "products" in updates:
+    if updates.get("products") is not None:
         product_ids = [ObjectId(productId) for productId in updates["products"]]
         products = {
             product["_id"]: product for product in query_resource("products", lookup={"_id": {"$in": product_ids}})

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -657,7 +657,7 @@ def test_create_user_inherit_sections(app):
     user_ids = app.data.insert("users", [{"email": "newuser@example.com", "company": company_ids[0]}])
     assert user_ids
     user = app.data.find_one("users", req=None, _id=user_ids[0])
-    assert user["sections"] == {"agenda": True, "wire": False}
+    assert user.get("sections") is None  # When sections has a `Falsy` value, the parent Company sections will be used
 
 
 def test_filter_and_sorting_user(app, client):

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -44,8 +44,7 @@ def test_return_search_for_users(client, app):
     response = client.get("/users/search?q=jo")
     assert "John" in response.get_data(as_text=True)
     user_data = response.get_json()[0]
-    assert user_data["sections"]["agenda"]
-    assert user_data["sections"]["wire"]
+    assert user_data.get("sections") is None
 
 
 def test_reset_password_token_sent_for_user_succeeds(app, client):

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -635,6 +635,7 @@ def test_check_etag_when_updating_user(client):
 
     user_data = response.get_json()[0]
     patch_data = user_data.copy()
+    patch_data["sections"] = "wire,agenda"
     patch_data["first_name"] = "Foo"
 
     response = client.post(f"/users/{user_data['_id']}", data=patch_data, headers={"If-Match": "something random"})


### PR DESCRIPTION
Same changes as https://github.com/superdesk/newsroom-core/pull/849 but for Newshub v2.5+

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments
