### PR TITLE
[STTNHUB-356] fix: Unable to send empty value for UserForm

### DIFF
--- a/newsroom/users/forms.py
+++ b/newsroom/users/forms.py
@@ -16,7 +16,9 @@ class CommaSeparatedListField(Field):
             return ""
 
     def process_formdata(self, valuelist):
-        if valuelist == [""]:  # An empty string from the client is equal to an empty array
+        if (
+                valuelist == [""] or valuelist == [None] or valuelist == ["None"]
+        ):  # An empty string from the client is equal to an empty array
             self.data = []
         elif len(valuelist):
             self.data = [x.strip() for x in valuelist[0].split(",")]

--- a/newsroom/users/forms.py
+++ b/newsroom/users/forms.py
@@ -17,7 +17,7 @@ class CommaSeparatedListField(Field):
 
     def process_formdata(self, valuelist):
         if (
-                valuelist == [""] or valuelist == [None] or valuelist == ["None"]
+            valuelist == [""] or valuelist == [None] or valuelist == ["None"]
         ):  # An empty string from the client is equal to an empty array
             self.data = []
         elif len(valuelist):


### PR DESCRIPTION
Was causing the following exception to be raised
```
  File "newsroom/users/forms.py", line 22, in process_formdata
    self.data = [x.strip() for x in valuelist[0].split(",")]
AttributeError: 'NoneType' object has no attribute 'split'
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments
