### PR TITLE
[CPCN-814] Send `user id` to GA and add column to user management table

### DIFF
--- a/assets/interfaces/user.ts
+++ b/assets/interfaces/user.ts
@@ -31,6 +31,7 @@ export interface IUser {
     locale: string;
     manage_company_topics?: boolean;
     last_active?: TDatetime;
+    _created?: TDatetime;
 
     original_creator?: IUser['_id'];
     version_creator?: IUser['_id'];

--- a/assets/users/components/UserListItem.tsx
+++ b/assets/users/components/UserListItem.tsx
@@ -1,40 +1,42 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {gettext, shortDate, fullDate} from 'utils';
 import {getUserLabel} from '../utils';
-import {get} from 'lodash';
+import {ICompany, IUser} from 'interfaces';
 
+interface IProps {
+    user: IUser;
+    isActive: boolean;
+    onClick: (userId: IUser['_id']) => void;
+    companiesById: Dictionary<ICompany>;
+}
 
-function UserListItem({user, isActive, onClick, companiesById}: any) {
+function UserListItem({user, isActive, onClick, companiesById}: IProps) {
+    const isCompanyUserNotEnabled  = user.company && companiesById[user.company] && !companiesById[user.company]?.is_enabled;
+    const isUserNotEnabled = !user.is_enabled;
+
     return (
         <tr key={user._id}
-            className={`${isActive?'table--selected':''}
-            ${(user.company && companiesById[user.company] && !get(companiesById[user.company],'is_enabled')) ||
-            !user.is_enabled?'table-secondary':null}`}
+            className={`
+                ${isActive ? 'table--selected' : ''}
+                ${isCompanyUserNotEnabled || isUserNotEnabled ? 'table-secondary' : ''}`
+            }
             onClick={() => onClick(user._id)}
             tabIndex={0}
             data-test-id={`user-list-item--${user._id}`}
         >
             <td className="name">{user.first_name} {user.last_name}</td>
             <td>{user.email}</td>
+            <td>{user._id}</td>
             <td>{user.phone}</td>
-            <td>{user.mobile}</td>
             <td>{user.role}</td>
             <td>{getUserLabel(user.user_type)}</td>
-            <td>{(user.company && companiesById ? get(companiesById[user.company],'name') : null)}</td>
+            <td>{(user.company && companiesById ? companiesById[user.company]?.name : null)}</td>
             <td>{(user.is_approved ? gettext('Approved') : gettext('Needs Approval'))} -
                 {(user.is_enabled ? gettext('Enabled') : gettext('Disabled'))}</td>
             <td>{shortDate(user._created)}</td>
-            <td>{get(user, 'last_active') ? fullDate(get(user, 'last_active')) : ''}</td>
+            <td>{user?.last_active ? fullDate(user?.last_active) : ''}</td>
         </tr>
     );
 }
-
-UserListItem.propTypes = {
-    user: PropTypes.object,
-    isActive: PropTypes.bool,
-    onClick: PropTypes.func,
-    companiesById: PropTypes.object,
-};
 
 export default UserListItem;

--- a/assets/users/components/UsersList.tsx
+++ b/assets/users/components/UsersList.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import UserListItem from './UserListItem';
 import {gettext} from 'utils';
+import {ICompany, IUser} from 'interfaces';
 
+interface IProps {
+    users: Array<IUser>;
+    onClick: (userId: IUser['_id']) => void;
+    activeUserId: string;
+    companiesById: Dictionary<ICompany>;
+}
 
-function UsersList({users, onClick, activeUserId, companiesById}: any) {
+function UsersList({users, onClick, activeUserId, companiesById}: IProps) {
     const list = users.map((user: any) =>
         <UserListItem
             key={user._id}
             user={user}
             onClick={onClick}
-            isActive={activeUserId===user._id}
+            isActive={activeUserId === user._id}
             companiesById={companiesById} />
     );
 
@@ -25,8 +31,8 @@ function UsersList({users, onClick, activeUserId, companiesById}: any) {
                         <tr>
                             <th>{ gettext('Name') }</th>
                             <th>{ gettext('Email') }</th>
+                            <th>{ gettext('User Id') }</th>
                             <th>{ gettext('Phone') }</th>
-                            <th>{ gettext('Mobile') }</th>
                             <th>{ gettext('Role') }</th>
                             <th>{ gettext('User Type') }</th>
                             <th>{ gettext('Company') }</th>
@@ -41,12 +47,5 @@ function UsersList({users, onClick, activeUserId, companiesById}: any) {
         </section>
     );
 }
-
-UsersList.propTypes = {
-    users: PropTypes.array.isRequired,
-    onClick: PropTypes.func.isRequired,
-    activeUserId: PropTypes.string,
-    companiesById: PropTypes.object,
-};
 
 export default UsersList;

--- a/newsroom/templates/scripts.html
+++ b/newsroom/templates/scripts.html
@@ -46,17 +46,8 @@
 
     let configParams = {};
     {% if session.get('user') %}
-        gtag('set', {'user_id': '{{ hash(session['user']) | tojson }}' });
-
         configParams['user_id'] = '{{ session['user'] }}';
     {% endif %}
-
-    if ('{{ get_setting('google_analytics') }}'.startsWith('UA')) {
-        configParams['custom_map'] = {
-            dimension1: 'company',
-            dimension2: 'user',
-        };
-    }
 
     gtag('config', '{{ get_setting('google_analytics') | tojson }}', configParams);
 

--- a/newsroom/templates/scripts.html
+++ b/newsroom/templates/scripts.html
@@ -35,35 +35,36 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ get_setting('google_analytics') | safe }}"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-  gtag('set', 'user_properties', {
-      company: (window.profileData || {}).companyName || 'none',
-      user: ((window.profileData || {}).user || {}).first_name || 'unknown',
-  });
+    gtag('set', 'user_properties', {
+        company: (window.profileData || {}).companyName || 'none',
+        user: ((window.profileData || {}).user || {}).first_name || 'unknown',
+    });
 
-  {% if session.get('user') %}
-  gtag('set', {'user_id': '{{ hash(session['user']) | tojson }}' });
-  {% endif %}
+    let configParams = {};
+    {% if session.get('user') %}
+        gtag('set', {'user_id': '{{ hash(session['user']) | tojson }}' });
 
-  if ('{{ get_setting('google_analytics') }}'.startsWith('UA')) {
-      gtag('config', '{{ get_setting('google_analytics') | tojson }}', {
-          custom_map: {
-              dimension1: 'company',
-              dimension2: 'user',
-          }
-      });
-  } else {
-      gtag('config', '{{ get_setting('google_analytics') | tojson }}');
-  }
-
-  {% with messages = get_flashed_messages(category_filter=['analytics']) %}
-    {% if messages %}
-        analytics.sendEvents({{ messages | tojson | safe }});
+        configParams['user_id'] = '{{ session['user'] }}';
     {% endif %}
-  {% endwith %}
+
+    if ('{{ get_setting('google_analytics') }}'.startsWith('UA')) {
+        configParams['custom_map'] = {
+            dimension1: 'company',
+            dimension2: 'user',
+        };
+    }
+
+    gtag('config', '{{ get_setting('google_analytics') | tojson }}', configParams);
+
+    {% with messages = get_flashed_messages(category_filter=['analytics']) %}
+        {% if messages %}
+            analytics.sendEvents({{ messages | tojson | safe }});
+        {% endif %}
+    {% endwith %}
 </script>
 {% endif %}
 


### PR DESCRIPTION
### Purpose
Send `User Id` to Google Analytics to it can be used in `Number of logged-in sessions` report. Plus replace `Mobile` column with `User Id` in User Management table. 

### What has changed
- Adjusted `gtag` script usage so user id is sent to Google Analytics
- Added new column `User Id` to user management table
- Completed some types

### To test
- Checkout branch and run the project
- Navigate the app. Verify in the browser terminal that user id is sent in collect request from google analytics (see screenshot below)
- Optional: Verify in Google Analytics dashboard that user id is being tracked

### Checklist
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

### Screenshots
Google Analytics collect request:
<img width="450" alt="image" src="https://github.com/superdesk/newsroom-core/assets/124766/194bd2a4-7cad-478c-9d5d-e150bf51a58a">

User's management table:
<img width="550" alt="image" src="https://github.com/superdesk/newsroom-core/assets/124766/ce2db9b7-1008-4e94-92e6-8e0a7fe86739">

Some references about the implementation from Google Analytics Documentation https://developers.google.com/analytics/devguides/collection/ga4/user-id?client_type=gtag#send_user_ids

Thanks for reviewing!

Resolves: [CPCN-814]


[CPCN-814]: https://sofab.atlassian.net/browse/CPCN-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ