### PR TITLE
fix global topic notifications when creator is deleted

### DIFF
--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -889,8 +889,8 @@ class BaseSearchService(Service):
                 continue
             queried_topics = []
             for topic in topics:
-                user_id = str(topic["user"])
-                if not user_id or str(user["_id"]) != user_id:
+                topic_subscribers = {subscriber["user_id"] for subscriber in topic.get("subscribers") or []}
+                if user["_id"] not in topic_subscribers and str(topic.get("user")) != str(user["_id"]):
                     continue
                 if topic["_id"] in topics_checked:
                     continue
@@ -923,7 +923,7 @@ class BaseSearchService(Service):
                     "Error in get_matching_topics",
                     extra=dict(
                         query=source,
-                        user=user_id,
+                        user=user["_id"],
                     ),
                 )
                 continue

--- a/tests/core/test_push.py
+++ b/tests/core/test_push.py
@@ -945,3 +945,37 @@ def test_matching_topics_when_disabling_section(client, app):
     with app.test_request_context():
         matching = search.get_matching_topics(item["guid"], topics, users, companies)
         assert [] == matching
+
+
+# CPCN-967
+def test_global_topic_after_deleting_user(client, app):
+    add_company_products(
+        app,
+        COMPANY_1_ID,
+        [
+            {
+                "name": "All",
+                "query": "*:*",
+                "is_enabled": True,
+                "product_type": "wire",
+            }
+        ],
+    )
+
+    client.post("/push", json=item)
+    search = get_resource_service("wire_search")
+
+    users = get_user_dict(use_globals=False)
+    companies = get_company_dict(use_globals=False)
+    topics = [
+        {
+            "_id": "all wire",
+            "query": "*:*",
+            "user": None,
+            "topic_type": "wire",
+            "subscribers": [{"user_id": TEST_USER_ID, "notification_type": "real-time"}],
+        },
+    ]
+    with app.test_request_context():
+        matching = search.get_matching_topics(item["guid"], topics, users, companies)
+        assert matching


### PR DESCRIPTION
when user who created topic is deleted the topic.user is set to `None` and previously such topics would be ignored.

CPCN-967

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
