### PR TITLE
[NHUB-570] fix(types): Make MonitoringProfile schedule optional

### DIFF
--- a/newsroom/monitoring/email_alerts.py
+++ b/newsroom/monitoring/email_alerts.py
@@ -185,6 +185,11 @@ class MonitoringEmailAlerts:
         yesterday: datetime,
         last_week: datetime,
     ):
+        if profile.schedule is None:
+            # This should not happen, as we're filtering specifically for monitoring profiles with a schedule
+            # but the schedule is optional, and the type dictates it could be `None`, so trap that scenario here
+            return
+
         last_run_time = parse_date_str(profile.last_run_time) if profile.last_run_time else None
         default_timezone = get_app_config("DEFAULT_TIMEZONE")
         if last_run_time:
@@ -263,6 +268,11 @@ class MonitoringEmailAlerts:
         companies_service = CompanyServiceAsync()
 
         for monitoring_data in monitoring_list:
+            if monitoring_data.schedule is None:
+                # This should not happen, as we're filtering specifically for monitoring profiles with a schedule
+                # but the schedule is optional, and the type dictates it could be `None`, so trap that scenario here
+                continue
+
             if monitoring_data.users and len(monitoring_data.users):
                 users = await users_service.find_items_by_ids(monitoring_data.users)
                 company = (

--- a/newsroom/types/monitoring.py
+++ b/newsroom/types/monitoring.py
@@ -32,7 +32,7 @@ class MonitoringProfileResourceModel(NewshubResourceModel):
     alert_type: str | None = None
     is_enabled: bool = True
     users: list[ObjectId] | None = None
-    schedule: MonitoringSchedule
+    schedule: MonitoringSchedule | None = None
     keywords: list[str] | None = None
     last_run_time: datetime | None = None
     format_type: str | None = None


### PR DESCRIPTION
### Purpose
Make MonitoringProfile schedule optional, as pydantic was raising validation errors when it is `None`

Resolves: [NHUB-570](https://sofab.atlassian.net/browse/NHUB-570)


[NHUB-570]: https://sofab.atlassian.net/browse/NHUB-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ