### PR TITLE
fix docker-compose missing on github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: docker-compose
-        run: docker-compose -f .actions-docker-compose.yml up -d
+      - name: docker compose
+        run: docker compose -f .actions-docker-compose.yml up -d
 
       - run: |
              sudo apt-get update

--- a/scripts/ci-start-services.sh
+++ b/scripts/ci-start-services.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker-compose -f .actions-docker-compose.yml up -d
+docker compose -f .actions-docker-compose.yml up -d
 while ! curl -sfo /dev/null 'http://localhost:9200/'; do echo -n '.' && sleep .5; done
 
 cd e2e


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
