### PR TITLE
fix(api): Use `_id` when creating item instances

### DIFF
--- a/newsroom/navigations/views.py
+++ b/newsroom/navigations/views.py
@@ -74,7 +74,7 @@ async def create(request: Request):
     service = NavigationsService()
 
     creation_data = await prepare_navigation_data(nav_data)
-    creation_data["id"] = service.generate_id()
+    creation_data["_id"] = service.generate_id()
     product_ids = creation_data.pop("products", [])
     created_ids = await service.create([creation_data])
 

--- a/newsroom/section_filters/views.py
+++ b/newsroom/section_filters/views.py
@@ -86,7 +86,7 @@ async def create():
     )
     if section and section.get("search_type"):
         creation_data["search_type"] = section["search_type"]
-    creation_data["id"] = service.generate_id()
+    creation_data["_id"] = service.generate_id()
 
     section_filter_id = await service.create([creation_data])
     return Response({"success": True, "_id": section_filter_id[0]}, 201)

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -184,7 +184,7 @@ async def create(request: Request):
             return Response({"email": [gettext("Email address is already in use")]}, 400)
 
         creation_data = get_updates_from_form(form, on_create=True)
-        creation_data["id"] = ObjectId()
+        creation_data["_id"] = ObjectId()
         new_user = UserResourceModel.model_validate(creation_data)
 
         if is_current_user_company_admin():


### PR DESCRIPTION
### Purpose
Use `_id` instead of `id` when constructing new instances to be saved. Using `id` is causing issues due to changes in the Projection feature now available in core. See related [PR](https://github.com/superdesk/superdesk-core/pull/2706)

