### PR TITLE
fix grouping of events with no end time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: "CI"
 on:
   [push, pull_request]
 
+env:
+  TZ: "Europe/Prague"
+
 jobs:
 
   server:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,6 @@ name: "CI"
 on:
   [push, pull_request]
 
-env:
-  TZ: "Europe/Prague"
-
 jobs:
 
   server:

--- a/assets/agenda/tests/utils.spec.ts
+++ b/assets/agenda/tests/utils.spec.ts
@@ -9,6 +9,20 @@ const getGroupedItems = (items: IAgendaItem[], minDate: moment.Moment, maxDate?:
     'date'
 );
 
+const createEvent = (id: string, dates: IAgendaItem['dates']): IAgendaItem => ({
+    _id: id,
+    guid: id,
+    type: 'agenda',
+    item_type: 'event',
+    state: 'scheduled',
+    _created: '2023-11-16T04:00:00+0000',
+    _updated: '2023-11-16T04:00:00+0000',
+    versioncreated: '2023-11-16T04:00:00+0000',
+    _etag: 'etag',
+    event: {_id: id},
+    dates,
+});
+
 describe('utils', () => {
     describe('groupItems', () => {
         it('returns grouped items per day', () => {
@@ -360,43 +374,17 @@ describe('utils', () => {
     });
 
     it('groupItems restricting groups to min and max dates', () => {
-        const items: Array<IAgendaItem> = [{
-            _id: 'event1',
-            guid: 'event1',
-            type: 'agenda',
-            item_type: 'event',
-            state: 'scheduled',
-            _created: '2023-11-16T04:00:00+0000',
-            _updated: '2023-11-16T04:00:00+0000',
-            versioncreated: '2023-11-16T04:00:00+0000',
-            _etag: 'etag123',
-            dates: {start: '2018-10-15T04:00:00+0000', end: '2018-10-15T05:00:00+0000', tz: 'Australia/Sydney'},
-            event: {_id: 'event1'},
-        }, {
-            _id: 'event2',
-            guid: 'event2',
-            type: 'agenda',
-            item_type: 'event',
-            state: 'scheduled',
-            _created: '2023-11-16T04:00:00+0000',
-            _updated: '2023-11-16T04:00:00+0000',
-            versioncreated: '2023-11-16T04:00:00+0000',
-            _etag: 'etag123',
-            dates: {start: '2018-10-16T04:00:00+0000', end: '2018-10-16T05:00:00+0000', tz: 'Australia/Sydney'},
-            event: {_id: 'event2'},
-        }, {
-            _id: 'event3',
-            guid: 'event3',
-            type: 'agenda',
-            item_type: 'event',
-            state: 'scheduled',
-            _created: '2023-11-16T04:00:00+0000',
-            _updated: '2023-11-16T04:00:00+0000',
-            versioncreated: '2023-11-16T04:00:00+0000',
-            _etag: 'etag123',
-            dates: {start: '2018-10-17T04:00:00+0000', end: '2018-10-17T05:00:00+0000', tz: 'Australia/Sydney'},
-            event: {_id: 'event3'},
-        }];
+        const items: Array<IAgendaItem> = [
+            createEvent('event1', {
+                start: '2018-10-15T04:00:00+0000', end: '2018-10-15T05:00:00+0000', tz: 'Australia/Sydney',
+            }),
+            createEvent('event2', {
+                start: '2018-10-16T04:00:00+0000', end: '2018-10-16T05:00:00+0000', tz: 'Australia/Sydney',
+            }),
+            createEvent('event3', {
+                start: '2018-10-17T04:00:00+0000', end: '2018-10-17T05:00:00+0000', tz: 'Australia/Sydney',
+            }),
+        ];
 
         let groupedItems = getGroupedItems(items, moment('2018-10-14'), moment('2018-10-18'));
 
@@ -422,44 +410,34 @@ describe('utils', () => {
 
     it('groupItems handles no_end_time events', () => {
         const items: Array<IAgendaItem> = [
-            {
-                _id: 'event1',
-                guid: 'event1',
-                type: 'agenda',
-                item_type: 'event',
-                state: 'scheduled',
-                _created: '2023-11-16T04:00:00+0000',
-                _updated: '2023-11-16T04:00:00+0000',
-                versioncreated: '2023-11-16T04:00:00+0000',
-                _etag: 'etag123',
-                event: {_id: 'event1'},
-                dates: {
-                    'start': '2024-05-22T23:07:00+0000',
-                    'end': '2024-05-22T23:07:00+0000',
-                    'no_end_time': true,
-                    'tz': 'US/Eastern',
-                    'all_day': false
-                }
-            },
-            {
-                _id: 'event2',
-                guid: 'event2',
-                type: 'agenda',
-                item_type: 'event',
-                state: 'scheduled',
-                _created: '2023-11-16T04:00:00+0000',
-                _updated: '2023-11-16T04:00:00+0000',
-                versioncreated: '2023-11-16T04:00:00+0000',
-                _etag: 'etag123',
-                event: {_id: 'event2'},
-                dates: {
-                    'start': '2024-05-24T01:00:00+0000',
-                    'end': '2024-05-24T01:00:00+0000',
-                    'no_end_time': true,
-                    'tz': 'Europe/Prague',
-                    'all_day': false
-                }
-            }
+            createEvent('event1', {
+                'start': '2024-05-22T23:07:00+0000',
+                'end': '2024-05-22T23:07:00+0000',
+                'no_end_time': true,
+                'tz': 'US/Eastern',
+                'all_day': false
+            }),
+            createEvent('event2', {
+                'start': '2024-05-24T01:00:00+0000',
+                'end': '2024-05-24T01:00:00+0000',
+                'no_end_time': true,
+                'tz': 'Europe/Prague',
+                'all_day': false
+            }),
+            createEvent('event3', {
+                'start': '2024-05-24T00:00:00+0000',
+                'end': '2024-05-24T00:00:00+0000',
+                'no_end_time': true,
+                'tz': 'Europe/Prague',
+                'all_day': false
+            }),
+            createEvent('event4', {
+                'start': '2024-05-23T23:25:00+0000',
+                'end': '2024-05-24T00:00:00+0000',
+                'no_end_time': true,
+                'tz': 'Europe/Prague',
+                'all_day': false
+            }),
         ];
         
         const groupedItems = getGroupedItems(items, moment('2024-05-21'), moment('2024-05-25'));
@@ -467,6 +445,15 @@ describe('utils', () => {
         expect(Object.keys(groupedItems)).toEqual(['23-05-2024', '24-05-2024']);
 
         expect(groupedItems['23-05-2024'].items).toEqual(['event1']);
-        expect(groupedItems['24-05-2024'].items).toEqual(['event2']);
+        expect(groupedItems['24-05-2024'].items).toEqual(['event2', 'event3', 'event4']);
+    });
+
+    describe('timezone', () => {
+        it('should be CET/CEST', () => {
+            const offset = new Date().getTimezoneOffset();
+
+            expect(offset).toBeLessThanOrEqual(-60);
+            expect(offset).toBeGreaterThanOrEqual(-120);
+        });
     });
 });

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -669,7 +669,7 @@ export function getStartDate(item: IAgendaItem): moment.Moment {
 
 // get end date in utc mode if there is no end time info
 export function getEndDate(item: IAgendaItem): moment.Moment {
-    return item.dates.no_end_time === true || item.dates.all_day === true ?
+    return item.dates.all_day === true ?
         moment.utc(item.dates.end || item.dates.start) :
         moment(item.dates.end || item.dates.start);
 }
@@ -682,17 +682,12 @@ const isBetweenDay = (day: moment.Moment, start: moment.Moment, end: moment.Mome
 
     if (allDay) {
         // we ignore times and only check dates
-        testDay = moment(day.format('YYYY-MM-DD'));
         startDate = moment(start.format('YYYY-MM-DD'));
         endDate = moment(end.format('YYYY-MM-DD'));
-    } else if (noEndTime) {
-        // we ignore time for end date
-        testDay = moment(day.format('YYYY-MM-DD'));
-        endDate = moment(end.format('YYYY-MM-DD'));
-        return day.isSameOrAfter(start) && testDay.isSameOrBefore(endDate);
+        testDay =  moment(day.format('YYYY-MM-DD'));
     }
 
-    return testDay.isBetween(startDate, endDate, 'day', '[]');
+    return testDay.isSameOrAfter(startDate, 'day') && testDay.isSameOrBefore(endDate, 'day');
 };
 
 /**
@@ -1093,7 +1088,7 @@ export function formatAgendaDate(item: IAgendaItem, {localTimeZone = true, onlyD
 
     const isTBCItem = isItemTBC(item);
     const start = parseDate(item.dates.start, item.dates.all_day);
-    const end = parseDate(item.dates.end, item.dates.all_day || item.dates.no_end_time);
+    const end = parseDate(item.dates.end, item.dates.all_day);
 
     const scheduleType = getScheduleType(item);
     const startDate = formatDate(start);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,6 +4,9 @@ const webpack = require('webpack');
 const webpackConfig = require('./webpack.config.js');
 
 module.exports = function(config) {
+    // set timezone for tests
+    process.env.TZ = 'Europe/Prague';
+
     config.set({
         files: [
             'assets/tests.ts',


### PR DESCRIPTION
moment isbetween didn't work properly when
start and end timestamps were identical
which is the case for events with no end time.

CPCN-806

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
