### PR TITLE
FIX : images rendered in the list view [STTNHUB-332]

### DIFF
--- a/assets/wire/tests/WireApp.spec.tsx
+++ b/assets/wire/tests/WireApp.spec.tsx
@@ -148,10 +148,10 @@ describe('shortHighlightedtext', () => {
     });
 
     it('handles the scenario when the highlight text has images', () => {
-        const html = '<p>foo <span class="es-highlight">bar &lt;img src="image1.jpg"&gt; baz</span></p>';
+        const html = 'experience.&lt;img src="img.jpg" alt="Team Vapaus" /&gt;Norion<span class="es-highlight">Nordic</span> financing bank.';
         const maxLength = 40;
         const output = shortHighlightedtext(html, maxLength);
-        expect(output).toEqual('foo <span class="es-highlight">bar &lt;img src="image1.jpg"&gt; baz</span>...');
+        expect(output).toEqual('experience. Norion <span class="es-highlight">Nordic</span> financing bank....');
     });
 });
   

--- a/assets/wire/tests/WireApp.spec.tsx
+++ b/assets/wire/tests/WireApp.spec.tsx
@@ -146,5 +146,12 @@ describe('shortHighlightedtext', () => {
         const output = shortHighlightedtext(html, maxLength);
         expect(output).toEqual('foo <span class="es-highlight">bar</span> foo <span class="es-highlight">bar</span> foo...');
     });
+
+    it('handles the scenario when the highlight text has images', () => {
+        const html = '<p>foo <span class="es-highlight">bar &lt;img src="image1.jpg"&gt; baz</span></p>';
+        const maxLength = 40;
+        const output = shortHighlightedtext(html, maxLength);
+        expect(output).toEqual('foo <span class="es-highlight">bar &lt;img src="image1.jpg"&gt; baz</span>...');
+    });
 });
   

--- a/assets/wire/utils.ts
+++ b/assets/wire/utils.ts
@@ -327,7 +327,7 @@ export function shortHighlightedtext(html: string, maxLength = 40) {
         lastNode = highlightSpan.nextSibling;
     }
     return extractedText.join(' ')
-        .replace(/<img[^>]*src="([^"]*)"[^>]*>/g, '&lt;img src="$1"&gt;')
+        .replace(/<img[^>]*src="([^"]*)"[^>]*>/g, ' ')
             + (html.length > maxLength ? '...' : ' ');
 }
 

--- a/assets/wire/utils.ts
+++ b/assets/wire/utils.ts
@@ -326,7 +326,9 @@ export function shortHighlightedtext(html: string, maxLength = 40) {
 
         lastNode = highlightSpan.nextSibling;
     }
-    return extractedText.join(' ')+(html.length > maxLength ? '...' : ' ');
+    return extractedText.join(' ')
+        .replace(/<img[^>]*src="([^"]*)"[^>]*>/g, '&lt;img src="$1"&gt;')
+            + (html.length > maxLength ? '...' : ' ');
 }
 
 /**

--- a/assets/wire/utils.ts
+++ b/assets/wire/utils.ts
@@ -289,6 +289,9 @@ function getTextFromNode(node: Node | null): string {
     if (node.nodeType === Node.TEXT_NODE) {
         const textContent = node.textContent || '';
         return textContent.trim();
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as HTMLElement;
+        return element.innerText.trim();
     }
     return '';
 }
@@ -318,7 +321,7 @@ export function shortHighlightedtext(html: string, maxLength = 40) {
             extractedText.push(textBefore);
         }
 
-        extractedText.push(highlightSpan.outerHTML);
+        extractedText.push(`<span class="es-highlight">${getTextFromNode(highlightSpan)}</span>`);
 
         if (textAfter) {
             extractedText.push(textAfter);


### PR DESCRIPTION
Fixed issue where the `shortHighlightedtext` function was unintentionally converting `&lt;` entities to `< `characters, leading to improper rendering of images in the list view.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
