### PR TITLE
[NHUB-565] Upgrade Products resource and endpoints to async

### DIFF
--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -18,7 +18,7 @@ from newsroom.auth.utils import (
     check_user_has_products,
 )
 from newsroom.agenda import blueprint
-from newsroom.products.products import get_products_by_company
+from newsroom.products import get_products_by_company
 from newsroom.topics import get_user_topics
 from newsroom.topics_folders import get_company_folders, get_user_folders
 from newsroom.navigations import get_navigations
@@ -140,7 +140,7 @@ async def get_view_data() -> Dict:
     company_dict = None if not company else company.to_dict()
 
     topics = await get_user_topics(user.id) if user else []
-    products = get_products_by_company(company_dict, product_type="agenda") if company else []
+    products = await get_products_by_company(company_dict, product_type="agenda") if company else []
 
     check_user_has_products(user, products)
     ui_config_service = UiConfigResourceService()

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -30,6 +30,7 @@ from newsroom.email import send_new_signup_email
 from newsroom.limiter import rate_limit
 from newsroom.users import UsersService, UsersAuthService
 from newsroom.companies.companies_async import CompanyService
+from newsroom.products import ProductsService
 
 from .utils import (
     get_user_from_request,
@@ -249,7 +250,8 @@ async def signup(req: Request):
 
         if company_dict is None:
             is_new_company = True
-            enabled_products = get_resource_service("products").get(req=None, lookup={"is_enabled": True})
+            enabled_products = await ProductsService().search({"is_enabled": True})
+
             company_dict = {
                 "name": form.company.data,
                 "contact_name": form.first_name.data + " " + form.last_name.data,
@@ -265,7 +267,7 @@ async def signup(req: Request):
                 "sections": {section["_id"]: True for section in app.sections},
                 "products": [
                     {"_id": product.get("_id"), "seats": 0, "section": product.get("product_type")}
-                    for product in enabled_products
+                    for product in await enabled_products.to_list_raw()
                 ],
             }
             company_dict["_id"] = (await company_service.create([company_dict]))[0]

--- a/newsroom/companies/companies_async/service.py
+++ b/newsroom/companies/companies_async/service.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Iterable, List, Dict, Any
 from copy import deepcopy
 
 from newsroom.types import CompanyResource
@@ -19,7 +19,7 @@ class CompanyService(NewshubAsyncResourceService[CompanyResource]):
         for company in docs:
             company_create.send(self, company=company.to_dict())
 
-    def _get_products(self, updates: Dict[str, Any], original: CompanyResource):
+    def _get_products(self, updates: Dict[str, Any], original: CompanyResource) -> Iterable[dict[str, Any]]:
         """
         Loop over products and checks if any of them is instance of CompanyProduct to
         convert them into dict

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -13,8 +13,9 @@ from superdesk.core.resources.fields import ObjectId as ObjectIdField
 
 from newsroom.auth import auth_rules
 from newsroom.types import AuthProviderConfig
-from newsroom.utils import get_public_user_data, query_resource, get_json_or_400_async
+from newsroom.utils import get_public_user_data, get_json_or_400_async
 from newsroom.ui_config_async import UiConfigResourceService
+from newsroom.products.service import ProductsService
 
 from .module import company_endpoints, company_configs
 from .utils import get_users_by_company
@@ -38,9 +39,9 @@ async def get_settings_data():
 
     ui_config_service = UiConfigResourceService()
     return {
-        "companies": [company async for company in CompanyService().get_all_raw()],
+        "companies": await CompanyService().get_all_raw_as_list(),
         "services": get_app_config("SERVICES"),
-        "products": list(query_resource("products")),
+        "products": await ProductsService().get_all_raw_as_list(),
         "sections": get_current_app().as_any().sections,
         "company_types": get_company_types_options(),
         "api_enabled": get_app_config("NEWS_API_ENABLED", False),

--- a/newsroom/company_expiry_alerts.py
+++ b/newsroom/company_expiry_alerts.py
@@ -75,7 +75,7 @@ class CompanyExpiryAlerts:
                     }
                     logger.info(f"{self.log_msg} Sending to following users of company {company['name']}: {recipients}")
 
-                    async for user in users_cursor.to_list():
+                    for user in await users_cursor.to_list():
                         await send_user_email(
                             user,
                             template="company_expiry_alert_user",

--- a/newsroom/core/resources/service.py
+++ b/newsroom/core/resources/service.py
@@ -49,3 +49,9 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
         """
         cursor = await self.search({"_id": {"$in": ids}})
         return await cursor.to_list()
+
+    async def get_all_raw_as_list(self):
+        """
+        Returns the list of all the entries raw as list
+        """
+        return [entry async for entry in self.get_all_raw()]

--- a/newsroom/core/resources/service.py
+++ b/newsroom/core/resources/service.py
@@ -50,7 +50,7 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
         cursor = await self.search({"_id": {"$in": ids}})
         return await cursor.to_list()
 
-    async def get_all_raw_as_list(self):
+    async def get_all_raw_as_list(self) -> list[dict[str, Any]]:
         """
         Returns the list of all the entries raw as list
         """

--- a/newsroom/core/resources/validators.py
+++ b/newsroom/core/resources/validators.py
@@ -1,7 +1,8 @@
 import re
 import ipaddress
 from typing import Any, Optional
-from pydantic import AfterValidator
+from bson import ObjectId, errors
+from pydantic import AfterValidator, BeforeValidator
 from pydantic_core import PydanticCustomError
 from quart_babel import gettext
 
@@ -116,3 +117,39 @@ def validate_multi_field_iunique_value_async(
             )
 
     return AsyncValidator(_validate_iunique_value)
+
+
+def validate_valid_objectid(field_name: str) -> BeforeValidator:
+    """
+    Creates a validator that processes a single value (str or ObjectId) for a specified field.
+    It attempts to parse a string into `bson.ObjectId` if necessary and raises a validation error
+    if the value is invalid or incompatible with `bson.ObjectId`.
+
+    Args:
+        field_name (str): The name of the field being validated, used in error messages.
+
+    Returns:
+        BeforeValidator: A validator that parses valid ObjectId strings and raises errors for invalid ones.
+
+    Usage:
+        This validator should be used with `typing.Annotated`, preferably placed to the most right side
+        within the `Annotated` parameters list, to ensure it processes after other validators.
+    """
+
+    def _validate_objectid(value: str | ObjectId) -> ObjectId:
+        if isinstance(value, str):
+            try:
+                value = ObjectId(value)
+            except errors.InvalidId:
+                raise PydanticCustomError(
+                    field_name, f"Provided ID '{value}' is not a valid ObjectId for field '{field_name}'."
+                )
+        elif not isinstance(value, ObjectId):
+            raise PydanticCustomError(
+                field_name,
+                f"Wrong value type for ID '{value}' in field '{field_name}': expected 'str' or 'ObjectId'.",
+            )
+
+        return value
+
+    return BeforeValidator(_validate_objectid)

--- a/newsroom/core/resources/validators.py
+++ b/newsroom/core/resources/validators.py
@@ -1,7 +1,8 @@
 import re
 import ipaddress
 from typing import Any, Optional
-from bson import ObjectId, errors
+from bson import ObjectId
+from bson.errors import InvalidId
 from pydantic import AfterValidator, BeforeValidator
 from pydantic_core import PydanticCustomError
 from quart_babel import gettext
@@ -140,7 +141,7 @@ def validate_valid_objectid(field_name: str) -> BeforeValidator:
         if isinstance(value, str):
             try:
                 value = ObjectId(value)
-            except errors.InvalidId:
+            except InvalidId:
                 raise PydanticCustomError(
                     field_name, f"Provided ID '{value}' is not a valid ObjectId for field '{field_name}'."
                 )

--- a/newsroom/monitoring/search.py
+++ b/newsroom/monitoring/search.py
@@ -47,6 +47,7 @@ class MonitoringSearchService(WireSearchService):
         """
 
         if search.company:
+            # TODO-ASYNC: Replace once MonitoringSearch is async
             search.products = get_products_by_company(
                 search.company,
                 search.navigation_ids,

--- a/newsroom/navigations/service.py
+++ b/newsroom/navigations/service.py
@@ -1,5 +1,3 @@
-from superdesk import get_resource_service
-
 from newsroom.types import NavigationModel
 from newsroom.core.resources.service import NewshubAsyncResourceService
 
@@ -14,8 +12,7 @@ class NavigationsService(NewshubAsyncResourceService[NavigationModel]):
         await super().on_delete(doc)
 
         navigation = doc.id
-        products_cursor = await ProductsService().search({"navigations": str(navigation)})
-
+        products_cursor = await ProductsService().search({"navigations": navigation})
         for product in await products_cursor.to_list_raw():
             product["navigations"].remove(navigation)
             await ProductsService().update(product["_id"], product)

--- a/newsroom/navigations/utils.py
+++ b/newsroom/navigations/utils.py
@@ -1,7 +1,7 @@
 from bson import ObjectId
 
 from newsroom.types import Company, Navigation, UserData, UserRole
-from newsroom.products.products import get_products_by_company, get_products_by_user
+from newsroom.products.products import get_products_by_user
 
 from .service import NavigationsService
 
@@ -17,13 +17,15 @@ async def get_navigations(user: UserData | None, company: Company | None, produc
     """
     Returns list of navigations for given user and company
     """
+    from newsroom.products import get_products_by_company
+
     if user and user.get("user_type") == UserRole.ADMINISTRATOR:
         cursor = await NavigationsService().search(lookup={"product_type": product_type})
         return await cursor.to_list_raw()
 
     products = []
     if company:
-        products += get_products_by_company(company, None, product_type, True)
+        products += await get_products_by_company(company, None, product_type, True)
     if user:
         products += get_products_by_user(user, product_type, None)
 

--- a/newsroom/news_api/default_settings.py
+++ b/newsroom/news_api/default_settings.py
@@ -31,7 +31,6 @@ CORE_APPS = [
     "newsroom.news_api.news.item.item",
     "newsroom.news_api.news.search",
     "newsroom.news_api.news.feed",
-    "newsroom.products",
     "newsroom.news_api.api_audit",
     "newsroom.history",
 ]
@@ -44,6 +43,7 @@ MODULES = [
     ("newsroom.settings", dict(register_endpoints=False, register_settings=False)),
     "newsroom.news_api.news.assets",
     "newsroom.news_api.news.atom",
+    "newsroom.products",
 ]
 
 INSTALLED_APPS = []

--- a/newsroom/news_api/news/atom/views.py
+++ b/newsroom/news_api/news/atom/views.py
@@ -17,7 +17,7 @@ from superdesk.etree import to_string
 from newsroom.core import get_current_wsgi_app
 from newsroom.auth.utils import get_company_or_none_from_request
 from newsroom.news_api.utils import check_association_permission
-from newsroom.products.products import get_products_by_company
+from newsroom.products import get_products_by_company
 
 logger = logging.getLogger(__name__)
 atom_endpoints = EndpointGroup("atom", __name__)
@@ -64,7 +64,7 @@ async def get_atom(request: Request):
     # TODO-ASYNC: replace once the service is ready
     response = await get_internal("news/search")
     company = get_company_or_none_from_request(None)
-    products = get_products_by_company(company.to_dict(context={"use_objectid": True}) if company else None)
+    products = await get_products_by_company(company.to_dict(context={"use_objectid": True}) if company else None)
 
     for item in response[0].get("_items"):
         try:

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -119,6 +119,7 @@ class NewsAPINewsService(BaseSearchService):
         )
 
         company = get_company_or_none_from_request(None)
+        # TODO-ASYNC: replace when NewsAPI is async
         products = get_products_by_company(
             company.to_dict(context={"use_objectid": True}) if company else None, product_type="news_api"
         )
@@ -190,6 +191,7 @@ class NewsAPINewsService(BaseSearchService):
                 )
             )
         else:
+            # TODO-ASYNC: replace when NewsAPI is async
             search.products = get_products_by_company(search.company, product_type=search.section)
 
     def prefill_search_args(self, search, req=None):

--- a/newsroom/products/__init__.py
+++ b/newsroom/products/__init__.py
@@ -1,7 +1,6 @@
 from quart_babel import lazy_gettext
 
 import superdesk
-from superdesk.flask import Blueprint
 from superdesk.core.module import Module
 from superdesk.core.app import SuperdeskAsyncApp
 from superdesk.core.mongo import MongoResourceConfig
@@ -12,9 +11,7 @@ from newsroom.types import ProductResourceModel
 
 from . import products
 from .service import ProductsService
-from .views import get_settings_data, products_endpoints
-
-blueprint = Blueprint("products", __name__)
+from .views import get_settings_data, products_endpoints, blueprint  # noqa
 
 
 def init_module(app: SuperdeskAsyncApp):

--- a/newsroom/products/__init__.py
+++ b/newsroom/products/__init__.py
@@ -1,15 +1,41 @@
 from quart_babel import lazy_gettext
+
 import superdesk
 from superdesk.flask import Blueprint
+from superdesk.core.module import Module
+from superdesk.core.app import SuperdeskAsyncApp
+from superdesk.core.mongo import MongoResourceConfig
+from superdesk.core.resources import ResourceConfig
+
+from newsroom import MONGO_PREFIX
+from newsroom.types import ProductResourceModel
 
 from . import products
+from .service import ProductsService
+from .views import get_settings_data, products_endpoints
 
 blueprint = Blueprint("products", __name__)
 
-from . import views  # noqa
 
+def init_module(app: SuperdeskAsyncApp):
+    app.wsgi.settings_app("products", lazy_gettext("Products"), weight=400, data=get_settings_data)
 
-def init_app(app):
+    # TODO-ASYNC: Remove when products is fully async
     products.products_service = products.ProductsService("products", superdesk.get_backend())
-    products.ProductsResource("products", app, products.products_service)
-    app.settings_app("products", lazy_gettext("Products"), weight=400, data=views.get_settings_data)
+    products.ProductsResource("products", app.wsgi, products.products_service)
+
+
+products_resource_config = ResourceConfig(
+    name="products",
+    data_class=ProductResourceModel,
+    service=ProductsService,
+    default_sort=[("name", 1)],
+    mongo=MongoResourceConfig(prefix=MONGO_PREFIX),
+)
+
+module = Module(
+    name="newsroom.products",
+    resources=[products_resource_config],
+    init=init_module,
+    endpoints=[products_endpoints],
+)

--- a/newsroom/products/__init__.py
+++ b/newsroom/products/__init__.py
@@ -11,7 +11,10 @@ from newsroom.types import ProductResourceModel
 
 from . import products
 from .service import ProductsService
-from .views import get_settings_data, products_endpoints, blueprint  # noqa
+from .views import get_settings_data, products_endpoints
+from .utils import get_products_by_company
+
+__all__ = ["get_products_by_company", "ProducsService"]
 
 
 def init_module(app: SuperdeskAsyncApp):

--- a/newsroom/products/products.py
+++ b/newsroom/products/products.py
@@ -109,6 +109,8 @@ def get_product_by_id(
     return product
 
 
+# Obsolete: This method has been migrated to async and it is located under `.utils.py`
+# TODO-ASYNC: remove when everything is async.
 def get_products_by_company(
     company: Optional[Company],
     navigation_ids: Optional[NavigationIds] = None,

--- a/newsroom/products/service.py
+++ b/newsroom/products/service.py
@@ -1,6 +1,57 @@
+import warnings
+
+from typing import Any, Sequence
+
+from bson import ObjectId
+from superdesk.core.resources import AsyncCacheableService
+
 from newsroom.types import ProductResourceModel
+from newsroom.companies.companies_async import CompanyService
 from newsroom.core.resources.service import NewshubAsyncResourceService
 
 
-class ProductsService(NewshubAsyncResourceService[ProductResourceModel]):
-    pass
+class ProductsService(NewshubAsyncResourceService[ProductResourceModel], AsyncCacheableService):
+    cache_lookup = {"is_enabled": True}
+
+    async def create(self, docs: Sequence[ProductResourceModel | dict[str, Any]]) -> list[str]:
+        company_products: dict[ObjectId, Any] = {}
+
+        for doc in docs:
+            if isinstance(doc, ProductResourceModel):
+                doc = doc.to_dict()
+
+            if doc.get("companies"):
+                for company_id in doc["companies"]:
+                    company_products.setdefault(company_id, []).append(doc)
+
+        res = await super().create(docs)
+
+        # TODO-ASYNC: check what is going on with this deprecation
+        if company_products:
+            warnings.warn("Using deprecated product.companies", DeprecationWarning)
+
+        company_service = CompanyService()
+        for company_id, products in company_products.items():
+            company = await company_service.find_by_id(company_id)
+
+            if company:
+                updates = {
+                    "products": company.products or [],
+                }
+                for product in products:
+                    updates["products"].append({"_id": product["_id"], "section": product["product_type"], "seats": 0})
+                await company_service.system_update(company.id, updates)
+
+        return res
+
+    async def on_deleted(self, doc: ProductResourceModel):
+        from newsroom.users import UsersService
+        from newsroom.companies.companies_async import CompanyService
+
+        lookup = {"products._id": doc.id}
+
+        for service in [UsersService(), CompanyService()]:
+            search_cursor = await service.search(lookup)
+            for item in await search_cursor.to_list_raw():
+                updates = {"products": [p for p in item["products"] if p["_id"] != doc.id]}
+                service.system_update(item["_id"], updates)

--- a/newsroom/products/service.py
+++ b/newsroom/products/service.py
@@ -53,5 +53,5 @@ class ProductsService(NewshubAsyncResourceService[ProductResourceModel], AsyncCa
         for service in [UsersService(), CompanyService()]:
             search_cursor = await service.search(lookup)
             for item in await search_cursor.to_list_raw():
-                updates = {"products": [p for p in item["products"] if p["_id"] != doc.id]}
-                service.system_update(item["_id"], updates)
+                updates = {"products": [p for p in item["products"] if str(p["_id"]) != str(doc.id)]}
+                await service.system_update(item["_id"], updates)

--- a/newsroom/products/service.py
+++ b/newsroom/products/service.py
@@ -1,0 +1,5 @@
+from newsroom.core.resources.service import NewshubAsyncResourceService
+
+
+class ProductsService(NewshubAsyncResourceService):
+    pass

--- a/newsroom/products/service.py
+++ b/newsroom/products/service.py
@@ -1,5 +1,6 @@
+from newsroom.types import ProductResourceModel
 from newsroom.core.resources.service import NewshubAsyncResourceService
 
 
-class ProductsService(NewshubAsyncResourceService):
+class ProductsService(NewshubAsyncResourceService[ProductResourceModel]):
     pass

--- a/newsroom/products/utils.py
+++ b/newsroom/products/utils.py
@@ -1,0 +1,47 @@
+from typing import Any
+from newsroom.types import Company, Product, NavigationIds
+from newsroom.utils import parse_objectid
+from .service import ProductsService
+
+
+IdsList = NavigationIds
+
+
+async def get_products_by_company(
+    company: Company | None,
+    navigation_ids: NavigationIds | None = None,
+    product_type: str | None = None,
+    unlimited_only: bool = False,
+) -> list[Product]:
+    """Get the list of products for a company
+
+    :param company: Company
+    :param navigation_ids: List of Navigation Ids
+    :param product_type: Type of the product
+    :param unlimited_only: Include unlimited only products
+    """
+    if company is None:
+        return []
+
+    company_product_ids = [
+        parse_objectid(product["_id"])
+        for product in company.get("products") or []
+        if (product_type is None or product["section"] == product_type)
+        and (not unlimited_only or not product.get("seats"))
+    ]
+
+    if company_product_ids:
+        lookup = get_products_lookup(company_product_ids, navigation_ids)
+        cursor = await ProductsService().search(lookup)
+        return cursor.to_list_raw()
+
+    return []
+
+
+def get_products_lookup(product_ids: IdsList, navigation_ids: IdsList | None) -> dict[str, Any]:
+    lookup = {"_id": {"$in": product_ids}}
+
+    if navigation_ids:
+        lookup["navigations"] = {"$in": navigation_ids}
+
+    return lookup

--- a/newsroom/products/utils.py
+++ b/newsroom/products/utils.py
@@ -33,7 +33,7 @@ async def get_products_by_company(
     if company_product_ids:
         lookup = get_products_lookup(company_product_ids, navigation_ids)
         cursor = await ProductsService().search(lookup)
-        return cursor.to_list_raw()
+        return await cursor.to_list_raw()
 
     return []
 

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -157,7 +157,7 @@ def remove_product_from_company(company: CompanyResource, product_id: ObjectId) 
     return cast(list[ProductRef], company_products), is_update_required
 
 
-def update_company_sections(company: CompanyResource, company_products: list[ProductRef]):
+def update_company_sections(company: CompanyResource, company_products: list[ProductRef]) -> dict[str, bool]:
     sections = company.sections
     for product in company_products:
         if isinstance(product, CompanyProduct):

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -68,22 +68,16 @@ async def search(_a: None, params: SearchParams, _r: None):
     return Response(products)
 
 
-async def convert_ids_or_abort(request: Request, data: dict[str, Any], key: str):
+async def parse_objectid_or_abort(request: Request, value: str | ObjectId) -> ObjectId:
     try:
-        if key in data:
-            data[key] = [ObjectId(str_id) for str_id in data[key]]
+        return ObjectId(value)
     except errors.InvalidId:
-        await request.abort(400, f"Please provide valid {key} ids")
+        await request.abort(400, f"The provided value '{value}' is not a valid ID.")
 
 
 @products_endpoints.endpoint("/products/new", methods=["POST"], auth=[auth_rules.admin_only])
 async def create(request: Request):
     creation_data = await get_json_or_400_async(request)
-
-    # convert navigations and companies ids from string to ObjectId
-    for key in ["companies", "navigations"]:
-        await convert_ids_or_abort(request, creation_data, key)
-
     products = await ProductsService().create([creation_data])
     return Response({"success": True, "_id": products[0]}, 201)
 
@@ -181,8 +175,7 @@ async def update_companies(args: ProductsArgs, _p: None, request: Request):
         await request.abort(404, gettext("Product not found"))
 
     updates = await request.get_json()
-    await convert_ids_or_abort(request, updates, "companies")
-    selected_companies: list[ObjectId] = updates.get("companies") or []
+    selected_companies = [await parse_objectid_or_abort(request, x) for x in updates.get("companies", [])]
     product_ref = get_product_ref(product.to_dict())
 
     async for company in CompanyService().get_all():

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Tuple, cast
+from typing import Tuple, cast
 
 from bson import ObjectId, errors
 from pydantic import BaseModel

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -72,7 +72,7 @@ async def parse_objectid_or_abort(request: Request, value: str | ObjectId) -> Ob
     try:
         return ObjectId(value)
     except errors.InvalidId:
-        await request.abort(400, f"The provided value '{value}' is not a valid ID.")
+        return await request.abort(400, f"The provided value '{value}' is not a valid ID.")
 
 
 @products_endpoints.endpoint("/products/new", methods=["POST"], auth=[auth_rules.admin_only])

--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -551,6 +551,7 @@ class BaseSearchService(Service):
                         search.products += user_products
 
                 # add unlimited (seats=0) company products
+                # TODO-ASYNC: replace once Search is async
                 company_products = get_products_by_company(
                     search.company,
                     search.navigation_ids,

--- a/newsroom/types/__init__.py
+++ b/newsroom/types/__init__.py
@@ -5,7 +5,7 @@ from enum import Enum
 from quart_babel.speaklater import LazyString
 
 from .user_roles import UserRole
-from .products import ProductType, PRODUCT_TYPES
+from .products import ProductType, PRODUCT_TYPES, ProductResourceModel
 from .cards import CardResourceModel, DashboardCardConfig, DashboardCardType, DashboardCardDict
 from .company import CompanyProduct, CompanyResource
 from .navigation import NavigationModel
@@ -52,6 +52,7 @@ __all__ = [
     "NotificationQueue",
     "NotificationTopic",
     "HistoryResourceModel",
+    "ProductResourceModel",
 ]
 
 

--- a/newsroom/types/company.py
+++ b/newsroom/types/company.py
@@ -1,9 +1,10 @@
 from typing import Annotated, Optional
 from datetime import datetime
+from dataclasses import asdict
 
 from superdesk.core.resources import dataclass
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
-from superdesk.core.resources.fields import ObjectId
+from superdesk.core.resources.fields import ObjectId, Field
 
 from newsroom.core.resources import NewshubResourceModel, validate_ip_address, validate_auth_provider
 
@@ -15,6 +16,9 @@ class CompanyProduct:
     _id: Annotated[ObjectId, validate_data_relation_async("products")]
     section: ProductType
     seats: int = 0
+
+    def to_dict(self):
+        return asdict(self)
 
 
 class CompanyResource(NewshubResourceModel):
@@ -28,7 +32,7 @@ class CompanyResource(NewshubResourceModel):
     phone: Optional[str] = None
     country: Optional[str] = None
     expiry_date: Optional[datetime] = None
-    sections: Optional[dict[str, bool]] = None
+    sections: dict[str, bool] = Field(default_factory=dict)
     archive_access: bool = False
     events_only: bool = False
     restrict_coverage_info: bool = False
@@ -40,7 +44,7 @@ class CompanyResource(NewshubResourceModel):
         validate_ip_address(),
     ] = None
 
-    products: Optional[list[CompanyProduct]] = None
+    products: list[CompanyProduct] = Field(default_factory=list)
 
     auth_domain: Optional[str] = None  # Deprecated
     auth_domains: Annotated[Optional[list[str]], validate_iunique_value_async("companies", "auth_domains")] = None

--- a/newsroom/types/products.py
+++ b/newsroom/types/products.py
@@ -1,4 +1,10 @@
 from enum import Enum
+from bson import ObjectId
+from typing import Annotated
+
+from superdesk.core.resources import validators
+from superdesk.core.resources.fields import Field
+from newsroom.core.resources.model import NewshubResourceModel
 
 PRODUCT_TYPES = ["wire", "agenda", "news_api"]
 
@@ -7,3 +13,25 @@ class ProductType(str, Enum):
     WIRE = "wire"
     AGENDA = "agenda"
     NEWS_API = "news_api"
+
+
+class ProductResourceModel(NewshubResourceModel):
+    name: Annotated[
+        str,
+        validators.validate_iunique_value_async(resource_name="products", field_name="name"),
+    ]
+    description: str | None = None
+    sd_product_id: str | None = None
+    query: str | None = None
+    planning_item_query: str | None = None
+    is_enabled: bool = True
+    product_type: ProductType = ProductType.WIRE
+    navigations: list[Annotated[ObjectId, validators.validate_data_relation_async("navigations")]] = Field(
+        default_factory=list
+    )
+
+    # obsolete
+    # TODO: check with the team why it is obsolete
+    companies: list[Annotated[ObjectId, validators.validate_data_relation_async("companies")]] = Field(
+        default_factory=list
+    )

--- a/newsroom/types/products.py
+++ b/newsroom/types/products.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from superdesk.core.resources import validators
 from superdesk.core.resources.fields import Field
 from newsroom.core.resources.model import NewshubResourceModel
+from newsroom.core.resources.validators import validate_multi_field_iunique_value_async
 
 PRODUCT_TYPES = ["wire", "agenda", "news_api"]
 
@@ -18,7 +19,7 @@ class ProductType(str, Enum):
 class ProductResourceModel(NewshubResourceModel):
     name: Annotated[
         str,
-        validators.validate_iunique_value_async(resource_name="products", field_name="name"),
+        validate_multi_field_iunique_value_async("products", ["name", "product_type"]),
     ]
     description: str | None = None
     sd_product_id: str | None = None

--- a/newsroom/types/products.py
+++ b/newsroom/types/products.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from superdesk.core.resources import validators
 from superdesk.core.resources.fields import Field
 from newsroom.core.resources.model import NewshubResourceModel
-from newsroom.core.resources.validators import validate_multi_field_iunique_value_async
+from newsroom.core.resources.validators import validate_multi_field_iunique_value_async, validate_valid_objectid
 
 PRODUCT_TYPES = ["wire", "agenda", "news_api"]
 
@@ -27,12 +27,20 @@ class ProductResourceModel(NewshubResourceModel):
     planning_item_query: str | None = None
     is_enabled: bool = True
     product_type: ProductType = ProductType.WIRE
-    navigations: list[Annotated[ObjectId, validators.validate_data_relation_async("navigations")]] = Field(
-        default_factory=list
-    )
+    navigations: list[
+        Annotated[
+            ObjectId,
+            validators.validate_data_relation_async("navigations"),
+            validate_valid_objectid("navigations"),
+        ]
+    ] = Field(default_factory=list)
 
     # obsolete
     # TODO: check with the team why it is obsolete
-    companies: list[Annotated[ObjectId, validators.validate_data_relation_async("companies")]] = Field(
-        default_factory=list
-    )
+    companies: list[
+        Annotated[
+            ObjectId,
+            validators.validate_data_relation_async("companies"),
+            validate_valid_objectid("companies"),
+        ]
+    ] = Field(default_factory=list)

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -138,7 +138,6 @@ CORE_APPS = [
     "newsroom.wire",
     "newsroom.topics",
     "newsroom.history",
-    "newsroom.products",
     "newsroom.section_filters",
     "newsroom.reports",
     "newsroom.agenda",
@@ -176,6 +175,7 @@ MODULES = [
     "newsroom.history_async",
     "newsroom.company_admin",
     "newsroom.public",
+    "newsroom.products",
 ]
 
 SITE_NAME = "Newshub"

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -117,7 +117,6 @@ BABEL_DEFAULT_TIMEZONE = DEFAULT_TIMEZONE
 BLUEPRINTS = [
     "newsroom.wire",
     "newsroom.design",
-    "newsroom.products",
     "newsroom.reports",
     "newsroom.agenda",
     "newsroom.news_api.api_tokens",

--- a/newsroom/wire/formatters/ninjs2.py
+++ b/newsroom/wire/formatters/ninjs2.py
@@ -17,6 +17,7 @@ class NINJSFormatter2(NINJSFormatter):
 
     def _transform_to_ninjs(self, item):
         company = get_company_or_none_from_request(None)
+        # TODO-ASYNC: replace then formatters are async
         products = get_products_by_company(company.to_dict() if company else None)
         if not check_association_permission(item, products):
             item.pop("associations", None)

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -29,7 +29,7 @@ from newsroom.auth.utils import (
 
 from newsroom.cards import get_card_size, get_card_type, CardsResourceService
 from newsroom.navigations import get_navigations
-from newsroom.products.products import get_products_by_company
+from newsroom.products import get_products_by_company
 from newsroom.wire import blueprint
 from newsroom.wire.utils import update_action_list
 from newsroom.decorator import login_required, admin_only, section, redirect_to_login
@@ -96,7 +96,7 @@ async def get_view_data() -> Dict:
     topics = await get_user_topics(user.id)
     user_folders = await get_user_folders(user, "wire") if user else []
     company_folders = await get_company_folders(company, "wire") if company else []
-    products = get_products_by_company(company_dict, product_type="wire") if company_dict else []
+    products = await get_products_by_company(company_dict, product_type="wire") if company_dict else []
     ui_config_service = UiConfigResourceService()
 
     check_user_has_products(user, products)
@@ -192,7 +192,7 @@ async def get_home_data():
 
     return {
         "cards": cards,
-        "products": get_products_by_company(company_dict) if company else [],
+        "products": await get_products_by_company(company_dict) if company else [],
         "user": str(user.id),
         "userProducts": user_dict.get("products") or [],
         "userType": user.user_type,

--- a/tests/core/test_products.py
+++ b/tests/core/test_products.py
@@ -147,7 +147,7 @@ async def test_gets_all_products(client, app):
     assert 251 == len(data)
 
 
-async def test_assign_products_to_companies(client, app, product, companies):
+async def test_assign_products_to_companies(client, product, companies):
     await test_login_succeeds_for_admin(client)
     await assign_product_to_companies(client, product, companies)
 


### PR DESCRIPTION
### Purpose
Migrate products into new async framework

### What has changed
- Added new resource model and service for products
- Implemented views using new async framework endpoints 
- Added a custom validator to parse and validate proper IDs values 
- Removed references to old resource and service as much as possible

### Pending
- Remove references to old products's model and service from search services 
- Move a couple of helper functions from `products.py` into new `utils.py` and make sure they're all async

> [!IMPORTANT]
> We have a flaky test (`test_delete_all_notifications`) that I will try to fix in a separate PR, probably early next week. 

Thanks for checking!

Resolves: [NHUB-565]


[NHUB-565]: https://sofab.atlassian.net/browse/NHUB-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ