### PR TITLE
fix agenda events not visible

### DIFF
--- a/assets/agenda/components/AgendaList.tsx
+++ b/assets/agenda/components/AgendaList.tsx
@@ -515,5 +515,6 @@ function getLastGroupWithItems(groupedItems: Array<IAgendaListGroup>): number {
         return groupedItems.indexOf(lastGroup);
     }
 
-    return -1;
+    // If no groups have items, return the last group
+    return groupedItems.length - 1;
 }

--- a/assets/agenda/tests/utils.spec.ts
+++ b/assets/agenda/tests/utils.spec.ts
@@ -438,14 +438,29 @@ describe('utils', () => {
                 'tz': 'Europe/Prague',
                 'all_day': false
             }),
+            createEvent('event5', {
+                'start': '2024-05-20T20:25:00+0000',
+                'end': '2024-05-23T00:00:00+0000',
+                'no_end_time': true,
+                'tz': 'Europe/Prague',
+            }),
         ];
         
         const groupedItems = getGroupedItems(items, moment('2024-05-21'), moment('2024-05-25'));
 
-        expect(Object.keys(groupedItems)).toEqual(['23-05-2024', '24-05-2024']);
+        expect(Object.keys(groupedItems)).toEqual(['21-05-2024', '22-05-2024', '23-05-2024', '24-05-2024']);
+
+        expect(groupedItems['21-05-2024'].items).toEqual([]);
+        expect(groupedItems['21-05-2024'].hiddenItems).toEqual(['event5']);
+
+        expect(groupedItems['22-05-2024'].items).toEqual([]);
+        expect(groupedItems['22-05-2024'].hiddenItems).toEqual(['event5']);
 
         expect(groupedItems['23-05-2024'].items).toEqual(['event1']);
+        expect(groupedItems['23-05-2024'].hiddenItems).toEqual(['event5']);
+
         expect(groupedItems['24-05-2024'].items).toEqual(['event2', 'event3', 'event4']);
+        expect(groupedItems['24-05-2024'].hiddenItems).toEqual([]);
     });
 
     describe('timezone', () => {

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -1037,12 +1037,16 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
 };
 
 function getScheduleType(item: IAgendaItem): string {
-    const start = moment(item.dates.start);
-    const end = moment(item.dates.end);
+    const start = getStartDate(item);
+    const end = getEndDate(item);
     const duration = end.diff(start, 'minutes');
 
     if (item.dates.all_day) {
         return duration === 0 ? SCHEDULE_TYPE.ALL_DAY : SCHEDULE_TYPE.MULTI_DAY;
+    }
+
+    if (item.dates.no_end_time && !start.isSame(end, 'day')) {
+        return SCHEDULE_TYPE.MULTI_DAY;
     }
 
     if (item.dates.no_end_time) {


### PR DESCRIPTION
if there were only events starting on previous days due to filtering.

CPCN-806

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
