### PR TITLE
Fix Content Activity and Subscriber Activity reports print functionality

### DIFF
--- a/assets/company-reports/actions.ts
+++ b/assets/company-reports/actions.ts
@@ -1,6 +1,6 @@
 import {errorHandler, getItemFromArray, getDateInputDate, notify, gettext} from '../utils';
 import server from '../server';
-import {get, cloneDeep} from 'lodash';
+import {cloneDeep} from 'lodash';
 import {type ICompanyReportsData} from './types';
 import {Store, Dispatch} from 'redux';
 
@@ -37,7 +37,7 @@ function getReportQueryString(currentState: any, next: boolean, exportReport: bo
     const params = cloneDeep(currentState.reportParams);
     if (params) {
         if (params.company) {
-            params.company = get(getItemFromArray(params.company, currentState.companies, 'name'), '_id');
+            params.company = getItemFromArray(params.company, currentState.companies, 'name')?._id;
         }
 
         if (params.date_from > params.date_to) {
@@ -53,22 +53,23 @@ function getReportQueryString(currentState: any, next: boolean, exportReport: bo
         }
 
         if (params.section) {
-            params.section = get(getItemFromArray(params.section, currentState.sections, 'name'), '_id');
+            params.section = getItemFromArray(params.section, currentState.sections, 'name')?._id;
         }
 
         if (params.product) {
-            params.product = get(getItemFromArray(params.product, currentState.products, 'name'), '_id');
+            params.product = getItemFromArray(params.product, currentState.products, 'name')?._id;
         }
 
         if (exportReport) {
             params.export = true;
         }
 
-        params['from'] = next ? get(currentState, 'results.length') : 0;
+        params['from'] = next ? currentState?.results?.length : 0;
         const queryString = Object.keys(params)
-            .filter((key: any) => params[key])
-            .map((key: any) => [key, params[key]].join('='))
+            .filter((key) => params[key])
+            .map((key) => [key, params[key]].join('='))
             .join('&');
+
         return queryString;
     }
 }

--- a/assets/render-utils.tsx
+++ b/assets/render-utils.tsx
@@ -3,7 +3,7 @@ import {Provider} from 'react-redux';
 import {render as _render} from 'react-dom';
 import '@superdesk/common/dist/src/index.css';
 
-export function render(store: any, App: any, element?: any, props?: any) {
+export function render<T = any>(store: any, App: any, element?: any, props?: T) {
     return _render(
         <Provider store={store}>
             <App {...props}/>

--- a/newsroom/reports/content_activity.py
+++ b/newsroom/reports/content_activity.py
@@ -253,31 +253,10 @@ def export_csv(args, results):
             aggs.get("total") or 0,
         ]
 
-        if "download" in actions:
-            row.append((aggs.get("actions") or {}).get("download") or 0)
-
-        if "copy" in actions:
-            row.append((aggs.get("actions") or {}).get("copy") or 0)
-
-        if "share" in actions:
-            row.append((aggs.get("actions") or {}).get("share") or 0)
-
-        if "print" in actions:
-            row.append((aggs.get("actions") or {}).get("print") or 0)
-
-        if "open" in actions:
-            row.append((aggs.get("actions") or {}).get("open") or 0)
-
-        if "preview" in actions:
-            row.append((aggs.get("actions") or {}).get("preview") or 0)
-
-        if "clipboard" in actions:
-            row.append((aggs.get("actions") or {}).get("clipboard") or 0)
-
-        if "api" in actions:
-            row.append((aggs.get("actions") or {}).get("api") or 0)
-
-        rows.append(row)
+        action_names = ["download", "copy", "share", "print", "open", "preview", "clipboard", "api"]
+        for action_name in action_names:
+            if action_name in actions:
+                row.append((aggs.get("actions") or {}).get(action_name, 0))
 
     return rows
 

--- a/newsroom/templates/reports_print.html
+++ b/newsroom/templates/reports_print.html
@@ -11,10 +11,11 @@
 
     <script>
         window.newsroom = {{ get_client_config() | tojson | safe }};
+        window.locale = '{{ get_locale() | tojson | safe }}';
         reportData = {{ data | tojson | safe }};
         report = "{{ report | tojson | safe }}";
     </script>
 
     {{ javascript_tag('%s_js' % setting_type) | safe }}
-    
+
 {% endblock %}


### PR DESCRIPTION
### Purpose
This PR fixes both bug connected with the print functionality of the Content Activity and Subscriber Activity reports. 

### What has changed
- The query parameters representing the filters of the reports were missing when calling the print view
- Missing `window.locale` value was producing breaking the print view UI

### How to test
- Checkout branch and run the project 
- Go to Content Activity and/or Subscriber Activity reports, select some filters
- Run "Print Report" and observe that it works as expected

### Checklist
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Thanks for checking!

Resolves: [CPCN-637] & [CPCN-636]


[CPCN-637]: https://sofab.atlassian.net/browse/CPCN-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPCN-636]: https://sofab.atlassian.net/browse/CPCN-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ