### PR TITLE
[NHUB-595] fix(celery): Dont use async for task.apply_async in celery beat

### DIFF
--- a/newsroom/celery_app.py
+++ b/newsroom/celery_app.py
@@ -20,7 +20,13 @@ import newsroom
 from celery import Celery
 from celery.worker.request import Request
 
-from superdesk.celery_app import __get_redis, HybridAppContextTask, ContextAwareSerializerFactory
+from superdesk.celery_app import (
+    __get_redis,
+    IS_BEAT_PROCESS,
+    HybridAppContextTask,
+    HybridAppContextWorkerTask,
+    ContextAwareSerializerFactory,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -50,7 +56,10 @@ class NewsroomRequest(Request):
         logger.warning("Failure detected for task %s", self.task.name)
 
 
-class NewsroomContextTask(HybridAppContextTask):
+BaseTaskClass: type[HybridAppContextTask] = HybridAppContextTask if IS_BEAT_PROCESS else HybridAppContextWorkerTask
+
+
+class NewsroomContextTask(BaseTaskClass):
     serializer = "newsroom/json"
     Request = NewsroomRequest
 
@@ -59,8 +68,7 @@ class NewsroomContextTask(HybridAppContextTask):
         return get_newsroom_web_app()
 
 
-celery = Celery(__name__)
-celery.Task = NewsroomContextTask
+celery = Celery(__name__, task_cls=NewsroomContextTask)
 
 
 def init_celery(app):


### PR DESCRIPTION
### Purpose
Celery beat is not awaiting the result of task.apply_async, and the task doesn't get scheduled to the event queue properly (therefor the task does not get sent to a worker process).

### What has changed
* Use a variation of our ``HybridAppContextTask`` that provides the original `apply_async` sync method from celery, while using our async version for celery worker and ASGI processes

### Steps to test
* Run Newshub using honcho, and you should:
    * not see `RuntimeWarning: coroutine 'HybridAppContextTask.apply_async' was never awaited` in the beat logs
    * see the commands running in the worker logs (such as `Scheduled Notifications: Starting to send scheduled notifications` or `Monitoring Scheduled Alerts: Starting to send alerts`)

Depends on: https://github.com/superdesk/superdesk-core/pull/2754
Resolves: [NHUB-595](https://sofab.atlassian.net/browse/NHUB-595)

[NHUB-595]: https://sofab.atlassian.net/browse/NHUB-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ