### PR TITLE
improve(login): Remove email validation and incorrect login error

### DIFF
--- a/newsroom/auth/forms.py
+++ b/newsroom/auth/forms.py
@@ -41,14 +41,14 @@ class SignupForm(QuartForm):
 
 
 class LoginForm(QuartForm):
-    email = StringField(lazy_gettext("Email"), validators=[DataRequired(), Length(1, 64), Email()])
+    email = StringField(lazy_gettext("Email"), validators=[DataRequired(), Length(1, 64)])
     password = PasswordField(lazy_gettext("Password"), validators=[DataRequired()])
     remember_me = BooleanField(lazy_gettext("Remember Me"), validators=[])
     firebase_status = StringField("firebase_status", validators=[])  # for firebase status code
 
 
 class TokenForm(QuartForm):
-    email = StringField(lazy_gettext("Email"), validators=[DataRequired(), Length(1, 64), Email()])
+    email = StringField(lazy_gettext("Email"), validators=[DataRequired(), Length(1, 64)])
     firebase_status = StringField("firebase_status", validators=[])  # for firebase status code
 
 

--- a/newsroom/auth/session_auth.py
+++ b/newsroom/auth/session_auth.py
@@ -27,7 +27,6 @@ class NewshubSessionAuth(UserAuthProtocol):
         if not request.user:
             user_id = request.storage.session.get("user", "")
             if not user_id:
-                await flash(gettext("Invalid username or password."), "danger")
                 return await self.clear_session_and_redirect_to_login(request)
 
             try:


### PR DESCRIPTION
### Purpose
* When visiting the login page for the first time, an invalid `Invalid username or password` error is shown.
* When attempting to login or reset password, the `email` field is validated to be a valid email address

### What has changed
* Remove unnecessary error upon first visiting the login page
* Remove `email` field validation on login or reset password forms (as the emails are validated when the user is created, and already validated to make sure a user with that email exists)
