### PR TITLE
fix agenda list loading

### DIFF
--- a/assets/agenda/components/AgendaList.tsx
+++ b/assets/agenda/components/AgendaList.tsx
@@ -428,7 +428,7 @@ class AgendaList extends React.Component<IProps, IState> {
                 }}
                 onScroll={this.props.onScroll}
             >
-                {this.props.groupedItems.map((group) => (
+                {this.props.groupedItems.filter((group) => group.items.length > 0).map((group) => (
                     <React.Fragment key={group.date}>
                         <div className='wire-articles__header' key={`${group.date}header`}>
                             {this.getListGroupDate(group)}

--- a/assets/agenda/components/AgendaList.tsx
+++ b/assets/agenda/components/AgendaList.tsx
@@ -414,6 +414,7 @@ class AgendaList extends React.Component<IProps, IState> {
     }
 
     render() {
+        const lastGroupWithItems = this.props.groupedItems.findLastIndex((group) => group.items.length > 0);
         return (
             <div
                 className={classNames('wire-articles wire-articles--list', {
@@ -428,7 +429,7 @@ class AgendaList extends React.Component<IProps, IState> {
                 }}
                 onScroll={this.props.onScroll}
             >
-                {this.props.groupedItems.filter((group) => group.items.length > 0).map((group) => (
+                {this.props.groupedItems.filter((group, index) => lastGroupWithItems >= index).map((group) => (
                     <React.Fragment key={group.date}>
                         <div className='wire-articles__header' key={`${group.date}header`}>
                             {this.getListGroupDate(group)}

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -686,7 +686,10 @@ class AgendaService(BaseSearchService):
     section = "agenda"
     limit_days_setting = None
     default_sort = [{"dates.start": "asc"}]
-    default_page_size = 250
+
+    @property
+    def default_page_size(self) -> int:
+        return app.config.get("AGENDA_PAGE_SIZE", 250)
 
     def get_advanced_search_fields(self, search: SearchQuery) -> List[str]:
         fields = super().get_advanced_search_fields(search)

--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -149,8 +149,11 @@ class BaseSearchService(Service):
     section: Section = "wire"
     limit_days_setting: Union[None, str] = "wire_time_limit_days"
     default_sort = [{"versioncreated": "desc"}]
-    default_page_size = 25
     _matched_ids = []  # array of IDs matched on the request, used when searching all versions
+
+    @property
+    def default_page_size(self) -> int:
+        return 25
 
     def get(self, req, lookup):
         search = SearchQuery()

--- a/package-lock.json
+++ b/package-lock.json
@@ -17243,9 +17243,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "ua-parser-js": {
       "version": "0.7.37",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "style-loader": "^0.19.0",
     "terser-webpack-plugin-legacy": "^1.2.5",
     "ts-loader": "^3.5.0",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "url-search-params-polyfill": "2.0.3",
     "webpack": "3.11.0",
     "webpack-dev-server": "2.11.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,10 @@
     "assets"
   ],
   "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "allowJs": true,
     "baseUrl": "./assets",
-    "target": "ES2017",
+    "target": "ES6",
     "module": "commonjs",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
only display days with some event starting
so the newly loaded events are added at the bottom. plus make agenda page size configurable

CPCN-818

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
