### PR TITLE
[NHUB-543] Notifications issues fix

### DIFF
--- a/assets/notifications/components/notificationItems.tsx
+++ b/assets/notifications/components/notificationItems.tsx
@@ -25,33 +25,35 @@ export function renderNotificationComponent(notification: any, item: any) {
 }
 
 function getNotificationFooterText(notification: any) {
+    const createdDatetime = notification._created;
+
     switch (notification.action) {
     case 'share':
         return (
-            isToday(notification.created) ?
+            isToday(createdDatetime) ?
                 gettext('Shared by {{ first_name }} {{ last_name }} at {{ time }}', {
                     first_name: get(notification, 'data.shared_by.first_name'),
                     last_name: get(notification, 'data.shared_by.last_name'),
-                    time: formatTime(notification.created),
+                    time: formatTime(createdDatetime),
                 }) :
                 gettext('Shared by {{ first_name }} {{ last_name }} on {{ date }}', {
                     first_name: get(notification, 'data.shared_by.first_name'),
                     last_name: get(notification, 'data.shared_by.last_name'),
-                    date: formatDate(notification.created),
+                    date: formatDate(createdDatetime),
                 })
         );
     case 'topic_matches':
         return (
-            isToday(notification.created) ?
-                gettext('Created at {{ time }}', {time: formatTime(notification.created)}) :
-                gettext('Created on {{ date }}', {date: formatDate(notification.created)})
+            isToday(createdDatetime) ?
+                gettext('Created at {{ time }}', {time: formatTime(createdDatetime)}) :
+                gettext('Created on {{ date }}', {date: formatDate(createdDatetime)})
         );
     case 'history_match':
     default:
         return (
-            isToday(notification.created) ?
-                gettext('Updated at {{ time }}', {time: formatTime(notification.created)}) :
-                gettext('Updated on {{ date }}', {date: formatDate(notification.created)})
+            isToday(createdDatetime) ?
+                gettext('Updated at {{ time }}', {time: formatTime(createdDatetime)}) :
+                gettext('Updated on {{ date }}', {date: formatDate(createdDatetime)})
         );
     }
 }

--- a/newsroom/notifications/commands.py
+++ b/newsroom/notifications/commands.py
@@ -168,12 +168,11 @@ class SendScheduledNotificationEmails:
         and the current time.
         """
 
-        try:
-            last_run_time_local = utc_to_local(schedule["timezone"], schedule["last_run_time"]).replace(
-                second=0, microsecond=0
-            )
-        except KeyError:
-            last_run_time_local = None
+        last_run_time_local = (
+            utc_to_local(schedule["timezone"], schedule.get("last_run_time")).replace(second=0, microsecond=0)
+            if schedule.get("last_run_time") is not None
+            else None
+        )
 
         if last_run_time_local is None and force:
             return True


### PR DESCRIPTION
### Purpose
Fixes two issues connected with notifications:
- It now renders the popup list of notifications when the bell icon is clicked. The problem was that the `created` attribute is no longer available in the notifications model, instead we now only have `_created` which is now being used. 
- Scheduled notifications should be sent now as the command was failing given a change in the notifications model. We used a try/exception statement relying on the absence of the `last_run_time` but now this is field is really optional and `None` value is set by default, therefore its key being always present once the model instance is serialised as dict. 

We can discuss these fixes more in detail during or after our scrum in case it doesn't feel like the proper fixes.

Thanks for checking!

Belongs to: [NHUB-543]


[NHUB-543]: https://sofab.atlassian.net/browse/NHUB-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ