### PR TITLE
[STTNHUB-379] fix: Planning items not shown in event preview with AGENDA_DEFAULT_FILTER_HIDE_PLANNING config

### DIFF
--- a/assets/agenda/actions.ts
+++ b/assets/agenda/actions.ts
@@ -335,7 +335,7 @@ function setListGroupsAndLoadHiddenItems(items: Array<IAgendaItem>, next?: boole
 
         // If there are groups shown, then load the hidden items for those groups
         const state = getState();
-        const {activeGrouping, featuredOnly} = state.agenda;
+        const {activeGrouping, featuredOnly, itemType} = state.agenda;
         const {fromDate, toDate, searchParams} = getAgendaSearchParamsFromState(state);
 
         let minDate: moment.Moment | undefined;
@@ -376,7 +376,7 @@ function setListGroupsAndLoadHiddenItems(items: Array<IAgendaItem>, next?: boole
         }
 
         const groups: Array<IAgendaListGroup> = (searchParams.sortQuery ?? '') === '' ?
-            groupItems(items, minDate, maxDate, activeGrouping, featuredOnly) :
+            groupItems(items, minDate, maxDate, activeGrouping, featuredOnly, itemType) :
             [{
                 date: '',
                 items: items.map((item) => item._id),

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -1,7 +1,15 @@
 import {get, isEmpty, keyBy, sortBy} from 'lodash';
 import moment from 'moment/moment';
 
-import {IAgendaItem, IPlanningItem, IAgendaListGroup, IAgendaListGroupItem, ICoverage, IUser} from 'interfaces';
+import {
+    IAgendaItem,
+    IPlanningItem,
+    IAgendaListGroup,
+    IAgendaListGroupItem,
+    ICoverage,
+    IUser,
+    IAgendaState
+} from 'interfaces';
 import {
     formatDate,
     formatMonth,
@@ -701,8 +709,12 @@ export function groupItems(
     minDate: moment.Moment | undefined,
     maxDate: moment.Moment | undefined,
     activeGrouping: string,
-    featuredOnly?: boolean
+    featuredOnly?: boolean,
+    itemTypeFilter?: IAgendaState['agenda']['itemType']
 ): Array<IAgendaListGroup> {
+    const excludePlanningExtraDates = (itemTypeFilter == null || itemTypeFilter === 'events') &&
+        window.newsroom.client_config.agenda_default_filter_hide_planning === true;
+
     if (items.length === 0) {
         return [];
     }
@@ -719,7 +731,7 @@ export function groupItems(
             item._hits?.matched_coverages?.length
         ))
         .forEach((item) => {
-            const itemExtraDates = getExtraDates(item);
+            const itemExtraDates = excludePlanningExtraDates ? [] : getExtraDates(item);
             const itemStartDate = getStartDate(item);
             let start: moment.Moment;
 

--- a/assets/globals.d.ts
+++ b/assets/globals.d.ts
@@ -65,6 +65,7 @@ interface IClientConfig {
     show_user_register?: boolean;
     multimedia_website_search_url?: string;
     show_default_time_frame_label?: boolean;
+    agenda_default_filter_hide_planning: boolean;
 }
 
 interface Window {

--- a/assets/tests.ts
+++ b/assets/tests.ts
@@ -94,6 +94,7 @@ window.newsroom = {
         },
         system_alert_recipients: '',
         wire_time_limit_days: 0,
+        agenda_default_filter_hide_planning: false,
     },
 };
 

--- a/newsroom/agenda/__init__.py
+++ b/newsroom/agenda/__init__.py
@@ -83,3 +83,7 @@ def init_app(app):
 
     if app.config.get("AGENDA_HIDE_COVERAGE_ASSIGNEES"):
         PRIVATE_FIELDS.extend(["*.assigned_desk_*", "*.assigned_user_*"])
+
+    app.config["CLIENT_CONFIG"]["agenda_default_filter_hide_planning"] = app.config.get(
+        "AGENDA_DEFAULT_FILTER_HIDE_PLANNING", False
+    )

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -993,7 +993,7 @@ class AgendaService(BaseSearchService):
                     },
                 }
             )
-            _remove_fields(search.source, ["planning_items", "display_dates"])
+            _remove_fields(search.source, ["display_dates"])
         else:
             # Don't include Planning items that are associated with an Event
             search.query["bool"]["filter"].append(


### PR DESCRIPTION
### Purpose
When AGENDA_DEFAULT_FILTER_HIDE_PLANNING config is enabled, no Planning item's are being displayed in the preview of an Event when in the "Events & Coverages" filter.

### What has changed
* Make sure the back-end includes the `planning_items` attribute on the Event
* Expose the `AGENDA_DEFAULT_FILTER_HIDE_PLANNING` back-end config to the front-end
* If item type filter is `Events & Coverages` and `AGENDA_DEFAULT_FILTER_HIDE_PLANNING` config is on, then don't include extra dates from planning items for showing in the list (only show the top level Event).

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: [STTNHUB-379](https://sofab.atlassian.net/browse/STTNHUB-379)


[STTNHUB-379]: https://sofab.atlassian.net/browse/STTNHUB-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ