### PR TITLE
[SDESK-7389] Fix sentry/quart integrations

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -453,7 +453,7 @@ rsa==4.9
     #   oauth2client
 s3transfer==0.10.3
     # via boto3
-sentry-sdk[quart]==2.14.0
+sentry-sdk[quart]==1.45.1
     # via -r requirements.txt
 sgmllib3k==1.0.0
     # via feedparser

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -16,7 +16,6 @@ from flask_caching import Cache
 from elasticapm.contrib.flask import ElasticAPM
 from pydantic import ValidationError
 from eve.io.mongo import ensure_mongo_indexes
-import sentry_sdk.integrations
 
 from superdesk.flask import jsonify, request, render_template, g
 from superdesk.storage import AmazonMediaStorage, SuperdeskGridFSMediaStorage

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -10,12 +10,13 @@ import re
 import pathlib
 import importlib
 
-# import sentry_sdk
+import sentry_sdk
 from flask_mail import Mail
 from flask_caching import Cache
 from elasticapm.contrib.flask import ElasticAPM
 from pydantic import ValidationError
 from eve.io.mongo import ensure_mongo_indexes
+import sentry_sdk.integrations
 
 from superdesk.flask import jsonify, request, render_template, g
 from superdesk.storage import AmazonMediaStorage, SuperdeskGridFSMediaStorage
@@ -28,7 +29,7 @@ from superdesk.cache import cache_backend
 from superdesk.core.storage import GridFSMediaStorageAsync
 from superdesk.factory.app import SuperdeskEve
 
-# from sentry_sdk.integrations.quart import QuartIntegration
+from sentry_sdk.integrations.quart import QuartIntegration
 
 import newsroom
 from newsroom.auth.eve_auth import SessionAuth
@@ -287,13 +288,15 @@ class BaseNewsroomApp(SuperdeskEve):
             self.logger.warning("Consider adding regex_url config to resource %s to fix HATEOAS", resource)
 
     def setup_sentry(self):
-        # TODO-ASYNC: Fix sentry/quart integrations
-        pass
-        # if self.config.get("SENTRY_DSN"):
-        #     sentry_sdk.init(
-        #         dsn=self.config["SENTRY_DSN"],
-        #         integrations=[QuartIntegration()],
-        #     )
+        if self.config.get("SENTRY_DSN"):
+            # Given how quart_flask_patch patches things, it makes Sentry SDK to think that flask is installed
+            # mistakenly enabling FlaskIntegration, which breaks QuartIntegration, and preventing sentry from working properly.
+            # https://github.com/pgjones/quart-flask-patch/blob/0.3.0/src/quart_flask_patch/_patch.py#L110
+            # This prevents flask integration from being enabled at all until we're can use a newer version of sentry-sdk where
+            # specific integrations can be disabled https://github.com/getsentry/sentry-python/releases/tag/2.11.0
+            sentry_sdk.integrations._processed_integrations.add("flask")
+
+            sentry_sdk.init(dsn=self.config["SENTRY_DSN"], integrations=[QuartIntegration()])
 
     def _get_apm_environment(self):
         if self.config.get("CLIENT_URL"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ honcho>=1.0.1
 hypercorn>=0.17.3
 PyRTF3>=0.47.5
 xhtml2pdf>=0.2.4
-sentry-sdk[quart]>=1.5.7,<2.15
+sentry-sdk[quart]>=1.5.7,<2.0
 python3-saml>=1.15,<1.17
 google-auth>=2.6,<2.30
 


### PR DESCRIPTION
### Purpose
Fix the integration between Quart and Sentry, particularly the self-hosted sentry that we use internally

### What has changed
- Sentry SDK dependency version has been adjusted to avoid installing newer than `v2.0` versions because of some breaking changes introduced as of that version. Events are now sent to `/envelope` endpoint instead of `/store`. This new `/envelope` endpoint [was implemented on Sentry Server `v10.0`](https://forum.sentry.io/t/csrf-verification-failed-token-was-not-found-or-was-invalid/12177/6) and we're stuck with `v9.0` (here is the info about the change in [v2.0.0](https://github.com/getsentry/sentry-python/releases/tag/2.0.0) . Look for "Removed support for sending events to the /store endpoint").
- Preventing `FlaskIntegration` from being enabled. [Because of `quart_flask_patch` patching](https://github.com/pgjones/quart-flask-patch/blob/0.3.0/src/quart_flask_patch/_patch.py#L110), Sentry SDK thinks Flask is installed, therefore mistakingly enabling its integration and breaking Quart's one. To avoid this and to avoid needing to enable manually the ["auto enabling integrations"](https://github.com/getsentry/sentry-python/blob/1.45.1/sentry_sdk/integrations/__init__.py#L71-L89), I've added "flask" to the `_processed_integrations` so the SDK will skip it. We can get rid of this sort of monkey patch when we move to a newer version of Sentry in the server and use a newer version of the SDK, where we can simply specify what integrations we want to disable.

Thanks for checking!

Resolves: [SDESK-7389]


[SDESK-7389]: https://sofab.atlassian.net/browse/SDESK-7389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ