### PR TITLE
Fix commands to work with latest changes from `superdesk-core@async`

### DIFF
--- a/newsroom/commands/__init__.py
+++ b/newsroom/commands/__init__.py
@@ -21,6 +21,7 @@ from .scheduled_notifications import send_scheduled_notifications
 from newsroom.celery_app import celery
 
 from . import elastic_reindex
+from .cli import commands_blueprint, newsroom_cli
 
 
 @celery.task(soft_time_limit=600)

--- a/newsroom/commands/alerts.py
+++ b/newsroom/commands/alerts.py
@@ -5,7 +5,7 @@ from newsroom.monitoring.email_alerts import MonitoringEmailAlerts
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("send_company_expiry_alerts")
+@newsroom_cli.command("send_company_expiry_alerts")
 @with_appcontext
 def send_company_expiry_alerts():
     """
@@ -20,7 +20,7 @@ def send_company_expiry_alerts():
     CompanyExpiryAlerts().send_alerts()
 
 
-@newsroom_cli.cli.command("send_monitoring_schedule_alerts")
+@newsroom_cli.command("send_monitoring_schedule_alerts")
 @with_appcontext
 def send_monitoring_schedule_alerts():
     """
@@ -35,7 +35,7 @@ def send_monitoring_schedule_alerts():
     MonitoringEmailAlerts().run()
 
 
-@newsroom_cli.cli.command("send_monitoring_immediate_alerts")
+@newsroom_cli.command("send_monitoring_immediate_alerts")
 @with_appcontext
 def send_monitoring_immediate_alerts():
     """

--- a/newsroom/commands/cli.py
+++ b/newsroom/commands/cli.py
@@ -1,3 +1,3 @@
-from superdesk.flask import Blueprint
+from superdesk.commands.async_cli import create_commands_blueprint
 
-newsroom_cli = Blueprint("newsroom", __name__, cli_group=None)
+commands_blueprint, newsroom_cli = create_commands_blueprint("newsroom")

--- a/newsroom/commands/content_reset.py
+++ b/newsroom/commands/content_reset.py
@@ -4,7 +4,7 @@ from superdesk.core import get_current_app
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("content_reset")
+@newsroom_cli.command("content_reset")
 @with_appcontext
 def content_reset():
     """Removes all data from 'items' and 'items_versions' indexes/collections.

--- a/newsroom/commands/create_user.py
+++ b/newsroom/commands/create_user.py
@@ -9,7 +9,7 @@ from newsroom.auth import get_user_by_email
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("create_user")
+@newsroom_cli.command("create_user")
 @click.argument("email")
 @click.argument("password")
 @click.argument("first_name")

--- a/newsroom/commands/data_updates.py
+++ b/newsroom/commands/data_updates.py
@@ -10,7 +10,7 @@ from newsroom.data_updates import (
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("data_generate_update")
+@newsroom_cli.command("data_generate_update")
 @click.option("-r", "--resource", required=True, help="Resource to generate update for")
 @with_appcontext
 def data_generate_update(resource):
@@ -18,7 +18,7 @@ def data_generate_update(resource):
     cmd.run(resource)
 
 
-@newsroom_cli.cli.command("data_upgrade")
+@newsroom_cli.command("data_upgrade")
 @click.option(
     "-i",
     "--id",
@@ -49,7 +49,7 @@ def data_upgrade(data_update_id=None, fake=False, dry=False):
     cmd.run(data_update_id, fake, dry)
 
 
-@newsroom_cli.cli.command("data_downgrade")
+@newsroom_cli.command("data_downgrade")
 @click.option(
     "-i",
     "--id",

--- a/newsroom/commands/elastic_init.py
+++ b/newsroom/commands/elastic_init.py
@@ -4,7 +4,7 @@ from superdesk.core import get_current_app
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("elastic_init")
+@newsroom_cli.command("elastic_init")
 @with_appcontext
 def elastic_init():
     """Init elastic index.

--- a/newsroom/commands/elastic_rebuild.py
+++ b/newsroom/commands/elastic_rebuild.py
@@ -7,7 +7,7 @@ from superdesk.commands.flush_elastic_index import FlushElasticIndex
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("elastic_rebuild")
+@newsroom_cli.command("elastic_rebuild")
 @with_appcontext
 def elastic_rebuild():
     """

--- a/newsroom/commands/elastic_reindex.py
+++ b/newsroom/commands/elastic_reindex.py
@@ -5,7 +5,7 @@ from superdesk.core import get_current_app
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("elastic_reindex")
+@newsroom_cli.command("elastic_reindex")
 @click.option("-r", "--resource", required=True, help="Resource to reindex")
 @click.option("-s", "--requests-per-second", default=1000, type=int, help="Number of requests per second")
 @with_appcontext

--- a/newsroom/commands/fix_topic_nested_filters.py
+++ b/newsroom/commands/fix_topic_nested_filters.py
@@ -12,7 +12,7 @@ from newsroom.search.config import nested_agg_groups, SearchGroupNestedConfig
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("fix_topic_nested_filters")
+@newsroom_cli.command("fix_topic_nested_filters")
 @with_appcontext
 def _fix_topic_nested_filters():
     fix_topic_nested_filters()

--- a/newsroom/commands/index_from_mongo.py
+++ b/newsroom/commands/index_from_mongo.py
@@ -11,7 +11,7 @@ from newsroom.mongo_utils import (
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("index_from_mongo_period")
+@newsroom_cli.command("index_from_mongo_period")
 @click.option("-h", "--hours", default=None, help="Number of hours to index")
 @click.option("-c", "--collection", default=None, help="Name of the collection to index")
 @click.option("-t", "--timestamp", default=None, help="Timestamp to start indexing from")
@@ -32,7 +32,7 @@ def index_from_mongo_period(hours, collection, timestamp, direction):
         index_elastic_from_mongo(hours=hours, collection=collection)
 
 
-@newsroom_cli.cli.command("index_from_mongo")
+@newsroom_cli.command("index_from_mongo")
 @click.option("--from", "-f", "collection_name", help="Name of the collection to index")
 @click.option("--all", "all_collections", is_flag=True, help="Index all collections")
 @click.option("--page-size", "-p", default=500, help="Page size for indexing")

--- a/newsroom/commands/initialize_data.py
+++ b/newsroom/commands/initialize_data.py
@@ -8,9 +8,7 @@ from collections import OrderedDict
 from quart.cli import with_appcontext
 
 from superdesk.core import get_current_app
-from apps.prepopulate.app_initialize import (
-    AppInitializeWithDataCommand as _AppInitializeWithDataCommand,
-)
+from apps.prepopulate.app_initialize import import_file
 from .cli import newsroom_cli
 
 from .elastic_rebuild import elastic_rebuild
@@ -27,7 +25,7 @@ __entities__: OrderedDict = OrderedDict(
 )
 
 
-class AppInitializeWithDataCommand(_AppInitializeWithDataCommand):
+class AppInitializeWithDataCommand:
     def run(self, entity_name=None, force=False, init_index_only=False):
         logger.info("Starting data initialization")
         app = get_current_app()
@@ -69,7 +67,7 @@ class AppInitializeWithDataCommand(_AppInitializeWithDataCommand):
                 (file_name, index_params, do_patch) = __entities__[name]
                 for path in data_paths:
                     if path.joinpath(file_name).exists():
-                        self.import_file(name, path, file_name, index_params, do_patch, force)
+                        import_file(name, path, file_name, index_params, do_patch, force)
                         break
             except KeyError:
                 continue
@@ -81,7 +79,7 @@ class AppInitializeWithDataCommand(_AppInitializeWithDataCommand):
         return 0
 
 
-@newsroom_cli.cli.command("initialize_data")
+@newsroom_cli.command("initialize_data")
 @click.option(
     "-n",
     "--entity-name",

--- a/newsroom/commands/remove_expired.py
+++ b/newsroom/commands/remove_expired.py
@@ -5,7 +5,7 @@ import content_api
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("remove_expired")
+@newsroom_cli.command("remove_expired")
 @click.option("-m", "--expiry", "expiry_days", required=False, help="Number of days to determine expiry")
 @with_appcontext
 def _remove_expired(expiry_days):

--- a/newsroom/commands/remove_expired_agenda.py
+++ b/newsroom/commands/remove_expired_agenda.py
@@ -19,7 +19,7 @@ from .cli import newsroom_cli
 logger = logging.getLogger(__name__)
 
 
-@newsroom_cli.cli.command("remove_expired_agenda")
+@newsroom_cli.command("remove_expired_agenda")
 @click.option("-m", "--expiry", "expiry_days", required=False, help="Number of days to determine expiry")
 @with_appcontext
 def remove_expired_agenda(expiry_days=None):

--- a/newsroom/commands/scheduled_notifications.py
+++ b/newsroom/commands/scheduled_notifications.py
@@ -5,7 +5,7 @@ from newsroom.notifications.send_scheduled_notifications import SendScheduledNot
 from .cli import newsroom_cli
 
 
-@newsroom_cli.cli.command("send_scheduled_notifications")
+@newsroom_cli.command("send_scheduled_notifications")
 @click.option(
     "-i",
     "--ignore-schedule",

--- a/newsroom/commands/schema_migrate.py
+++ b/newsroom/commands/schema_migrate.py
@@ -11,7 +11,7 @@ from .cli import newsroom_cli
 VERSION_ID = "schema_version"
 
 
-@newsroom_cli.cli.command("schema_migrate")
+@newsroom_cli.command("schema_migrate")
 @click.argument("resource_name", required=False)
 @with_appcontext
 def schema_migrate(resource_name=None):

--- a/newsroom/web/factory.py
+++ b/newsroom/web/factory.py
@@ -3,7 +3,7 @@ import os
 from newsroom.flask import send_from_directory
 
 from newsroom.auth import get_user
-from newsroom.commands.cli import newsroom_cli
+from newsroom.commands.cli import commands_blueprint, newsroom_cli
 from newsroom.factory import BaseNewsroomApp
 from newsroom.template_filters import (
     datetime_short,
@@ -305,6 +305,7 @@ def get_app(config=None, **kwargs) -> NewsroomWebApp:
     app = NewsroomWebApp(__name__, config=config, **kwargs)
 
     # register newsroom commands group
-    app.register_blueprint(newsroom_cli)
+    newsroom_cli.set_current_app(app)
+    app.register_blueprint(commands_blueprint)
 
     return app


### PR DESCRIPTION
- Updates the broken reference to superdesk's `AppInitializeWithDataCommand` as it was removed in https://github.com/superdesk/superdesk-core/pull/2680
- Updates commands to use `create_commands_blueprint` from superdesk
- Pending: Update commands to be async