### PR TITLE
fix(config): Duplicate key error with History resource

### DIFF
--- a/newsroom/history_async.py
+++ b/newsroom/history_async.py
@@ -128,12 +128,9 @@ history_resource_config = ResourceConfig(
         prefix=MONGO_PREFIX,
         indexes=[
             MongoIndexOptions(
-                name="item",
-                keys=[("item", 1)],
-            ),
-            MongoIndexOptions(
                 name="company_user",
-                keys=[("company", 1), ("user", 1), ("item", 1)],
+                keys=[("item", 1), ("company", 1), ("user", 1)],
+                unique=False,
             ),
         ],
     ),


### PR DESCRIPTION
### Purpose
History Mongo index were configured to be unique, and we had 2 indexes when we can just use the 1.

### What has changed
* Remove the "item" index
* Place "item" first in the list of keys for "company_user" index
* Make "company_user" index not unique
