### PR TITLE
fix webpack v4 manifest format

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,7 @@ const config = {
         mainFields: ['browser', 'main'],
     },
     plugins: [
-        new WebpackManifestPlugin({writeToFileEmit: true}),
+        new WebpackManifestPlugin({writeToFileEmit: true, publicPath: '/'}),
     ],
     devServer: {
         compress: true,


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
