### PR TITLE
[NHUB-575] fix: Filters users by ProductID not working

### DIFF
--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -2,8 +2,8 @@ import re
 import json
 
 from copy import deepcopy
-from typing import Any, Dict, Optional
-from pydantic import BaseModel, field_validator
+from typing import Any, Dict, Optional, Annotated
+from pydantic import BaseModel, field_validator, AliasChoices, Field
 
 from bson import ObjectId
 from quart_babel import gettext
@@ -98,8 +98,10 @@ async def get_view_data():
 
 
 class WhereParam(BaseModel):
-    company: Optional[ObjectIdField] = None
-    products_id: Optional[ObjectIdField] = None
+    company: ObjectIdField | None = None
+    products_id: Annotated[
+        ObjectIdField | None, Field(validation_alias=AliasChoices("products_id", "products._id"))
+    ] = None
 
 
 class ObjectIdListModel(BaseModel):


### PR DESCRIPTION
### Purpose
In the CompanyAdmin page, filtering users by the available Products is not working, it always shows all users.

### What has changed
* The front-end is sending the param as "products._id" not "products_id", so add support for both

Resolves: [NHUB-575](https://sofab.atlassian.net/browse/NHUB-575)


[NHUB-575]: https://sofab.atlassian.net/browse/NHUB-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ