### PR TITLE
fix iCal export for onclusive events

### DIFF
--- a/newsroom/agenda/formatters/ical_formatter.py
+++ b/newsroom/agenda/formatters/ical_formatter.py
@@ -57,15 +57,17 @@ class iCalFormatter(BaseFormatter):
             event.add("priority", item["priority"])
 
         # calendar as category
-        for calendar in item.get("calendars", []):
+        for calendar in item.get("calendars") or []:
             if calendar.get("name"):
                 event.add("categories", [calendar["name"]])
 
         # dates
         dates = item.get("dates", {})
-        event.add("dtstart", datetime(dates["start"]))
+        start = datetime(dates["start"])
+        event.add("dtstart", start.date() if dates.get("all_day") else start)
         if dates.get("end"):
-            event.add("dtend", datetime(dates["end"]))
+            end = datetime(dates["end"])
+            event.add("dtend", end.date() if dates.get("no_end_time") or dates.get("all_day") else end)
         try:
             rrule = item["event"]["dates"]["recurring_rule"]
             event.add("rrule", get_rrule_kwargs(rrule))

--- a/tests/core/test_ical_formatter.py
+++ b/tests/core/test_ical_formatter.py
@@ -56,7 +56,7 @@ def test_ical_formatter_item(client, app, mocker):
     assert vevent["rrule"].to_ical() == b"FREQ=DAILY;COUNT=3;INTERVAL=1"
 
 
-def test_ical_formatter_failing(client, app):
+def test_ical_formatter_failing():
     with open(
         os.path.join(os.path.dirname(__file__), "../fixtures", "agenda_fixture.json"),
         "r",
@@ -64,3 +64,33 @@ def test_ical_formatter_failing(client, app):
         item = json.load(fixture)
     formatter = iCalFormatter()
     formatter.format_item(item, item_type="agenda")
+
+
+def test_onclusive_all_day():
+    event = {
+        "name": "test",
+        "dates": {
+            "start": "2024-01-01T00:00:00",
+            "end": "2024-01-03T00:00:00",
+            "all_day": True,
+        },
+    }
+    formatter = iCalFormatter()
+    output = formatter.format_item(event, item_type="agenda").decode("utf-8")
+    assert "DTSTART;VALUE=DATE:20240101" in output
+    assert "DTEND;VALUE=DATE:20240103" in output
+
+
+def test_onclusive_no_end_time():
+    event = {
+        "name": "test",
+        "dates": {
+            "start": "2024-01-01T10:00:00",
+            "end": "2024-01-03T00:00:00",
+            "no_end_time": True,
+        },
+    }
+    formatter = iCalFormatter()
+    output = formatter.format_item(event, item_type="agenda").decode("utf-8")
+    assert "DTSTART;VALUE=DATE-TIME:20240101T100000Z" in output
+    assert "DTEND;VALUE=DATE:20240103" in output


### PR DESCRIPTION
- there might be no calendars assigned
- handle all_day and no_end_time properly

CPCN-840

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
