### PR TITLE
avoid dynamic mapping in agenda

### DIFF
--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -152,7 +152,8 @@ class AgendaResource(newsroom.Resource):
     schema["urgency"] = {**planning_schema["urgency"], "mapping": {"type": "keyword"}}
     schema["priority"] = {**planning_schema["priority"], "mapping": {"type": "keyword"}}
     schema["place"] = planning_schema["place"]
-    schema["service"] = planning_schema["anpa_category"]
+    schema["service"] = deepcopy(planning_schema["anpa_category"])
+    schema["service"]["mapping"]["dynamic"] = False
     schema["state_reason"] = {"type": "string"}
 
     # Fields supporting Nested Aggregation / Filtering
@@ -185,6 +186,7 @@ class AgendaResource(newsroom.Resource):
         "type": "list",
         "mapping": {
             "type": "nested",
+            "dynamic": False,
             "include_in_parent": True,  # Enabled so advanced search works across multiple fields
             "properties": {
                 "planning_id": not_analyzed,
@@ -230,7 +232,8 @@ class AgendaResource(newsroom.Resource):
 
     # other searchable fields needed in UI
     schema["calendars"] = events_schema["calendars"]
-    schema["location"] = events_schema["location"]
+    schema["location"] = deepcopy(events_schema["location"])
+    schema["location"]["mapping"]["dynamic"] = False
 
     # update location name to allow exact search and term based searching
     schema["location"]["mapping"]["properties"]["name"] = {"type": "text", "fields": {"keyword": {"type": "keyword"}}}
@@ -246,6 +249,7 @@ class AgendaResource(newsroom.Resource):
         "type": "list",
         "mapping": {
             "type": "nested",
+            "dynamic": False,
             "include_in_parent": True,
             "properties": {
                 "_id": not_analyzed,

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -234,6 +234,7 @@ class AgendaResource(newsroom.Resource):
     schema["calendars"] = events_schema["calendars"]
     schema["location"] = deepcopy(events_schema["location"])
     schema["location"]["mapping"]["dynamic"] = False
+    schema["location"]["mapping"]["properties"]["address"]["dynamic"] = True  # used for location search
 
     # update location name to allow exact search and term based searching
     schema["location"]["mapping"]["properties"]["name"] = {"type": "text", "fields": {"keyword": {"type": "keyword"}}}


### PR DESCRIPTION
we had issue in production where inside location there were all possible translations from openstreetmaps and eventually we hit 1000 fields limit

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
