### PR TITLE
[SDESK-7287] Support async tasks in Celery

### DIFF
--- a/newsroom/celery_app.py
+++ b/newsroom/celery_app.py
@@ -15,76 +15,24 @@ Created on May 29, 2014
 """
 
 import logging
+import newsroom
 
-import arrow
-from bson import ObjectId
 from celery import Celery
 from celery.worker.request import Request
-from kombu.serialization import register
-from eve.io.mongo import MongoJSONEncoder
-from eve.utils import str_to_date
 
-from superdesk.core import json
-from superdesk.celery_app import (  # noqa
-    finish_subtask_from_progress,
-    finish_task_for_progress,
-    __get_redis,
-    update_key,
-    _update_subtask_progress,
-)
-
-import newsroom
-from newsroom.errors import LockedError
+from superdesk.celery_app import __get_redis, HybridAppContextTask, ContextAwareSerializerFactory
 
 
 logger = logging.getLogger(__name__)
-celery = Celery(__name__)
-TaskBase = celery.Task
 
 
-def try_cast(v):
-    # False and 0 are getting converted to datetime by arrow
-    if v is None or isinstance(v, bool) or v == 0:
-        return v
-
-    try:
-        str_to_date(v)  # try if it matches format
-        return arrow.get(v).datetime  # return timezone aware time
-    except Exception:
-        try:
-            return ObjectId(v)
-        except Exception:
-            return v
+def get_newsroom_web_app():
+    # using `newsroom.flas_app` as it's the one that returns the right app context
+    return newsroom.flask_app
 
 
-def dumps(o):
-    with newsroom.flask_app.app_context():
-        return MongoJSONEncoder().encode(o)
-
-
-def loads(s):
-    o = json.loads(s)
-    with newsroom.flask_app.app_context():
-        return serialize(o)
-
-
-def serialize(o):
-    if isinstance(o, list):
-        return [serialize(item) for item in o]
-    elif isinstance(o, dict):
-        if o.get("kwargs") and not isinstance(o["kwargs"], dict):
-            o["kwargs"] = json.loads(o["kwargs"])
-        return {k: serialize(v) for k, v in o.items()}
-    else:
-        return try_cast(o)
-
-
-register("newsroom/json", dumps, loads, content_type="application/json")
-
-
-def handle_exception(exc):
-    """Log exception to logger."""
-    logger.exception(exc)
+serializer_factory = ContextAwareSerializerFactory(get_newsroom_web_app)
+serializer_factory.register_serializer("newsroom/json")
 
 
 class NewsroomRequest(Request):
@@ -102,27 +50,17 @@ class NewsroomRequest(Request):
         logger.warning("Failure detected for task %s", self.task.name)
 
 
-class AppContextTask(TaskBase):  # type: ignore
-    abstract = True
+class NewsroomContextTask(HybridAppContextTask):
     serializer = "newsroom/json"
     Request = NewsroomRequest
 
-    def __call__(self, *args, **kwargs):
-        with newsroom.flask_app.app_context():
-            try:
-                return super().__call__(*args, **kwargs)
-            except LockedError as e:  # workaround to skip with block body without error logged
-                logger.debug("Lock conflict on %s", e)
-            except Exception as e:
-                logger.warning("Error when calling task %s", self.name)
-                handle_exception(e)
-
-    def on_failure(self, exc, task_id, args, kwargs, einfo):
-        logger.warning("Failure detected for task %s", self.name)
-        handle_exception(exc)
+    def get_current_app(self):
+        """Simple override to use the right context app"""
+        return get_newsroom_web_app()
 
 
-celery.Task = AppContextTask
+celery = Celery(__name__)
+celery.Task = NewsroomContextTask
 
 
 def init_celery(app):

--- a/newsroom/core/__init__.py
+++ b/newsroom/core/__init__.py
@@ -2,7 +2,7 @@ from typing import cast
 from superdesk.core import get_current_app
 
 
-def get_newsroom_app():
+def get_current_wsgi_app():
     from newsroom.web.factory import NewsroomWebApp
 
     return cast(NewsroomWebApp, get_current_app())

--- a/newsroom/errors.py
+++ b/newsroom/errors.py
@@ -1,2 +1,0 @@
-class LockedError(RuntimeError):
-    pass

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -20,7 +20,6 @@ from superdesk.utc import utcnow
 from superdesk.errors import SuperdeskApiError
 from planning.common import WORKFLOW_STATE
 from newsroom.celery_app import celery
-from newsroom.errors import LockedError
 from superdesk.lock import lock, unlock
 
 from newsroom.notifications import (
@@ -765,7 +764,9 @@ def set_item_reference(coverage):
 def locked(_id: str, service: str):
     lock_name = f"notify-{service}-{_id}"
     if not lock(lock_name, expire=300):
-        raise LockedError(lock_name)
+        logger.debug(f"Lock conflict on {lock_name}")
+        return
+
     logger.debug("Starting task %s", lock_name)
     try:
         yield lock_name


### PR DESCRIPTION
### Purpose
Introduce the new class from `superdesk-core` to handle celery tasks with both async and sync code. This PR depends on https://github.com/superdesk/superdesk-core/pull/2658

### What has changed
- Created a new class `NewsroomContextTask` that inherits from superdesk's `HybridAppContextTask`. This has helped removing a lot of duplicated code
- Registered custom serializer for celery using superdesk's new `ContextAwareSerializerFactory` class.
- Removed `LockedError` exception class as it was basically useless (just to raise it and log a debug message)

### To test
You can, for instance, change the task `monitoring_immediate_alerts`, prefix it with `async` and add some asyncio.sleep(0.1) and a `print` statement inside. Then run the services (celery worker and beat) and observe that the task runs properly

Resolves: [SDESK-7287]

### Checklist
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments


[SDESK-7287]: https://sofab.atlassian.net/browse/SDESK-7287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ