### PR TITLE
avoid `body` tag in wire preview

### DIFF
--- a/assets/ui/components/ArticleBodyHtml.tsx
+++ b/assets/ui/components/ArticleBodyHtml.tsx
@@ -99,7 +99,9 @@ class ArticleBodyHtmlComponent extends React.PureComponent<IProps, IState> {
             return false;
         }
 
-        this.bodyRef.current.appendChild(getBodyElement(bodyHtml, item));
+        const body = getBodyElement(bodyHtml, item);
+
+        this.bodyRef.current.innerHTML = body.innerHTML;
 
         return true;
     }


### PR DESCRIPTION
NHUB-510

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
