### PR TITLE
[NHUB-548] Upgrade push endpoints to use async

### DIFF
--- a/e2e/server/newsroom_e2e/module.py
+++ b/e2e/server/newsroom_e2e/module.py
@@ -36,7 +36,7 @@ async def reset_dbs():
 async def populate_resources(request: Request) -> Response:
     json = await request.get_json()
     ids = []
-    user = create_default_user()
+    user = await create_default_user()
     start_user_session(user, True)
 
     app = get_current_app()

--- a/e2e/server/newsroom_e2e/utils.py
+++ b/e2e/server/newsroom_e2e/utils.py
@@ -9,19 +9,19 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from bson import ObjectId
-from flask import current_app as app
 
-from superdesk import get_resource_service
 from newsroom.types import User
+from newsroom.users.service import UsersService
+from tests.core.utils import create_entries_for
 
 USER_ADMIN_ID = ObjectId("445460066f6a58e1c6b11540")
 
 
-def create_default_user() -> User:
-    user_service = get_resource_service("users")
-    user = user_service.find_one(req=None, _id=USER_ADMIN_ID)
+async def create_default_user() -> User:
+    user = await UsersService().find_by_id(USER_ADMIN_ID)
+
     if not user:
-        app.data.insert(
+        await create_entries_for(
             "users",
             [
                 {
@@ -39,6 +39,6 @@ def create_default_user() -> User:
                 }
             ],
         )
-        user = user_service.find_one(req=None, _id=USER_ADMIN_ID)
+        user = await UsersService().find_by_id(USER_ADMIN_ID)
 
-    return user
+    return user.to_dict()

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -1207,7 +1207,7 @@ class AgendaService(BaseSearchService):
 
         return bookmark_users
 
-    def set_delivery(self, wire_item):
+    async def set_delivery(self, wire_item):
         if not wire_item.get("coverage_id"):
             return
 
@@ -1295,7 +1295,7 @@ class AgendaService(BaseSearchService):
             updated_agenda = get_entity_or_404(item.get("_id"), "agenda")
             # Notify agenda to update itself with new details of coverage
             self.enhance_coverage_with_wire_details(parent_coverage, wire_item)
-            push_agenda_item_notification("new_item", item=item)
+            await push_agenda_item_notification("new_item", item=item)
 
             # If published first time, coverage completion will trigger email - not needed now
             if (delivery or {}).get("sequence_no", 0) > 0 and not agenda_updated_notification_sent:

--- a/newsroom/agenda/utils.py
+++ b/newsroom/agenda/utils.py
@@ -3,13 +3,13 @@ from datetime import timedelta
 
 from quart_babel import gettext
 
+from newsroom.companies.companies_async.service import CompanyService
 from superdesk.core import get_app_config
 from planning.common import WORKFLOW_STATE, ASSIGNMENT_WORKFLOW_STATE
 from superdesk.metadata.item import CONTENT_STATE
 
 from newsroom.template_filters import time_short, parse_date, format_datetime
 from newsroom.gettext import get_session_locale
-from newsroom.utils import query_resource
 from newsroom.notifications import push_notification
 
 DAY_IN_MINUTES = 24 * 60 - 1
@@ -276,10 +276,9 @@ def remove_restricted_coverage_info(items):
     return items
 
 
-def push_agenda_item_notification(name, item, **kwargs):
-    restricted_companies = [
-        item["_id"] for item in query_resource("companies", lookup={"restrict_coverage_info": True})
-    ]
+async def push_agenda_item_notification(name, item, **kwargs):
+    cursor = await CompanyService().search({"restrict_coverage_info": True})
+    restricted_companies = [item["_id"] for item in await cursor.to_list_raw()]
 
     if not len(restricted_companies):
         push_notification(name, item=item, **kwargs)

--- a/newsroom/agenda/utils.py
+++ b/newsroom/agenda/utils.py
@@ -3,14 +3,14 @@ from datetime import timedelta
 
 from quart_babel import gettext
 
-from newsroom.companies.companies_async.service import CompanyService
 from superdesk.core import get_app_config
 from planning.common import WORKFLOW_STATE, ASSIGNMENT_WORKFLOW_STATE
 from superdesk.metadata.item import CONTENT_STATE
 
-from newsroom.template_filters import time_short, parse_date, format_datetime
 from newsroom.gettext import get_session_locale
 from newsroom.notifications import push_notification
+from newsroom.companies.companies_async import CompanyService
+from newsroom.template_filters import time_short, parse_date, format_datetime
 
 DAY_IN_MINUTES = 24 * 60 - 1
 TO_BE_CONFIRMED_FIELD = "_time_to_be_confirmed"

--- a/newsroom/notifications/utils.py
+++ b/newsroom/notifications/utils.py
@@ -1,9 +1,9 @@
+import superdesk
 import datetime
 
 from bson import ObjectId
-import superdesk
-
 from typing import Any
+
 from superdesk.utc import utcnow
 from superdesk.flask import session
 from superdesk.core import get_app_config

--- a/newsroom/notifications/utils.py
+++ b/newsroom/notifications/utils.py
@@ -1,9 +1,9 @@
-import superdesk
 import datetime
 
 from bson import ObjectId
 from typing import Any
 
+import superdesk
 from superdesk.utc import utcnow
 from superdesk.flask import session
 from superdesk.core import get_app_config

--- a/newsroom/push/agenda_manager.py
+++ b/newsroom/push/agenda_manager.py
@@ -17,6 +17,9 @@ from .utils import format_qcode_items, get_display_dates, parse_dates, set_dates
 logger = logging.getLogger(__name__)
 
 
+# TODO-ASYNC: revisit when agenda, items and content_api are async
+
+
 class AgendaManager:
     def init_adhoc_agenda(self, planning, agenda):
         """

--- a/newsroom/push/publishing.py
+++ b/newsroom/push/publishing.py
@@ -22,12 +22,14 @@ from .utils import fix_hrefs, fix_updates, get_event_dates, set_dates, validate_
 
 
 logger = logging.getLogger(__name__)
-
 agenda_manager = AgendaManager()
 
 
+# TODO-ASYNC: Revisit when agenda and content_api are async
+
+
 class Publisher:
-    def publish_item(self, doc: Item, original: Item):
+    async def publish_item(self, doc: Item, original: Item):
         """Duplicating the logic from content_api.publish service."""
         set_dates(doc)
 
@@ -83,7 +85,7 @@ class Publisher:
 
         try:
             if doc.get("coverage_id"):
-                agenda_items = get_resource_service("agenda").set_delivery(doc)
+                agenda_items = await get_resource_service("agenda").set_delivery(doc)
                 if agenda_items:
                     [notify_new_agenda_item.delay(item["_id"], check_topics=False) for item in agenda_items]
         except Exception as ex:

--- a/newsroom/users/service.py
+++ b/newsroom/users/service.py
@@ -208,3 +208,12 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
                 return True
 
         return False
+
+    async def find_by_email(self, email: str) -> UserResourceModel | None:
+        """Find a user registry by email
+
+        :param email: Email of user to find
+        :return: ``None`` if user not found, otherwise an instance of ``UserResourceModel``
+        """
+
+        return await self.find_one(email=email)

--- a/newsroom/users/service.py
+++ b/newsroom/users/service.py
@@ -1,10 +1,12 @@
+import pytz
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, date
 from typing import Any, Dict
 
 from quart_babel import gettext
 from werkzeug.exceptions import BadRequest
 
+from newsroom.types import User
 from superdesk.core import get_app_config
 from superdesk.flask import request, abort, session
 from superdesk.utils import is_hashed, get_hash
@@ -189,3 +191,20 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
             await self.elastic.update(item_id, updates)
         except KeyError:
             pass
+
+    @classmethod
+    def user_has_paused_notifications(cls, user: User) -> bool:
+        schedule = user.get("notification_schedule") or {}
+        timezone = pytz.timezone(schedule.get("timezone") or get_app_config("DEFAULT_TIMEZONE") or "UTC")
+        pause_from = schedule.get("pause_from")
+        pause_to = schedule.get("pause_to")
+
+        if pause_from and pause_to:
+            now = datetime.now(timezone).date()
+            pause_from_date = date.fromisoformat(pause_from)
+            pause_to_date = date.fromisoformat(pause_to)
+
+            if pause_from_date <= now <= pause_to_date:
+                return True
+
+        return False

--- a/newsroom/users/service.py
+++ b/newsroom/users/service.py
@@ -192,8 +192,8 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
         except KeyError:
             pass
 
-    @classmethod
-    def user_has_paused_notifications(cls, user: User) -> bool:
+    @staticmethod
+    def user_has_paused_notifications(user: User) -> bool:
         schedule = user.get("notification_schedule") or {}
         timezone = pytz.timezone(schedule.get("timezone") or get_app_config("DEFAULT_TIMEZONE") or "UTC")
         pause_from = schedule.get("pause_from")

--- a/newsroom/users/users.py
+++ b/newsroom/users/users.py
@@ -1,13 +1,8 @@
-import pytz
 import newsroom
 import superdesk
 
-from datetime import datetime, date
-
-from superdesk.core import get_app_config
 from superdesk.flask import request
 from newsroom.products.types import PRODUCT_TYPES
-from newsroom.types import User
 from newsroom.auth import get_user_id, get_user, SessionAuth
 from newsroom.user_roles import UserRole
 
@@ -223,21 +218,7 @@ class UsersService(newsroom.Service):
     Serves mainly as a proxy to the data layer.
     """
 
-    # TODO-ASYNC: migrate these two pending methods below to `.service.UsersService`
-    # and update the references
-
-    def user_has_paused_notifications(self, user: User) -> bool:
-        schedule = user.get("notification_schedule") or {}
-        timezone = pytz.timezone(schedule.get("timezone") or get_app_config("DEFAULT_TIMEZONE") or "UTC")
-        pause_from = schedule.get("pause_from")
-        pause_to = schedule.get("pause_to")
-        if pause_from and pause_to:
-            now = datetime.now(timezone).date()
-            pause_from_date = date.fromisoformat(pause_from)
-            pause_to_date = date.fromisoformat(pause_to)
-            if pause_from_date <= now <= pause_to_date:
-                return True
-        return False
+    # TODO-ASYNC: remove this service once it is not needed at all
 
 
 class AuthUserService(newsroom.Service):

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -367,10 +367,6 @@ async def get_user_dict(use_globals: bool = True) -> dict[str, User]:
     return g.user_dict
 
 
-def get_users_by_email(emails: List[str]):
-    return query_resource("users", lookup={"email": {"$in": emails}})
-
-
 async def get_company_dict(use_globals: bool = True) -> Dict[str, Company]:
     """Get all active companies indexed by _id.
 

--- a/tests/core/test_signup.py
+++ b/tests/core/test_signup.py
@@ -1,4 +1,3 @@
-from typing import Any, Dict
 from unittest import mock
 
 from quart import url_for
@@ -7,9 +6,8 @@ from newsroom.types import CompanyType, Country
 from newsroom.auth import get_auth_user_by_email
 from newsroom.companies.companies_async import CompanyService, CompanyProduct
 from newsroom.products.types import ProductType
-from newsroom.users.service import UsersService
 
-from tests.utils import mock_send_email
+from tests.utils import get_user_by_email, mock_send_email
 
 
 @mock.patch("newsroom.email.send_email", mock_send_email)
@@ -114,11 +112,6 @@ async def test_new_user_signup_fails_if_fields_not_provided(client, app):
     assert "name: This field is required" in txt
     assert "country: This field is required" in txt
     assert "occupation: This field is required" in txt
-
-
-async def get_user_by_email(email: str) -> Dict[str, Any]:
-    new_user = await UsersService().find_one(email=email)
-    return new_user.model_dump(by_alias=True)
 
 
 @mock.patch("newsroom.email.send_email", mock_send_email)

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -663,18 +663,18 @@ async def test_create_user_inherit_sections(users_service):
     assert user.sections is None  # When sections has a `Falsy` value, the parent Company sections will be used
 
 
-async def test_user_has_paused_notifications(app):
+async def test_user_has_paused_notifications():
     user = User(email="foo", user_type="public")
-    assert not get_resource_service("users").user_has_paused_notifications(user)
+    assert not UsersService.user_has_paused_notifications(user)
 
     user["notification_schedule"] = {"pause_from": "2024-01-01", "pause_to": "2024-01-01"}
-    assert not get_resource_service("users").user_has_paused_notifications(user)
+    assert not UsersService.user_has_paused_notifications(user)
 
     user["notification_schedule"] = {"pause_from": "2024-01-01", "pause_to": "2050-01-01"}
-    assert get_resource_service("users").user_has_paused_notifications(user)
+    assert UsersService.user_has_paused_notifications(user)
 
 
-async def test_search_all_users(app, client):
+async def test_search_all_users(client):
     response = await client.get("/users/search?q=")
     users = await response.get_json()
     assert len(users) == 3

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -18,7 +18,7 @@ from newsroom.signals import user_created, user_updated, user_deleted
 from unittest import mock
 
 from tests.core.utils import create_entries_for
-from tests.utils import mock_send_email, login
+from tests.utils import get_user_by_email, mock_send_email, login
 from newsroom.users import UsersService
 
 
@@ -108,7 +108,7 @@ async def test_new_user_has_correct_flags(client):
     )
 
     assert response.status_code == 201
-    user = get_resource_service("users").find_one(req=None, email="newuser@abc.org")
+    user = await get_user_by_email("newuser@abc.org")
     assert not user["is_approved"]
     assert not user["is_enabled"]
 
@@ -240,15 +240,13 @@ async def test_new_user_can_be_deleted(client):
         },
     )
 
-    # print(response.get_data(as_text=True))
-
     assert response.status_code == 201
-    user = get_resource_service("users").find_one(req=None, email="newuser@abc.org")
+    user = await get_user_by_email("newuser@abc.org")
 
     response = await client.delete("/users/{}".format(user["_id"]))
     assert response.status_code == 200
 
-    user = get_resource_service("users").find_one(req=None, email="newuser@abc.org")
+    user = await UsersService().find_by_email("newuser@abc.org")
     assert user is None
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ from typing import Dict, Any
 from os import path
 from quart.testing import QuartClient
 
+from newsroom.users.service import UsersService
 from superdesk.core import get_current_app, get_app_config, json
 from superdesk.flask import url_for
 from superdesk import get_resource_service
@@ -123,3 +124,9 @@ def add_fixture_to_db(resource: str, filename: str):
 
 def get_resource_by_id(resource: str, item_id: str):
     return get_current_app().data.find_one(resource, req=None, _id=item_id)
+
+
+async def get_user_by_email(email: str) -> Dict[str, Any]:
+    new_user = await UsersService().find_by_email(email)
+    assert new_user is not None
+    return new_user.to_dict()


### PR DESCRIPTION
### What has changed
- Update the `push` endpoints to use async resources as much as possible.
- Migrate the last method from old `sync` users service to the new `async` one
- Removed some of the references to old `sync` users service in tests and a couple of more modules 

Resolves: [NHUB-548] 

Note: For future references, this is the second PR for [NHUB-548]. First one was https://github.com/superdesk/newsroom-core/pull/1113 was about refactoring push module.


[NHUB-548]: https://sofab.atlassian.net/browse/NHUB-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ