### PR TITLE
improve(cli): Support async commands and wrap in app context

### DIFF
--- a/newsroom/commands/alerts.py
+++ b/newsroom/commands/alerts.py
@@ -1,12 +1,10 @@
-from quart.cli import with_appcontext
-
 from newsroom.company_expiry_alerts import CompanyExpiryAlerts
 from newsroom.monitoring.email_alerts import MonitoringEmailAlerts
+
 from .cli import newsroom_cli
 
 
 @newsroom_cli.command("send_company_expiry_alerts")
-@with_appcontext
 def send_company_expiry_alerts():
     """
     Send expiry alerts for companies which are close to be expired (now + 7 days)
@@ -21,7 +19,6 @@ def send_company_expiry_alerts():
 
 
 @newsroom_cli.command("send_monitoring_schedule_alerts")
-@with_appcontext
 def send_monitoring_schedule_alerts():
     """
     Send monitoring schedule alerts.
@@ -36,7 +33,6 @@ def send_monitoring_schedule_alerts():
 
 
 @newsroom_cli.command("send_monitoring_immediate_alerts")
-@with_appcontext
 def send_monitoring_immediate_alerts():
     """
     Send monitoring immediate alerts.

--- a/newsroom/commands/cli.py
+++ b/newsroom/commands/cli.py
@@ -1,3 +1,3 @@
-from superdesk.commands.async_cli import create_commands_blueprint
+from superdesk.core.cli import create_commands_blueprint
 
 commands_blueprint, newsroom_cli = create_commands_blueprint("newsroom")

--- a/newsroom/commands/content_reset.py
+++ b/newsroom/commands/content_reset.py
@@ -1,11 +1,9 @@
-from quart.cli import with_appcontext
-
 from superdesk.core import get_current_app
+
 from .cli import newsroom_cli
 
 
 @newsroom_cli.command("content_reset")
-@with_appcontext
 def content_reset():
     """Removes all data from 'items' and 'items_versions' indexes/collections.
 

--- a/newsroom/commands/create_user.py
+++ b/newsroom/commands/create_user.py
@@ -1,11 +1,9 @@
 import click
-from bson import ObjectId
-from quart.cli import with_appcontext
-from newsroom.async_utils import run_async_to_sync
+
 from newsroom.users.model import UserResourceModel
 from newsroom.users.service import UsersService
-
 from newsroom.auth import get_user_by_email
+
 from .cli import newsroom_cli
 
 
@@ -15,8 +13,7 @@ from .cli import newsroom_cli
 @click.argument("first_name")
 @click.argument("last_name")
 @click.argument("is_admin", type=bool)
-@with_appcontext
-def create_user(email, password, first_name, last_name, is_admin):
+async def create_user(email, password, first_name, last_name, is_admin):
     """Create a user with given email, password, first_name, last_name and is_admin flag.
 
     If user with given username exists it's noop.
@@ -34,7 +31,6 @@ def create_user(email, password, first_name, last_name, is_admin):
         "user_type": "administrator" if is_admin else "public",
         "is_enabled": True,
         "is_approved": True,
-        "id": ObjectId(),
     }
     new_user = UserResourceModel.from_dict(new_user)
     user = get_user_by_email(email)
@@ -43,7 +39,7 @@ def create_user(email, password, first_name, last_name, is_admin):
         print("User already exists %s" % str(new_user))
     else:
         print("Creating user...")
-        run_async_to_sync(UsersService().create([new_user]))
+        await UsersService().create([new_user])
         print("User created successfully %s" % (new_user.to_dict()))
 
     return new_user

--- a/newsroom/commands/data_updates.py
+++ b/newsroom/commands/data_updates.py
@@ -1,5 +1,5 @@
 import click
-from quart.cli import with_appcontext
+
 from newsroom.data_updates import (
     GenerateUpdate,
     Upgrade,
@@ -12,7 +12,6 @@ from .cli import newsroom_cli
 
 @newsroom_cli.command("data_generate_update")
 @click.option("-r", "--resource", required=True, help="Resource to generate update for")
-@with_appcontext
 def data_generate_update(resource):
     cmd = GenerateUpdate()
     cmd.run(resource)
@@ -43,7 +42,6 @@ def data_generate_update(resource):
     required=False,
     help="Does not mark data updates as done. This can be useful for development.",
 )
-@with_appcontext
 def data_upgrade(data_update_id=None, fake=False, dry=False):
     cmd = Upgrade()
     cmd.run(data_update_id, fake, dry)
@@ -74,7 +72,6 @@ def data_upgrade(data_update_id=None, fake=False, dry=False):
     required=False,
     help="Does not mark data updates as done. This can be useful for development.",
 )
-@with_appcontext
 def data_downgrade(data_update_id=None, fake=False, dry=False):
     cmd = Downgrade()
     cmd.run(data_update_id, fake, dry)

--- a/newsroom/commands/elastic_init.py
+++ b/newsroom/commands/elastic_init.py
@@ -1,12 +1,9 @@
-from quart.cli import with_appcontext
-
 from superdesk.core import get_current_app
 from .cli import newsroom_cli
 
 
 @newsroom_cli.command("elastic_init")
-@with_appcontext
-def elastic_init():
+async def elastic_init():
     """Init elastic index.
 
     It will create index and put mapping. It should run only once so locks are in place.
@@ -19,4 +16,4 @@ def elastic_init():
 
     """
     app = get_current_app()
-    app.data.init_elastic(app)
+    await app.data.init_elastic(app)

--- a/newsroom/commands/elastic_rebuild.py
+++ b/newsroom/commands/elastic_rebuild.py
@@ -1,15 +1,14 @@
-from quart.cli import with_appcontext
 from elasticsearch import exceptions as es_exceptions
 from eve_elastic import get_es
 
 from superdesk.core import get_current_app
 from superdesk.commands.flush_elastic_index import FlushElasticIndex
+
 from .cli import newsroom_cli
 
 
 @newsroom_cli.command("elastic_rebuild")
-@with_appcontext
-def elastic_rebuild():
+async def elastic_rebuild():
     """
     It removes elastic index, creates a new one(s) and index it from mongo.
 
@@ -19,11 +18,15 @@ def elastic_rebuild():
         $ flask newsroom elastic_rebuild
 
     """
+    await run_elastic_rebuild()
+
+
+async def run_elastic_rebuild():
     app = get_current_app()
 
     delete_elastic(app.config["ELASTICSEARCH_INDEX"])
     delete_elastic(app.config["CONTENTAPI_ELASTICSEARCH_INDEX"])
-    FlushElasticIndex().run(sd_index=True, capi_index=True)
+    await FlushElasticIndex().run(sd_index=True, capi_index=True)
 
 
 def delete_elastic(index_prefix: str):

--- a/newsroom/commands/elastic_reindex.py
+++ b/newsroom/commands/elastic_reindex.py
@@ -1,5 +1,4 @@
 import click
-from quart.cli import with_appcontext
 
 from superdesk.core import get_current_app
 from .cli import newsroom_cli
@@ -8,7 +7,6 @@ from .cli import newsroom_cli
 @newsroom_cli.command("elastic_reindex")
 @click.option("-r", "--resource", required=True, help="Resource to reindex")
 @click.option("-s", "--requests-per-second", default=1000, type=int, help="Number of requests per second")
-@with_appcontext
 def elastic_reindex(resource, requests_per_second=1000):
     assert resource in ("items", "agenda", "history")
     return get_current_app().data.elastic.reindex(resource, requests_per_second=requests_per_second)

--- a/newsroom/commands/fix_topic_nested_filters.py
+++ b/newsroom/commands/fix_topic_nested_filters.py
@@ -1,7 +1,6 @@
 from typing import List, Dict, Optional, Any
 from copy import deepcopy
 
-from quart.cli import with_appcontext
 from eve.utils import ParsedRequest
 
 from superdesk.core import json
@@ -13,7 +12,6 @@ from .cli import newsroom_cli
 
 
 @newsroom_cli.command("fix_topic_nested_filters")
-@with_appcontext
 def _fix_topic_nested_filters():
     fix_topic_nested_filters()
 

--- a/newsroom/commands/index_from_mongo.py
+++ b/newsroom/commands/index_from_mongo.py
@@ -1,5 +1,4 @@
 import click
-from quart.cli import with_appcontext
 
 from superdesk.core import get_current_app
 from superdesk.commands.index_from_mongo import IndexFromMongo
@@ -16,14 +15,13 @@ from .cli import newsroom_cli
 @click.option("-c", "--collection", default=None, help="Name of the collection to index")
 @click.option("-t", "--timestamp", default=None, help="Timestamp to start indexing from")
 @click.option("-d", "--direction", type=click.Choice(["older", "newer"]), default="older", help="Direction of indexing")
-@with_appcontext
-def index_from_mongo_period(hours, collection, timestamp, direction):
+async def index_from_mongo_period(hours, collection, timestamp, direction):
     """
     It allows to reindex up to a certain period.
     """
     app = get_current_app()
     print("Checking if elastic index exists, a new one will be created if not")
-    app.data.init_elastic(app)
+    await app.data.init_elastic(app)
     print("Elastic index check has been completed")
 
     if timestamp:
@@ -36,7 +34,6 @@ def index_from_mongo_period(hours, collection, timestamp, direction):
 @click.option("--from", "-f", "collection_name", help="Name of the collection to index")
 @click.option("--all", "all_collections", is_flag=True, help="Index all collections")
 @click.option("--page-size", "-p", default=500, help="Page size for indexing")
-@with_appcontext
 def index_from_mongo(collection_name, all_collections, page_size):
     """Index the specified mongo collection in the specified elastic collection/type.
 

--- a/newsroom/commands/initialize_data.py
+++ b/newsroom/commands/initialize_data.py
@@ -5,13 +5,11 @@ import elasticsearch.exceptions
 
 from collections import OrderedDict
 
-from quart.cli import with_appcontext
-
 from superdesk.core import get_current_app
 from apps.prepopulate.app_initialize import import_file
-from .cli import newsroom_cli
 
-from .elastic_rebuild import elastic_rebuild
+from .cli import newsroom_cli
+from .elastic_rebuild import run_elastic_rebuild
 
 
 logger = logging.getLogger(__name__)
@@ -25,58 +23,57 @@ __entities__: OrderedDict = OrderedDict(
 )
 
 
-class AppInitializeWithDataCommand:
-    def run(self, entity_name=None, force=False, init_index_only=False):
-        logger.info("Starting data initialization")
-        app = get_current_app()
+async def run(entity_name=None, force=False, init_index_only=False):
+    logger.info("Starting data initialization")
+    app = get_current_app()
 
-        data_paths = [
-            path
-            for path in [
-                pathlib.Path(app.config["SERVER_PATH"]).resolve().joinpath("data"),
-                pathlib.Path(__file__).resolve().parent.parent.joinpath("init_data"),
-            ]
-            if path.exists()
+    data_paths = [
+        path
+        for path in [
+            pathlib.Path(app.config["SERVER_PATH"]).resolve().joinpath("data"),
+            pathlib.Path(__file__).resolve().parent.parent.joinpath("init_data"),
         ]
+        if path.exists()
+    ]
 
-        # create indexes in mongo
-        app.init_indexes()
-        # put mapping to elastic
-        try:
-            app.data.init_elastic(app)
-        except elasticsearch.exceptions.TransportError as err:
-            logger.error("Error when initializing elastic %s", err)
+    # create indexes in mongo
+    app.init_indexes()
+    # put mapping to elastic
+    try:
+        await app.data.init_elastic(app)
+    except elasticsearch.exceptions.TransportError as err:
+        logger.error("Error when initializing elastic %s", err)
 
-            if app.config.get("REBUILD_ELASTIC_ON_INIT_DATA_ERROR"):
-                logger.warning("Can't update the mapping, running elastic_rebuild command now.")
-                elastic_rebuild()
-            else:
-                logger.warning("Can't update the mapping, please run elastic_rebuild command.")
+        if app.config.get("REBUILD_ELASTIC_ON_INIT_DATA_ERROR"):
+            logger.warning("Can't update the mapping, running elastic_rebuild command now.")
+            await run_elastic_rebuild()
+        else:
+            logger.warning("Can't update the mapping, please run elastic_rebuild command.")
 
-        if init_index_only:
-            logger.info("Only indexes initialized.")
-            return 0
-
-        if entity_name is None:
-            entity_name = list(__entities__.keys())
-        elif isinstance(entity_name, str):
-            entity_name = [entity_name]
-
-        for name in entity_name:
-            try:
-                (file_name, index_params, do_patch) = __entities__[name]
-                for path in data_paths:
-                    if path.joinpath(file_name).exists():
-                        import_file(name, path, file_name, index_params, do_patch, force)
-                        break
-            except KeyError:
-                continue
-            except Exception as ex:
-                logger.exception(ex)
-                logger.info("Exception loading entity %s", name)
-
-        logger.info("Data import finished")
+    if init_index_only:
+        logger.info("Only indexes initialized.")
         return 0
+
+    if entity_name is None:
+        entity_name = list(__entities__.keys())
+    elif isinstance(entity_name, str):
+        entity_name = [entity_name]
+
+    for name in entity_name:
+        try:
+            (file_name, index_params, do_patch) = __entities__[name]
+            for path in data_paths:
+                if path.joinpath(file_name).exists():
+                    import_file(name, path, file_name, index_params, do_patch, force)
+                    break
+        except KeyError:
+            continue
+        except Exception as ex:
+            logger.exception(ex)
+            logger.info("Exception loading entity %s", name)
+
+    logger.info("Data import finished")
+    return 0
 
 
 @newsroom_cli.command("initialize_data")
@@ -101,8 +98,7 @@ class AppInitializeWithDataCommand:
     required=False,
     help="if True, it only initializes index only",
 )
-@with_appcontext
-def initialize_data(entity_name, force, init_index_only):
+async def initialize_data(entity_name, force, init_index_only):
     """Initialize application with predefined data for various entities.
 
     Loads predefined data (users, ui_config, email_templates, etc..) for instance.
@@ -121,8 +117,8 @@ def initialize_data(entity_name, force, init_index_only):
         $ flask newsroom initialize_data
 
     """
-    cmd = AppInitializeWithDataCommand()
-    cmd.run(
+
+    await run(
         entity_name=entity_name,
         force=force,
         init_index_only=init_index_only,

--- a/newsroom/commands/remove_expired.py
+++ b/newsroom/commands/remove_expired.py
@@ -1,5 +1,5 @@
 import click
-from quart.cli import with_appcontext
+
 import content_api
 
 from .cli import newsroom_cli
@@ -7,7 +7,6 @@ from .cli import newsroom_cli
 
 @newsroom_cli.command("remove_expired")
 @click.option("-m", "--expiry", "expiry_days", required=False, help="Number of days to determine expiry")
-@with_appcontext
 def _remove_expired(expiry_days):
     remove_expired(expiry_days)
 

--- a/newsroom/commands/remove_expired_agenda.py
+++ b/newsroom/commands/remove_expired_agenda.py
@@ -1,5 +1,4 @@
 import click
-from quart.cli import with_appcontext
 import logging
 
 from typing import List, Set, Dict, Any, Generator
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 @newsroom_cli.command("remove_expired_agenda")
 @click.option("-m", "--expiry", "expiry_days", required=False, help="Number of days to determine expiry")
-@with_appcontext
 def remove_expired_agenda(expiry_days=None):
     """Remove expired Agenda items
 

--- a/newsroom/commands/scheduled_notifications.py
+++ b/newsroom/commands/scheduled_notifications.py
@@ -1,5 +1,4 @@
 import click
-from quart.cli import with_appcontext
 
 from newsroom.notifications.send_scheduled_notifications import SendScheduledNotificationEmails
 from .cli import newsroom_cli
@@ -14,8 +13,7 @@ from .cli import newsroom_cli
     required=False,
     help="Runs a schedule if one has not been run for that user's schedule",
 )
-@with_appcontext
-def send_scheduled_notifications(force=False):
+async def send_scheduled_notifications(force=False):
     """
     Send scheduled notifications
 
@@ -24,4 +22,4 @@ def send_scheduled_notifications(force=False):
 
         $ python manage.py send_scheduled_notifications
     """
-    SendScheduledNotificationEmails().run(force)
+    await SendScheduledNotificationEmails().run(force)

--- a/newsroom/commands/schema_migrate.py
+++ b/newsroom/commands/schema_migrate.py
@@ -1,5 +1,4 @@
 import click
-from quart.cli import with_appcontext
 
 from superdesk.core import get_current_app, get_app_config
 from superdesk.lock import lock, unlock
@@ -13,7 +12,6 @@ VERSION_ID = "schema_version"
 
 @newsroom_cli.command("schema_migrate")
 @click.argument("resource_name", required=False)
-@with_appcontext
 def schema_migrate(resource_name=None):
     """Migrate elastic schema if needed, should be triggered on every deploy.
 

--- a/newsroom/web/factory.py
+++ b/newsroom/web/factory.py
@@ -3,7 +3,7 @@ import os
 from newsroom.flask import send_from_directory
 
 from newsroom.auth import get_user
-from newsroom.commands.cli import commands_blueprint, newsroom_cli
+from newsroom.commands.cli import commands_blueprint
 from newsroom.factory import BaseNewsroomApp
 from newsroom.template_filters import (
     datetime_short,
@@ -307,7 +307,6 @@ def get_app(config=None, **kwargs) -> NewsroomWebApp:
     app = NewsroomWebApp(__name__, config=config, **kwargs)
 
     # register newsroom commands group
-    newsroom_cli.set_current_app(app)
     app.register_blueprint(commands_blueprint)
 
     return app


### PR DESCRIPTION
### Purpose
Replace `register_async_command` with standard `command` when registering commands. This enables automatic wrapping of app context and running async in current thread.

### What has changed
1. Use `command` instead of `register_async_command`
2. Convert commands to async functions, and add await where necessary (probably needs further looking into)

Depends on https://github.com/superdesk/superdesk-core/pull/2723
