### PR TITLE
Update `@actions/upload-artifact` to `v4`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
           CYPRESS_SCREENSHOTS_FOLDER: /tmp/cypress
       - name: Upload screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots-e2e
           path: /tmp/cypress/**/*.png


### PR DESCRIPTION
### Purpose
Updates the E2E Github `@actions/upload-artifact` to latest version as current one is deprecated and not working anymore. Additional information here https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Example failed job here https://github.com/superdesk/newsroom-core/actions/runs/10770209797/job/29863095178
