### PR TITLE
As a NH user I like to know which timeframe has been used as a default filter for the wire search

### DIFF
--- a/assets/globals.d.ts
+++ b/assets/globals.d.ts
@@ -64,6 +64,7 @@ interface IClientConfig {
     collapsed_search_by_default?: boolean;
     show_user_register?: boolean;
     multimedia_website_search_url?: string;
+    show_default_time_frame_label?: boolean;
 }
 
 interface Window {

--- a/assets/interfaces/agenda.ts
+++ b/assets/interfaces/agenda.ts
@@ -1,6 +1,6 @@
 import {AnyAction} from 'redux';
 import {ThunkAction, ThunkDispatch} from 'redux-thunk';
-import {IFilterGroup, IOccurStatus, ISingleItemAction, IResourceItem, ISection, ISubject, TDatetime, IDateFilter} from './common';
+import {IFilterGroup, IOccurStatus, ISingleItemAction, IResourceItem, ISection, ISubject, TDatetime, IDateFilters} from './common';
 import {IAgendaUIConfig} from './configs';
 import {IUser, IUserType} from './user';
 import {ITopic, ITopicFolder} from './topic';
@@ -313,7 +313,7 @@ export interface IAgendaState {
     };
     errors?: {[field: string]: Array<string>};
     loadingAggregations?: boolean;
-    dateFilters?: IDateFilter
+    dateFilters?: IDateFilters;
 }
 
 export type AgendaGetState = () => IAgendaState;

--- a/assets/interfaces/common.ts
+++ b/assets/interfaces/common.ts
@@ -87,3 +87,5 @@ export interface IDateFilter {
     filter?: string;
     query?: string;
 }
+
+export type IDateFilters = Array<IDateFilter>

--- a/assets/search/components/SearchResultsBar/SearchResultTagsList.tsx
+++ b/assets/search/components/SearchResultsBar/SearchResultTagsList.tsx
@@ -8,7 +8,7 @@ import {IFilterGroup, INavigation, ISearchFields, ISearchParams, ITopic, IUser} 
 import {SearchResultTagList} from './SearchResultTagList';
 import {gettext} from 'utils';
 import {getTopicUrl} from 'search/utils';
-import {IDateFilter} from 'interfaces/common';
+import {IDateFilters} from 'interfaces/common';
 
 export interface IProps {
     user: IUser;
@@ -35,7 +35,7 @@ export interface IProps {
 
     saveMyTopic?: (params: ISearchParams) => void;
     deselectMyTopic?: (topicId: ITopic['_id']) => void;
-    dateFilters?: IDateFilter;
+    dateFilters?: IDateFilters;
 }
 
 export function SearchResultTagsList({

--- a/assets/search/components/SearchResultsBar/index.tsx
+++ b/assets/search/components/SearchResultsBar/index.tsx
@@ -75,6 +75,7 @@ interface IOwnProps {
     showTotalLabel?: boolean;
     showSaveTopic?: boolean;
     showSortDropdown?: boolean;
+    showDefaultTimeframeLabel?: boolean;
     totalItems?: number;
     activeTopic: ITopic;
     topicType: ITopic['topic_type'];
@@ -210,14 +211,15 @@ class SearchResultsBarComponent extends React.Component<IProps, IState> {
                                             })
                                         }
                                     </div>
-                                    {(() => {
+                                    {this.props.showDefaultTimeframeLabel && (() => {
                                         if (!(this.props.activeDateFilter?.date_filter == null && defaultDateFilter?.name != null)) {
                                             return null;
                                         }
                                         const dateFilterName = defaultDateFilter.name;
+
                                         return (
                                             <span className='d-flex align-items-center'>
-                                                <span className='popup-text--label'>{gettext('{{dateFilterName}}', {dateFilterName: dateFilterName})}</span>
+                                                <span className='popup-text--label'>{dateFilterName}</span>
     
                                                 <Popup
                                                     placement='right'

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1659,6 +1659,21 @@ article.list {
     }
 }
 
+.popup-text--label {
+    font-size: 0.875rem;
+    color: var(--color-text--muted);
+    line-height: 1.2;
+    margin-inline-end: 8px;
+}
+
+.popup-text--info {
+    font-size: 0.875rem;
+    color: var(--color-text--muted);
+    line-height: 1.2;
+    letter-spacing: 0.02rem;
+    margin: 0;
+}
+
 .text-break {
     overflow-wrap: break-word;
     word-break: break-word;

--- a/assets/ui/components/Popover.tsx
+++ b/assets/ui/components/Popover.tsx
@@ -13,8 +13,8 @@ interface IState {
 }
 
 export class Popup extends React.PureComponent<IProps, IState> {
-    elem: any;
-    referenceElem: any;
+    elem: HTMLElement | undefined;
+    referenceElem: HTMLElement | undefined;
     constructor(props: any) {
         super(props);
 

--- a/assets/ui/components/Popover.tsx
+++ b/assets/ui/components/Popover.tsx
@@ -1,0 +1,58 @@
+import {Placement} from 'popper.js';
+import * as React from 'react';
+import {Popover} from 'reactstrap';
+
+interface IProps {
+    children(toggle: () => void): React.ReactNode;
+    placement: Placement;
+    component: React.ComponentType<{closePopup(): void}>;
+}
+
+interface IState {
+    isOpen: boolean;
+}
+
+export class Popup extends React.PureComponent<IProps, IState> {
+    elem: any;
+    referenceElem: any;
+    constructor(props: any) {
+        super(props);
+
+        this.state = {
+            isOpen: false,
+        };
+
+        this.toggle = this.toggle.bind(this);
+    }
+
+    toggle() {
+        this.setState({
+            isOpen: !this.state.isOpen,
+        });
+    }
+
+    render() {
+        const {component: Component} = this.props;
+
+        return (
+            <>
+                <div
+                    ref={(elem: any) => this.referenceElem = elem}
+                >
+                    {this.props.children(this.toggle)}
+                </div>
+
+                {this.referenceElem && (
+                    <Popover
+                        className="action-popover"
+                        target={this.referenceElem}
+                        isOpen={this.state.isOpen}
+                        placement={this.props.placement ?? 'auto'}
+                    >
+                        <Component closePopup={this.toggle} />
+                    </Popover>
+                )}
+            </>
+        );
+    }
+}

--- a/assets/wire/components/WireApp.tsx
+++ b/assets/wire/components/WireApp.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {get, isEqual} from 'lodash';
 
 import {ISearchSortValue} from 'interfaces';
-import {gettext, DISPLAY_NEWS_ONLY, DISPLAY_ALL_VERSIONS_TOGGLE} from 'utils';
+import {gettext, DISPLAY_NEWS_ONLY, DISPLAY_ALL_VERSIONS_TOGGLE, getConfig} from 'utils';
 import {getSingleFilterValue, searchParamsUpdated} from 'search/utils';
 
 import {
@@ -224,6 +224,7 @@ class WireApp extends SearchBase<any> {
                                             refresh={this.props.fetchItems}
                                             setSortQuery={this.props.setSortQuery}
                                             setQuery={this.props.setQuery}
+                                            showDefaultTimeframeLabel={getConfig('show_default_time_frame_label') ?? true}
                                         />
                                     )
                                 }

--- a/assets/wire/components/filters/NavCreatedPicker.tsx
+++ b/assets/wire/components/filters/NavCreatedPicker.tsx
@@ -3,14 +3,14 @@ import {gettext} from 'utils';
 
 import NavGroup from './NavGroup';
 
-import {IDateFilter} from 'interfaces/common';
+import {IDateFilter, IDateFilters} from 'interfaces/common';
 import {ICreatedFilter} from 'interfaces/search';
 
 interface IProps {
     context: 'wire' | 'agenda';
     createdFilter: ICreatedFilter;
     setCreatedFilter: (createdFilter: ICreatedFilter) => void;
-    dateFilters: IDateFilter[];
+    dateFilters: IDateFilters;
 }
 
 function NavCreatedPicker({setCreatedFilter, createdFilter, context, dateFilters}: IProps) {


### PR DESCRIPTION
NHUB-560

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
- As a NH user I like to know which timeframe has been used as a default filter for the wire search

### What has changed
<!--- Explain what has changed and how -->
- A new Popover component has been created, used for displaying information about default timeframe

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
1. Go to the Wire section
2. Search for some title
- Below the search results, you will see an icon for the popover.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
