### PR TITLE
fix(es): Set query_string default in separate config setting

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -477,9 +477,9 @@ NEWS_API_ENABLED = strtobool(env("NEWS_API_ENABLED", "false"))
 # Enables the application of product filtering to image references in the API and ATOM responses
 NEWS_API_IMAGE_PERMISSIONS_ENABLED = strtobool(env("NEWS_API_IMAGE_PERMISSIONS_ENABLED", "false"))
 
-ELASTICSEARCH_SETTINGS.setdefault("settings", {})["query_string"] = {
+ELASTICSEARCH_QUERY_STRING_DEFAULT_PARAMS = {
     # https://discuss.elastic.co/t/configuring-the-standard-tokenizer/8691/5
-    "analyze_wildcard": False
+    "analyze_wildcard": False,
 }
 
 # count above 10k

--- a/newsroom/web/factory.py
+++ b/newsroom/web/factory.py
@@ -3,7 +3,7 @@ import os
 from newsroom.flask import send_from_directory
 
 from newsroom.auth import get_user
-from newsroom.commands.cli import commands_blueprint, newsroom_cli
+from newsroom.commands.cli import commands_blueprint
 from newsroom.factory import BaseNewsroomApp
 from newsroom.template_filters import (
     datetime_short,
@@ -307,7 +307,6 @@ def get_app(config=None, **kwargs) -> NewsroomWebApp:
     app = NewsroomWebApp(__name__, config=config, **kwargs)
 
     # register newsroom commands group
-    newsroom_cli.set_current_app(app)
     app.register_blueprint(commands_blueprint)
 
     return app

--- a/tests/search/test_search_filters.py
+++ b/tests/search/test_search_filters.py
@@ -2,6 +2,7 @@ from pytest import fixture, raises
 from quart import session, json
 from eve.utils import ParsedRequest
 
+from superdesk.core import get_app_config
 from content_api.errors import BadParameterValueError
 
 from newsroom import auth  # noqa
@@ -42,7 +43,7 @@ async def init(app):
 
 async def test_apply_section_filter(client, app):
     async with app.test_request_context("/"):
-        query_string_settings = app.config["ELASTICSEARCH_SETTINGS"]["settings"]["query_string"]
+        query_string_settings = get_app_config("ELASTICSEARCH_QUERY_STRING_DEFAULT_PARAMS")
         session["user"] = ADMIN_USER_ID
         search = SearchQuery()
         service.section = "wire"
@@ -125,7 +126,7 @@ async def test_apply_time_limit_filter(client, app):
 
 async def test_apply_products_filter(client, app):
     def assert_products_query(user_id, args=None, products=None):
-        query_string_settings = app.config["ELASTICSEARCH_SETTINGS"]["settings"]["query_string"]
+        query_string_settings = get_app_config("ELASTICSEARCH_QUERY_STRING_DEFAULT_PARAMS")
         session["user"] = user_id
         search = SearchQuery()
 
@@ -173,7 +174,7 @@ async def test_apply_products_filter(client, app):
 
 
 async def test_apply_request_filter__query_string(client, app):
-    query_string_settings = app.config["ELASTICSEARCH_SETTINGS"]["settings"]["query_string"]
+    query_string_settings = get_app_config("ELASTICSEARCH_QUERY_STRING_DEFAULT_PARAMS")
     search = SearchQuery()
     search.args = {"q": "Sport AND Tennis"}
     service.apply_request_filter(search)


### PR DESCRIPTION
### Purpose
The `ELASTICSEARCH_SETTINGS` config is used for the settings when creating indexes. We're storing `query_string.analyze_wildcard` on this config for use when constructing query_strings from the client, which is an invalid index setting. This causes an exception to be raised when attempting to create a new index.

### What has changed
Use a `ELASTICSEARCH_QUERY_STRING_DEFAULT_PARAMS` config specifically for use when constructing query_strings from clients. This avoid the conflict of uses between the two configs.
