### PR TITLE
Fix : X button doesn't work on any of the search depth options [CPCN-922] (#1031)

### DIFF
--- a/assets/search/components/SearchResultsBar/SearchResultsFiltersRow.tsx
+++ b/assets/search/components/SearchResultsBar/SearchResultsFiltersRow.tsx
@@ -163,6 +163,7 @@ function SearchResultsFiltersRow(props: IPropsAgendaExtended) {
                             ...searchParams.created,
                             from: null,
                             to: null,
+                            date_filter:null,
                         });
                     }}
                 />

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -794,5 +794,5 @@ def test_agenda_filters_query(app):
     # Test case 5: Filter for this_week
     args = {"date_from": "2024-08-13", "date_filter": "today"}
     date_range = get_date_filters(args)
-    assert date_range["gt"] == datetime(2024, 8, 13, 0, 0, tzinfo=pytz.UTC)
-    assert date_range["lt"] == datetime(2024, 8, 13, 23, 59, 59, tzinfo=pytz.UTC)
+    assert date_range["gt"] == datetime(2024, 8, 14, 0, 0, tzinfo=pytz.UTC)
+    assert date_range["lt"] == datetime(2024, 8, 14, 23, 59, 59, tzinfo=pytz.UTC)


### PR DESCRIPTION


add missing default_filter param

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
