### PR TITLE
Migrate design Blueprint to an EndpointGroup [NHUB-568]

### DIFF
--- a/newsroom/design.py
+++ b/newsroom/design.py
@@ -1,14 +1,25 @@
+from typing import Optional
+from pydantic import BaseModel
 from datetime import datetime, timedelta
-from superdesk.flask import Blueprint, url_for, render_template
 
-blueprint = Blueprint("design", __name__)
+from superdesk.flask import url_for, render_template
+from superdesk.core.web import EndpointGroup
+from superdesk.core.types import Request
+from superdesk.core.module import Module
+
+blueprint = EndpointGroup("design", __name__)
 
 
-@blueprint.route("/design/detail")
-async def detail():
+class RouteArguments(BaseModel):
+    page: Optional[str] = None
+
+
+@blueprint.endpoint("/design/detail", auth=False)
+async def detail(args: None, params: None, req: Request):
     item = {
         "headline": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
         "slugline": "Slugline",
+        "type": "text",
         "byline": "Author byline",
         "versioncreated": datetime.utcnow(),
         "description_html": "<p>IN this exclusive interview, Aussie rock legend Jimmy Barnes reveals how he almost paid the ultimate price for his years of hard living.</p>",  # noqa
@@ -39,11 +50,14 @@ async def detail():
     return await render_template("wire_item.html", item=item, previous_versions=previous_versions)
 
 
-@blueprint.route("/design/")
-async def index():
+@blueprint.endpoint("/design/", auth=False)
+async def index(args: None, params: None, req: Request):
     return await render_template("design_index.html")
 
 
-@blueprint.route("/design/<page>")
-async def page(page):
-    return await render_template("design_%s.html" % page)
+@blueprint.endpoint("/design/<string:page>", auth=False)
+async def page(args: RouteArguments, params: None, req: Request):
+    return await render_template("design_%s.html" % args.page)
+
+
+module = Module(name="newsroom.design", endpoints=[blueprint])

--- a/newsroom/design.py
+++ b/newsroom/design.py
@@ -56,7 +56,7 @@ async def index():
 
 @blueprint.endpoint("/design/<string:page>", auth=False)
 async def page(args: RouteArguments, params: None, req: Request):
-    return await render_template("design_%s.html" % args.page)
+    return await render_template(f"design_{args.page}.html")
 
 
 module = Module(name="newsroom.design", endpoints=[blueprint])

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -175,7 +175,7 @@ MODULES = [
     "newsroom.history_async",
     "newsroom.company_admin",
     "newsroom.public",
-    "newsroom.design"
+    "newsroom.design",
 ]
 
 SITE_NAME = "Newshub"

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -116,7 +116,6 @@ BABEL_DEFAULT_TIMEZONE = DEFAULT_TIMEZONE
 
 BLUEPRINTS = [
     "newsroom.wire",
-    "newsroom.design",
     "newsroom.products",
     "newsroom.reports",
     "newsroom.agenda",
@@ -176,6 +175,7 @@ MODULES = [
     "newsroom.history_async",
     "newsroom.company_admin",
     "newsroom.public",
+    "newsroom.design"
 ]
 
 SITE_NAME = "Newshub"


### PR DESCRIPTION
### Purpose
Migrate design Blueprint to an async EndpointGroup

Resolves: #[NHUB-568](https://sofab.atlassian.net/browse/NHUB-568)


[NHUB-568]: https://sofab.atlassian.net/browse/NHUB-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ