### PR TITLE
fix agenda search results not visible

### DIFF
--- a/assets/agenda/components/AgendaList.tsx
+++ b/assets/agenda/components/AgendaList.tsx
@@ -122,6 +122,7 @@ interface IStateProps {
     userType: IUserType;
     hiddenGroupsShown: {[dateString: string]: boolean};
     itemTypeFilter: IAgendaState['agenda']['itemType'];
+    activeSortQuery: string;
 }
 
 interface IDispatchProps {
@@ -356,7 +357,7 @@ class AgendaList extends React.Component<IProps, IState> {
                     const isRead = version == null
                         ? this.props.readItems[itemId] != null // event
                         : version === this.props.readItems[itemId]; // planning item
-
+                    
                     return plans.length > 0 ? (
                         <React.Fragment key={`${itemId}--${group.date}`}>
                             {plans.map((plan) => (
@@ -435,7 +436,7 @@ class AgendaList extends React.Component<IProps, IState> {
                 }}
                 onScroll={this.props.onScroll}
             >
-                {groupedItems.length === 1 ?
+                {groupedItems.length === 1 && this.props.activeSortQuery !== '' ?
                     this.renderGroupItems(groupedItems[0], false) :
                     groupedItems.map((group) => (
                         <React.Fragment key={group.date}>
@@ -495,6 +496,7 @@ const mapStateToProps = (state: IAgendaState): IStateProps => ({
     userType: state.userType,
     hiddenGroupsShown: hiddenGroupsShownSelector(state),
     itemTypeFilter: state.agenda?.itemType,
+    activeSortQuery: state.search.activeSortQuery || '',
 });
 
 const mapDispatchToProps: IDispatchProps = {


### PR DESCRIPTION
when there was a search returning single group with only items starting previously it would show an empty list.

CPCN-762

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: CPCN-762