### PR TITLE
Fix issue with missing date_filter param in search API payload [NHUB-508]

### DIFF
--- a/assets/search/selectors.ts
+++ b/assets/search/selectors.ts
@@ -66,7 +66,8 @@ export const searchParamsSelector = createSelector<
         const params: ISearchParams = {
             query: (search.activeQuery?.length ?? 0) ? search.activeQuery : undefined,
             sortQuery: (search.activeSortQuery?.length ?? 0) ? search.activeSortQuery : undefined,
-            created: ((search.createdFilter?.from?.length ?? 0) + (search.createdFilter?.to?.length ?? 0)) > 0 ?
+            created: ((search.createdFilter?.from?.length ?? 0) + (search.createdFilter?.to?.length ?? 0)) > 0 ||
+                search.createdFilter.date_filter?
                 search.createdFilter :
                 undefined,
             navigation: search.activeNavigation ?? [],

--- a/assets/search/selectors.ts
+++ b/assets/search/selectors.ts
@@ -67,7 +67,7 @@ export const searchParamsSelector = createSelector<
             query: (search.activeQuery?.length ?? 0) ? search.activeQuery : undefined,
             sortQuery: (search.activeSortQuery?.length ?? 0) ? search.activeSortQuery : undefined,
             created: ((search.createdFilter?.from?.length ?? 0) + (search.createdFilter?.to?.length ?? 0)) > 0 ||
-                search.createdFilter.date_filter?
+                search.createdFilter?.date_filter ?
                 search.createdFilter :
                 undefined,
             navigation: search.activeNavigation ?? [],


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
