### PR TITLE
[NHUB-564] fix(ws): topic_matches message not including topic ids

### DIFF
--- a/features/web_api/agenda_push.feature
+++ b/features/web_api/agenda_push.feature
@@ -93,3 +93,42 @@ Feature: Agenda Push
             }]
         }
         """
+
+    @auth @admin @notification
+    Scenario: Websocket notifications sent on agenda topic matches
+        When we post json to "users/#CONTEXT_USER_ID#/topics"
+        """
+        {
+            "label": "Weather",
+            "subscribers": [{"user_id": "#CONTEXT_USER_ID#", "notification_type": "real-time"}],
+            "is_global": false,
+            "topic_type": "agenda",
+            "query": "weather"
+        }
+        """
+        Then we get OK response
+        And we store "TOPIC_ID" with item id
+        When we post json to "/push"
+        """
+        {
+            "guid": "event1", "type": "event", "state": "scheduled", "pubstatus": "usable",
+            "slugline": "weather",
+            "name": "The weather is happening somewhere",
+            "dates": {
+                "start": "2050-05-28T03:00:00+0000",
+                "end": "2050-05-28T04:00:00+0000",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get OK response
+        And we get notifications
+        """
+        [{
+            "event": "topic_matches",
+            "extra": {
+                "item": {"_id": "event1"},
+                "topics": ["#TOPIC_ID#"]
+            }
+        }]
+        """

--- a/features/web_api/wire_push.feature
+++ b/features/web_api/wire_push.feature
@@ -1,0 +1,36 @@
+Feature: Wire Push
+    @auth @admin @notification
+    Scenario: Websocket notifications sent on wire topic matches
+        When we post json to "users/#CONTEXT_USER_ID#/topics"
+        """
+        {
+            "label": "Weather",
+            "subscribers": [{"user_id": "#CONTEXT_USER_ID#", "notification_type": "real-time"}],
+            "is_global": false,
+            "topic_type": "wire",
+            "query": "weather"
+        }
+        """
+        Then we get OK response
+        And we store "TOPIC_ID" with item id
+        When we post json to "/push"
+        """
+        {
+            "guid": "article1", "type": "text",
+            "headline": "weather",
+            "firstcreated": "2050-11-27T08:00:57+0000",
+            "body_html": "<p>The weather is happening somewhere</p>",
+            "genre": [{"name": "News", "code": "news"}]
+        }
+        """
+        Then we get OK response
+        And we get notifications
+        """
+        [{
+            "event": "topic_matches",
+            "extra": {
+                "item": {"_id": "article1"},
+                "topics": ["#TOPIC_ID#"]
+            }
+        }]
+        """

--- a/newsroom/push/notifications.py
+++ b/newsroom/push/notifications.py
@@ -87,7 +87,7 @@ class NotificationManager:
         if not topic_matches:
             return set()
 
-        push_notification("topic_matches", item=item, topics=topic_matches)
+        push_notification("topic_matches", item=item, topics=list(topic_matches))
         return await self.send_topic_notification_emails(item, topics, topic_matches, users, companies)
 
     async def send_topic_notification_emails(
@@ -300,5 +300,5 @@ class NotificationManager:
         if not topic_matches:
             return set()
 
-        await push_agenda_item_notification("topic_matches", item=item, topics=topic_matches)
+        await push_agenda_item_notification("topic_matches", item=item, topics=list(topic_matches))
         return await self.send_topic_notification_emails(item, topics, topic_matches, users, companies)

--- a/newsroom/tests/web_api/environment.py
+++ b/newsroom/tests/web_api/environment.py
@@ -3,9 +3,11 @@ import asyncio
 import logging
 
 from superdesk.flask import Config
+from superdesk.tests import setup_notification, set_placeholder
 from superdesk.tests.steps import get_prefixed_url
-from newsroom.tests.conftest import drop_mongo, reset_elastic, root
 
+from newsroom.types import UserAuthResourceModel, CompanyResource
+from newsroom.tests.conftest import drop_mongo, reset_elastic, root
 from newsroom.web.factory import get_app
 from newsroom.web.default_settings import CORE_APPS, BLUEPRINTS
 from newsroom.agenda.filters import aggregations as agenda_aggs
@@ -56,6 +58,7 @@ async def before_scenario_async(context, scenario):
             "MONGO_DBNAME": "newsroom_behave",
             "CONTENTAPI_MONGO_DBNAME": "newsroom_behave",
             "AUTH_SERVER_SHARED_SECRET": "2kZOf0VI9T70vU9uMlKLyc5GlabxVgl6",
+            "CELERY_TASK_ALWAYS_EAGER": True,
             "AGENDA_GROUPS": [
                 {
                     "field": "sttdepartment",
@@ -101,6 +104,9 @@ async def before_scenario_async(context, scenario):
     context.client = context.app.test_client()
 
     if scenario.status != "skipped":
+        if "notification" in scenario.tags:
+            setup_notification(context)
+
         if "auth" in scenario.tags:
             await setup_users(context)
             await login_user(context, scenario)
@@ -108,8 +114,8 @@ async def before_scenario_async(context, scenario):
 
 async def setup_users(context):
     async with context.app.test_request_context("/login"):
-        context.app.data.insert("companies", COMPANIES)
-        context.app.data.insert("users", USERS)
+        await CompanyResource.get_service().create(COMPANIES)
+        await UserAuthResourceModel.get_service().create(USERS)
 
 
 async def login_user(context, scenario):
@@ -130,3 +136,7 @@ async def login_user(context, scenario):
             headers=context.headers,
         )
         assert response.status_code == 302, response.status_code
+
+        # Get the logged-in user and add its ID to ``CONTEXT_USER_ID`` for use in behave tests
+        user = await UserAuthResourceModel.get_service().find_one(email=data["email"])
+        set_placeholder(context, "CONTEXT_USER_ID", str(user.id))


### PR DESCRIPTION
### Purpose
When topic matches on push, websocket notification `topic_matches` message is not including the topic IDs

### What has changed
* Convert `set` to `list` for websocket message
* Add mock websocket notifications to behave tests
* Add behave tests for push websocket notifications

Resolves: [NHUB-564](https://sofab.atlassian.net/browse/NHUB-564)


[NHUB-564]: https://sofab.atlassian.net/browse/NHUB-564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ