### PR TITLE
Move the searched fields toggle inline with the advanced search pills

### DIFF
--- a/assets/search/components/SearchResultsBar/SearchResultsAdvancedSearchRow.tsx
+++ b/assets/search/components/SearchResultsBar/SearchResultsAdvancedSearchRow.tsx
@@ -150,42 +150,48 @@ export function SearchResultsAdvancedSearchRow({
         body_html: gettext('Body'),
     };
 
+    const fieldSearchTags = (
+        <div className="toggle-button__group toggle-button__group--spaced toggle-button__group--loose" data-test-id='search-results--advanced-fields'>
+            <span
+                key="tag-separator--clear"
+                className="tag-list__separator tag-list__separator--blanc"
+            />
+            <span className="search-result__tags-list-row-helper-text">inside</span>
+            <span
+                key="tag-separator--clear"
+                className="tag-list__separator tag-list__separator--blanc"
+            />
+            {(Object.keys(fieldNameToLabel) as Array<keyof typeof fieldNameToLabel>)
+                .filter((fieldName) => availableFields.includes(fieldName))
+                .map((fieldName) => (
+                    <button
+                        disabled={readonly}
+                        key={fieldName}
+                        data-test-id={`toggle-${fieldName}-button`}
+                        className={classNames(
+                            'toggle-button toggle-button--no-txt-transform toggle-button--small',
+                            {'toggle-button--active': fields.includes(fieldName)}
+                        )}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            toggleAdvancedSearchField(fieldName);
+                            refresh?.();
+                        }}
+                    >
+                        {fieldNameToLabel[fieldName]}
+                    </button>
+                ))
+            }
+        </div>
+    );
+
     return (
         <React.Fragment>
             <SearchResultTagList
                 testId="search-results--advanced-keywords"
                 title={gettext('Search for')}
-                tags={advancedSearchTags}
+                tags={[...advancedSearchTags, fieldSearchTags]}
             />
-            <SearchResultTagList
-                testId="search-results--advanced-fields"
-                secondary={true}
-                title={gettext('inside')}
-            >
-                <div className="toggle-button__group toggle-button__group--spaced toggle-button__group--loose">
-                    {(Object.keys(fieldNameToLabel) as Array<keyof typeof fieldNameToLabel>)
-                        .filter((fieldName) => availableFields.includes(fieldName))
-                        .map((fieldName) => (
-                            <button
-                                disabled={readonly}
-                                key={fieldName}
-                                data-test-id={`toggle-${fieldName}-button`}
-                                className={classNames(
-                                    'toggle-button toggle-button--no-txt-transform toggle-button--small',
-                                    {'toggle-button--active': fields.includes(fieldName)}
-                                )}
-                                onClick={(event) => {
-                                    event.preventDefault();
-                                    toggleAdvancedSearchField(fieldName);
-                                    refresh?.();
-                                }}
-                            >
-                                {fieldNameToLabel[fieldName]}
-                            </button>
-                        ))
-                    }
-                </div>
-            </SearchResultTagList>
         </React.Fragment>
     );
 }

--- a/assets/search/components/SearchResultsBar/SearchResultsAdvancedSearchRow.tsx
+++ b/assets/search/components/SearchResultsBar/SearchResultsAdvancedSearchRow.tsx
@@ -152,7 +152,7 @@ export function SearchResultsAdvancedSearchRow({
 
     const fieldSearchTags = (
         <div className="toggle-button__group toggle-button__group--spaced toggle-button__group--compact" data-test-id='search-results--advanced-fields'>
-            <span className="search-result__tags-list-row-helper-text me-1">inside</span>
+            <span className="search-result__tags-list-row-helper-text me-1">{gettext('inside')}</span>
             {(Object.keys(fieldNameToLabel) as Array<keyof typeof fieldNameToLabel>)
                 .filter((fieldName) => availableFields.includes(fieldName))
                 .map((fieldName) => (

--- a/assets/search/components/SearchResultsBar/SearchResultsAdvancedSearchRow.tsx
+++ b/assets/search/components/SearchResultsBar/SearchResultsAdvancedSearchRow.tsx
@@ -130,7 +130,7 @@ export function SearchResultsAdvancedSearchRow({
         advancedSearchTags.push(
             <button
                 key="tag-clear-button"
-                className='nh-button nh-button--tertiary nh-button--small'
+                className='nh-button nh-button--tertiary nh-button--small me-2'
                 onClick={(event) => {
                     event.preventDefault();
                     clearAdvancedSearchParams();
@@ -151,16 +151,8 @@ export function SearchResultsAdvancedSearchRow({
     };
 
     const fieldSearchTags = (
-        <div className="toggle-button__group toggle-button__group--spaced toggle-button__group--loose" data-test-id='search-results--advanced-fields'>
-            <span
-                key="tag-separator--clear"
-                className="tag-list__separator tag-list__separator--blanc"
-            />
-            <span className="search-result__tags-list-row-helper-text">inside</span>
-            <span
-                key="tag-separator--clear"
-                className="tag-list__separator tag-list__separator--blanc"
-            />
+        <div className="toggle-button__group toggle-button__group--spaced toggle-button__group--compact" data-test-id='search-results--advanced-fields'>
+            <span className="search-result__tags-list-row-helper-text me-1">inside</span>
             {(Object.keys(fieldNameToLabel) as Array<keyof typeof fieldNameToLabel>)
                 .filter((fieldName) => availableFields.includes(fieldName))
                 .map((fieldName) => (


### PR DESCRIPTION
NHUB-580

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
To save space, the toggles should be moved inline with the advanced search result pills. Functionally, they belong together anyway.

### What has changed
<!--- Explain what has changed and how -->
Deleted one row in filter tag section
### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
Activate Advanced Search
<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
