### PR TITLE
Fix(async): DuplicateKeyError in Notifications resources due to Null created Field

### DIFF
--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -300,3 +300,4 @@ class BaseNewsroomApp(SuperdeskEve):
     def init_indexes(self):
         for resource in self.config["DOMAIN"]:
             ensure_mongo_indexes(self, resource)
+        self.async_app.mongo.create_indexes_for_all_resources()

--- a/newsroom/notifications/module.py
+++ b/newsroom/notifications/module.py
@@ -17,13 +17,13 @@ notifications_resource_config = ResourceConfig(
     name="notifications",
     data_class=Notification,
     service=NotificationsService,
-    default_sort=[("created", -1)],
+    default_sort=[("_created", -1)],
     mongo=MongoResourceConfig(
         prefix=MONGO_PREFIX,
         indexes=[
             MongoIndexOptions(
                 name="user_created",
-                keys=[("user", 1), ("created", -1)],
+                keys=[("user", 1), ("_created", -1)],
                 collation={"locale": "en", "strength": 2},
             )
         ],

--- a/newsroom/notifications/services.py
+++ b/newsroom/notifications/services.py
@@ -42,12 +42,9 @@ class NotificationsService(AsyncResourceService[Notification]):
                 creation_data = {
                     "_id": notification_id,
                     "user": ObjectId(doc["user"]),
-                    "item": doc["item"],
-                    "resource": doc.get("resource"),
-                    "action": doc.get("action"),
-                    "data": doc.get("data"),
                 }
-                await self.create([creation_data])
+                doc.update(creation_data)
+                await self.create([doc])
 
             ids.append(notification_id)
 

--- a/newsroom/tests/conftest.py
+++ b/newsroom/tests/conftest.py
@@ -140,6 +140,7 @@ async def app(request):
     async with app.app_context():
         await reset_elastic(app)
         cache.clean()
+        app.init_indexes()
         yield app
 
     # Clean up blueprints, so they can be re-registered

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -93,7 +93,13 @@ async def test_delete_all_notifications(client, service):
     await service.create_or_update(
         [
             TEST_NOTIFICATION,
-            {"item": ObjectId(), "user": TEST_USER, "resource": "test-resource", "action": "test-action"},
+            {
+                "item": ObjectId(),
+                "user": TEST_USER,
+                "resource": "test-resources",
+                "action": "test-action",
+                "created": utcnow() - datetime.timedelta(days=1),
+            },
         ]
     )
 

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -98,7 +98,7 @@ async def test_delete_all_notifications(client, service):
                 "user": TEST_USER,
                 "resource": "test-resources",
                 "action": "test-action",
-                "created": utcnow() - datetime.timedelta(days=1),
+                "_created": utcnow() - datetime.timedelta(days=1),
             },
         ]
     )

--- a/tests/search/fixtures.py
+++ b/tests/search/fixtures.py
@@ -205,14 +205,14 @@ SECTION_FILTERS = [
     {
         "_id": ObjectId("5e65964bf5db68883df561e0"),
         "is_enabled": True,
-        "name": "test",
+        "name": "test1",
         "filter_type": "wire",
         "query": 'NOT genre.code:"AM Service"',
     },
     {
         "_id": ObjectId("5e65964bf5db68883df561e1"),
         "is_enabled": True,
-        "name": "test",
+        "name": "test2",
         "filter_type": "agenda",
         "query": 'NOT calendars.name:"Exclude Me"',
     },


### PR DESCRIPTION
### Purpose
Resolve the DuplicateKeyError caused by a null value in the created field when inserting notifications. Replaced the created field with _created to ensure a valid datetime value is always set.
### What has changed

- Updated the notifications_resource_config to use `_created` instead of `created` for sorting and indexing.
- Modified the `create_or_update` method to set a valid `_created` timestamp if we have.
- Updated test cases to reflect changes, ensuring `datetime` is properly set (e.g., `utcnow() - timedelta(days=1)`).
- Added `app.init_indexes()` to the conftest.py fixture to ensure MongoDB indexes are created during app initialization and before running tests.

### Steps to test

- Run the `test_delete_all_notifications` test case to ensure notifications are created, fetched, and deleted without errors.
- Verify that no `DuplicateKeyError` is raised when creating or updating notifications.
- Ensure notifications are sorted by `_created` in descending order.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
