### PR TITLE
fix agenda search in planning items

### DIFF
--- a/features/web_api/agenda_search.feature
+++ b/features/web_api/agenda_search.feature
@@ -21,7 +21,8 @@ Feature: Agenda Search
                 {"code": "NSW", "name": "New South Wales"}
             ],
             "anpa_category": [
-                {"qcode": "a", "name": "Australian General News"}
+                {"qcode": "e", "name": "Entertainment"},
+                {"qcode": "f", "name": "Finance"}
             ],
             "location": [{
                 "name": "Sydney Harbour Bridge",
@@ -60,7 +61,8 @@ Feature: Agenda Search
             ],
             "urgency": 3,
             "anpa_category": [
-                {"qcode": "e", "name": "Entertainment"}
+                {"qcode": "e", "name": "Entertainment"},
+                {"qcode": "f", "name": "Finance"}
             ],
             "coverages": [{
                 "coverage_id": "plan1_cov1",
@@ -104,7 +106,8 @@ Feature: Agenda Search
             ],
             "urgency": 3,
             "anpa_category": [
-                {"qcode": "e", "name": "Entertainment"}
+                {"qcode": "e", "name": "Entertainment"},
+                {"qcode": "f", "name": "Finance"}
             ],
             "coverages": [{
                 "coverage_id": "plan2_cov1",
@@ -150,7 +153,11 @@ Feature: Agenda Search
                     "label": "Planned",
                     "qcode": "ncostat:int"
                 }
-            }]
+            }],
+            "anpa_category": [
+                {"qcode": "e", "name": "Entertainment"},
+                {"qcode": "f", "name": "Finance"}
+            ]
         }
         """
 
@@ -183,7 +190,7 @@ Feature: Agenda Search
             "place": ["New South Wales", "Victoria"],
             "coverage.coverage_type": ["text", "photo"],
             "urgency": [3],
-            "service": ["Australian General News", "Entertainment"],
+            "service": ["Entertainment", "Finance"],
             "event_type.event_type_filtered.event_type": ["Sports"],
             "sttdepartment.sttdepartment_filtered.sttdepartment": ["Dep1", "Dep2", "Dep3"],
             "sttsubj.sttsubj_filtered.sttsubj": ["Sub1", "Sub2"]
@@ -364,3 +371,8 @@ Feature: Agenda Search
         """
         ["helsinki_event1"]
         """
+
+    @auth @admin
+    Scenario: Search should not match planning items (CPCN-666)
+        When we get "/agenda/search?q=NOT service.name:Finance NOT service.name:Entertainment&date_from=2018-05-28"
+        Then we get list with 0 items

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, Set, Any, Optional, List
 import logging
 from copy import deepcopy
@@ -662,7 +663,27 @@ def _remove_fields(source, fields):
     source["_source"]["exclude"].extend(fields)
 
 
-def planning_items_query_string(query, fields=None):
+def planning_items_query_string(query, fields=None, nested=False):
+    if nested:
+        # when searching nested planning items we need to prefix field names
+        # in query with `planning_items.` otherwise it will never match in nested
+        # field and negative queries eg. NOT service.name:Sport will match all
+        # nested planning items
+        query = re.sub(r'''\b(
+                service\.name|
+                service\.code|
+                subject\.name|
+                subject\.code|
+                headline|
+                slugline|
+                description_text|
+                guid
+            ):''',
+            r'planning_items.\1:',
+            query,
+            flags=re.VERBOSE,
+        )
+
     return query_string(query, fields=fields or ["planning_items.*"])
 
 
@@ -1632,7 +1653,7 @@ class AgendaService(BaseSearchService):
                 "bool": {
                     "should": [
                         self.query_string(query),
-                        nested_query("planning_items", planning_items_query_string(query), name="query"),
+                        nested_query("planning_items", planning_items_query_string(query, nested=True), name="query"),
                     ]
                 },
             }

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -669,7 +669,8 @@ def planning_items_query_string(query, fields=None, nested=False):
         # in query with `planning_items.` otherwise it will never match in nested
         # field and negative queries eg. NOT service.name:Sport will match all
         # nested planning items
-        query = re.sub(r'''\b(
+        query = re.sub(
+            r"""\b(
                 service\.name|
                 service\.code|
                 subject\.name|
@@ -678,8 +679,8 @@ def planning_items_query_string(query, fields=None, nested=False):
                 slugline|
                 description_text|
                 guid
-            ):''',
-            r'planning_items.\1:',
+            ):""",
+            r"planning_items.\1:",
             query,
             flags=re.VERBOSE,
         )


### PR DESCRIPTION
fix planning items nested searching in agenda when using field names in the query.

CPCN-666

### Purpose

Fix a bug when searching events with nested planning items using field names
in the query returns unexpected results.

Searching using top bar in agenda when specifying the field (eg. `q=headline:foo`)
will never match a nested planning item because elastic uses the full field name including
the nested path. Users didn't notice that but when using negative search like `NOT headline:foo`
it would match any planning item because there is never `headline` field, only `planning_items.headline`.

### What has changed

When creating query for nested planning items add `planning_items.` prefix
to fields in the query so the nested query works as expected.

### Steps to test

Search events with planning items using field name in the query.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: CPCN-666
