### PR TITLE
Improve error exceptions

### DIFF
--- a/newsroom/core/resources/__init__.py
+++ b/newsroom/core/resources/__init__.py
@@ -1,6 +1,6 @@
 from .model import NewshubResourceModel, NewshubResourceDict
 from .service import NewshubAsyncResourceService
-from .validators import validate_ip_address, validate_auth_provider
+from .validators import validate_ip_address, validate_auth_provider, raise_custom_validation_error
 
 __all__ = [
     "NewshubResourceModel",
@@ -8,4 +8,5 @@ __all__ = [
     "NewshubAsyncResourceService",
     "validate_ip_address",
     "validate_auth_provider",
+    "raise_custom_validation_error",
 ]

--- a/newsroom/core/resources/model.py
+++ b/newsroom/core/resources/model.py
@@ -2,12 +2,18 @@ from typing import Annotated, Optional, TypedDict
 
 from bson import ObjectId
 
-from superdesk.core.resources import ResourceModelWithObjectId
+from superdesk.core.resources import ResourceModelWithObjectId, default_model_config
 from superdesk.core.resources.validators import validate_data_relation_async
 from superdesk.core.resources.fields import ObjectId as ObjectIdField
 
 
+# Use strict models for Newshub resources (except for Agenda & Wire)
+model_config = default_model_config.copy()
+model_config["extra"] = "forbid"
+
+
 class NewshubResourceModel(ResourceModelWithObjectId):
+    model_config = model_config
     original_creator: Annotated[Optional[ObjectIdField], validate_data_relation_async("users")] = None
     version_creator: Annotated[Optional[ObjectIdField], validate_data_relation_async("users")] = None
 

--- a/newsroom/core/resources/validators.py
+++ b/newsroom/core/resources/validators.py
@@ -1,10 +1,11 @@
+from typing import Any, Optional, NoReturn
 import re
 import ipaddress
-from typing import Any, Optional
+
 from bson import ObjectId
 from bson.errors import InvalidId
-from pydantic import AfterValidator, BeforeValidator
-from pydantic_core import PydanticCustomError
+from pydantic import AfterValidator, BeforeValidator, ValidationError
+from pydantic_core import PydanticCustomError, InitErrorDetails
 from quart_babel import gettext
 
 from superdesk.core.app import get_current_async_app
@@ -154,3 +155,21 @@ def validate_valid_objectid(field_name: str) -> BeforeValidator:
         return value
 
     return BeforeValidator(_validate_objectid)
+
+
+def raise_custom_validation_error(resource: str, field_name: str, error_msg: str, input_value: Any) -> NoReturn:
+    """Raise a Pydantic ValidationError so it is caught by our error handlers
+
+    :raises pydantic.ValidationError: With the supplied details
+    """
+
+    raise ValidationError.from_exception_data(
+        resource,
+        [
+            InitErrorDetails(
+                type=PydanticCustomError(field_name, error_msg),
+                loc=(field_name,),
+                input=input_value,
+            )
+        ],
+    )

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -223,6 +223,7 @@ class BaseNewsroomApp(SuperdeskEve):
             Gets the ValidationException error raised from Core framework's models/services, parses and returns it
             to the client in a valid json format.
             """
+            self.logger.exception("Validation Error", exc_info=error)
             errors = parse_validation_error(error)
             return jsonify(errors), 400
 

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -28,6 +28,7 @@ from superdesk.cache import cache_backend
 from superdesk.core.storage import GridFSMediaStorageAsync
 from superdesk.factory.app import SuperdeskEve
 
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.quart import QuartIntegration
 
 import newsroom
@@ -225,12 +226,20 @@ class BaseNewsroomApp(SuperdeskEve):
             errors = parse_validation_error(error)
             return jsonify(errors), 400
 
+        async def handle_any_exception(error: Exception):
+            self.logger.exception("An unhandled exception was raised", exc_info=error)
+            if request and is_json_request(request):
+                return jsonify({"error": str(error), "code": 500}), 500
+            else:
+                return await render_template("500.html"), 500
+
         self.register_error_handler(AssertionError, assertion_error)
         self.register_error_handler(404, render_404)
         self.register_error_handler(403, render_403)
         self.register_error_handler(SuperdeskApiError, superdesk_api_error)
         self.register_error_handler(AuthorizationError, authorization_error)
         self.register_error_handler(ValidationError, handle_validation_error)
+        self.register_error_handler(Exception, handle_any_exception)
 
     def general_setting(
         self,
@@ -290,7 +299,13 @@ class BaseNewsroomApp(SuperdeskEve):
             # specific integrations can be disabled https://github.com/getsentry/sentry-python/releases/tag/2.11.0
             sentry_sdk.integrations._processed_integrations.add("flask")
 
-            sentry_sdk.init(dsn=self.config["SENTRY_DSN"], integrations=[QuartIntegration()])
+            sentry_sdk.init(
+                dsn=self.config["SENTRY_DSN"],
+                integrations=[
+                    QuartIntegration(),
+                    AsyncioIntegration()
+                ]
+            )
 
     def _get_apm_environment(self):
         if self.config.get("CLIENT_URL"):

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -299,13 +299,7 @@ class BaseNewsroomApp(SuperdeskEve):
             # specific integrations can be disabled https://github.com/getsentry/sentry-python/releases/tag/2.11.0
             sentry_sdk.integrations._processed_integrations.add("flask")
 
-            sentry_sdk.init(
-                dsn=self.config["SENTRY_DSN"],
-                integrations=[
-                    QuartIntegration(),
-                    AsyncioIntegration()
-                ]
-            )
+            sentry_sdk.init(dsn=self.config["SENTRY_DSN"], integrations=[QuartIntegration(), AsyncioIntegration()])
 
     def _get_apm_environment(self):
         if self.config.get("CLIENT_URL"):

--- a/newsroom/templates/500.html
+++ b/newsroom/templates/500.html
@@ -1,0 +1,10 @@
+{% extends "layout.html" %}
+
+{% block content %}
+<section class="content">
+    <div class="jumbotron">
+        <h1>{{ gettext("500. Internal server error.") }}</h1>
+        <p class="lead">{{ gettext('An internal server error was raised. Please consult your system administrator for assistance.', url=request.path) }}</p>
+    </div>
+</section>
+{% endblock %}

--- a/newsroom/templates/500.html
+++ b/newsroom/templates/500.html
@@ -4,7 +4,7 @@
 <section class="content">
     <div class="jumbotron">
         <h1>{{ gettext("500. Internal server error.") }}</h1>
-        <p class="lead">{{ gettext('An internal server error was raised. Please consult your system administrator for assistance.', url=request.path) }}</p>
+        <p class="lead">{{ gettext('An internal server error was raised. Please consult your system administrator for assistance.') }}</p>
     </div>
 </section>
 {% endblock %}

--- a/newsroom/topics_folders/folders.py
+++ b/newsroom/topics_folders/folders.py
@@ -1,3 +1,9 @@
+from typing import Sequence, Any
+
+from pymongo.errors import DuplicateKeyError
+from bson import ObjectId
+from quart_babel import gettext
+
 # from superdesk.core.module import SuperdeskAsyncApp
 from superdesk.core.resources import (
     ResourceConfig,
@@ -10,13 +16,25 @@ from superdesk.core.resources import (
 from newsroom import MONGO_PREFIX
 from newsroom.types import TopicFolderResourceModel, UserTopicFoldersResourceModel, CompanyTopicFoldersResourceModel
 from newsroom.auth import auth_rules
-from newsroom.core.resources import NewshubAsyncResourceService
+from newsroom.core.resources import NewshubAsyncResourceService, raise_custom_validation_error
 from newsroom.topics.topics_async import TopicService
 
 # from newsroom.signals import user_deleted
 
 
 class FolderResourceService(NewshubAsyncResourceService[TopicFolderResourceModel]):
+    async def create(self, docs: Sequence[TopicFolderResourceModel | dict[str, Any]]) -> list[str]:
+        try:
+            return await super().create(docs)
+        except DuplicateKeyError:
+            raise_custom_validation_error(TopicFolderResourceModel.__name__, "name", gettext("Name must be unique"), "")
+
+    async def update(self, item_id: str | ObjectId, updates: dict[str, Any], etag: str | None = None) -> None:
+        try:
+            await super().update(item_id, updates, etag)
+        except DuplicateKeyError:
+            raise_custom_validation_error(TopicFolderResourceModel.__name__, "name", gettext("Name must be unique"), "")
+
     async def on_deleted(self, doc):
         await self.delete_many(lookup={"parent": doc.id})
         await TopicService().delete_many(lookup={"folder": doc.id})

--- a/newsroom/wire/service.py
+++ b/newsroom/wire/service.py
@@ -112,7 +112,7 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
         cursor = await self.search(
             NewshubSearchRequest(
                 section=section or self.section,
-                args=WireSearchRequestArgs(bookmarks=[user.id], page_size=0),
+                args=self.search_args_class(bookmarks=[user.id], page_size=0),
             )
         )
         return await cursor.count()
@@ -126,7 +126,7 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
         :returns: The list of WIre items
         """
 
-        cursor = await self.get_items_by_id(item_ids, args=WireSearchRequestArgs(ignore_latest=True))
+        cursor = await self.get_items_by_id(item_ids, args=self.search_args_class(ignore_latest=True))
         items = await cursor.to_list_raw()
         for item in items:
             if item.get("slugline") and item.get("anpa_take_key"):
@@ -328,7 +328,7 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
             request.products = [product]
 
         cursor = await self.search(
-            WireSearchRequestArgs(
+            self.search_args_class(
                 product_ids=[product.id],
                 page_size=size,
                 exclude_embargoed=not get_app_config("DASHBOARD_EMBARGOED") or exclude_embargoed,
@@ -367,7 +367,7 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
         search_request = NewshubSearchRequest(
             section=self.section,
             web_request=None,
-            args=WireSearchRequestArgs(ids=item_ids, ignore_latest=True),
+            args=self.search_args_class(ids=item_ids, ignore_latest=True),
             search=ESQuery(),
         )
         filters: list[SearchFilterFunction] = [
@@ -454,7 +454,7 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
             NewshubSearchRequest(
                 section=cast(SectionEnum | None, product.product_type) or self.section or SectionEnum.WIRE,
                 products=[product],
-                args=WireSearchRequestArgs(page_size=0),
+                args=self.search_args_class(page_size=0),
                 search=ESQuery(aggs=aggs),
             ),
             filters=[

--- a/tests/core/test_topics.py
+++ b/tests/core/test_topics.py
@@ -4,7 +4,6 @@ from quart import json
 from unittest import mock
 from copy import deepcopy
 from bson import ObjectId
-import pymongo
 
 from newsroom.types import UserResourceModel, TopicResourceModel, SectionEnum
 from newsroom.topics.views import get_topic_url
@@ -314,47 +313,29 @@ async def test_topic_folders_unique_validation(client):
     assert 201 == resp.status_code, await resp.get_data(as_text=True)
 
     # second one should raise DuplicateKeyError
-    try:
-        resp = await client.post(user_topic_folders_url, json=folder)
-    except pymongo.errors.DuplicateKeyError:
-        # assert that the DuplicateKeyError occurred as expected
-        print("DuplicateKeyError for user topic folder as expected")
-    else:
-        # If no exception is raised, fail the test
-        assert False, "Expected DuplicateKeyError for user topic folder, but got success"
+    resp = await client.post(user_topic_folders_url, json=folder)
+    assert resp.status_code == 400, await resp.get_data(as_text=True)
+    assert await resp.get_json() == {"name": "Name must be unique"}
 
     # create company topic with same name
-    print("URL=")
-    print(company_topic_folders_url)
     resp = await client.post(company_topic_folders_url, json=folder)
     assert 201 == resp.status_code, await resp.get_data(as_text=True)
 
     # second one should raise DuplicateKeyError for company topic
-    try:
-        resp = await client.post(company_topic_folders_url, json=folder)
-    except pymongo.errors.DuplicateKeyError:
-        # assert that the DuplicateKeyError occurred as expected
-        print("DuplicateKeyError for company topic folder as expected")
-    else:
-        # If no exception is raised, fail the test
-        assert False, "Expected DuplicateKeyError for company topic folder, but got success"
+    resp = await client.post(company_topic_folders_url, json=folder)
+    assert resp.status_code == 400, await resp.get_data(as_text=True)
+    assert await resp.get_json() == {"name": "Name must be unique"}
 
     # check case-insensitive uniqueness for user topic
     folder["name"] = "Test"
-    try:
-        resp = await client.post(user_topic_folders_url, json=folder)
-    except pymongo.errors.DuplicateKeyError:
-        print("DuplicateKeyError for case-insensitive user topic folder as expected")
-    else:
-        assert False, "Expected DuplicateKeyError for case-insensitive user topic folder, but got success"
+    resp = await client.post(user_topic_folders_url, json=folder)
+    assert resp.status_code == 400, await resp.get_data(as_text=True)
+    assert await resp.get_json() == {"name": "Name must be unique"}
 
     # check case-insensitive uniqueness for company topic
-    try:
-        resp = await client.post(company_topic_folders_url, json=folder)
-    except pymongo.errors.DuplicateKeyError:
-        print("DuplicateKeyError for case-insensitive company topic folder as expected")
-    else:
-        assert False, "Expected DuplicateKeyError for case-insensitive company topic folder, but got success"
+    resp = await client.post(company_topic_folders_url, json=folder)
+    assert resp.status_code == 400, await resp.get_data(as_text=True)
+    assert await resp.get_json() == {"name": "Name must be unique"}
 
 
 async def test_topic_subscriber_auto_enable_user_emails(app, client, navigation_items):


### PR DESCRIPTION
### Purpose
When an uncaught exception was raised, another exception `TypeError: get_headers() takes from 1 to 2 positional arguments but 3 were given` was raised.

### What has changed
* Add a catch all other exception handler, so we can control more the error handling across all error types (this is a big hammer to fix above exception, but I could not find the root cause).
* Add a 500.html template and use that to show InternalServerError to the user
* Add `AsyncioIntegration` to Sentry
* Also fixed an issue in the Monitoring app raising an exception when getting the bookmark count, causing the page to crash
* Log the validation error, so we can debug where it happens (we should really separate out UserValidation and SystemValidation errors. i.e. is validation from the request data or data constructed from code)
* Use strict model fields in most of Newshub resources (as we've proved it works so far in Newshub)
* Raise pydantic.ValidationError for Topic Folder name (we're using the MongoDB index to raise the exception for us, so catch it and re-raise it)

Resolves: [NHUB-572](https://sofab.atlassian.net/browse/NHUB-572)


[NHUB-572]: https://sofab.atlassian.net/browse/NHUB-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ