### PR TITLE
set dependabot ignore for webpack v5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "webpack"
+        versions: [">=5.0.0"]
+      - dependency-name: "webpack-dev-server"
+        versions: [">=5.0.0"]
+      - dependency-name: "css-loader"
+        versions: [">=6.0.0"]
+      - dependency-name: "style-loader"
+        versions: [">=2.0.0"]


### PR DESCRIPTION
it must be updated manually

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
