### PR TITLE
Fix code scanning alert no. 32: Clear-text logging of sensitive information

### DIFF
--- a/newsroom/commands/create_user.py
+++ b/newsroom/commands/create_user.py
@@ -30,10 +30,12 @@ def create_user(email, password, first_name, last_name, is_admin):
     user = get_user_by_email(email)
 
     if user:
-        print("user already exists %s" % str(new_user))
+        sanitized_user = {k: v for k, v in new_user.items() if k != 'password'}
+        print("user already exists %s" % str(sanitized_user))
     else:
-        print("creating user %s" % str(new_user))
+        sanitized_user = {k: v for k, v in new_user.items() if k != 'password'}
+        print("creating user %s" % str(sanitized_user))
         get_resource_service("users").post([new_user])
-        print("user saved %s" % (new_user))
+        print("user saved %s" % (sanitized_user))
 
     return new_user


### PR DESCRIPTION
Fixes [https://github.com/superdesk/newsroom-core/security/code-scanning/32](https://github.com/superdesk/newsroom-core/security/code-scanning/32)

To fix the problem, we need to ensure that sensitive information, such as passwords, is not logged. The best way to achieve this is to create a sanitized version of the `new_user` dictionary that excludes the password before logging it. This way, we maintain the functionality of logging user creation events without exposing sensitive data.

1. Create a copy of the `new_user` dictionary without the password field.
2. Log the sanitized dictionary instead of the original `new_user` dictionary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
