### PR TITLE
Fix iCalendar DTEND Handling for Multi-Day All-Day Events[CPCN-840]

### DIFF
--- a/newsroom/agenda/formatters/ical_formatter.py
+++ b/newsroom/agenda/formatters/ical_formatter.py
@@ -6,6 +6,7 @@ from superdesk.utc import utcnow
 
 from newsroom.agenda.contacts import get_contact_name, get_contact_email
 from newsroom.formatter import BaseFormatter
+from datetime import timedelta
 
 
 def datetime(value):
@@ -67,7 +68,9 @@ class iCalFormatter(BaseFormatter):
         event.add("dtstart", start.date() if dates.get("all_day") else start)
         if dates.get("end"):
             end = datetime(dates["end"])
-            event.add("dtend", end.date() if dates.get("no_end_time") or dates.get("all_day") else end)
+            event.add(
+                "dtend", end.date() + timedelta(days=1) if dates.get("no_end_time") or dates.get("all_day") else end
+            )
         try:
             rrule = item["event"]["dates"]["recurring_rule"]
             event.add("rrule", get_rrule_kwargs(rrule))

--- a/tests/core/test_ical_formatter.py
+++ b/tests/core/test_ical_formatter.py
@@ -107,6 +107,5 @@ def test_onclusive_multiday():
     }
     formatter = iCalFormatter()
     output = formatter.format_item(event, item_type="agenda").decode("utf-8")
-    print(output)
     assert "DTSTART;VALUE=DATE:20241118" in output
     assert "DTEND;VALUE=DATE:20241121" in output

--- a/tests/core/test_ical_formatter.py
+++ b/tests/core/test_ical_formatter.py
@@ -78,7 +78,7 @@ def test_onclusive_all_day():
     formatter = iCalFormatter()
     output = formatter.format_item(event, item_type="agenda").decode("utf-8")
     assert "DTSTART;VALUE=DATE:20240101" in output
-    assert "DTEND;VALUE=DATE:20240103" in output
+    assert "DTEND;VALUE=DATE:20240104" in output
 
 
 def test_onclusive_no_end_time():
@@ -93,4 +93,20 @@ def test_onclusive_no_end_time():
     formatter = iCalFormatter()
     output = formatter.format_item(event, item_type="agenda").decode("utf-8")
     assert "DTSTART;VALUE=DATE-TIME:20240101T100000Z" in output
-    assert "DTEND;VALUE=DATE:20240103" in output
+    assert "DTEND;VALUE=DATE:20240104" in output
+
+
+def test_onclusive_multiday():
+    event = {
+        "name": "test",
+        "dates": {
+            "start": "2024-11-18T00:00:00",
+            "end": "2024-11-20T00:00:00",
+            "all_day": True,
+        },
+    }
+    formatter = iCalFormatter()
+    output = formatter.format_item(event, item_type="agenda").decode("utf-8")
+    print(output)
+    assert "DTSTART;VALUE=DATE:20241118" in output
+    assert "DTEND;VALUE=DATE:20241121" in output


### PR DESCRIPTION
### Purpose
This PR fixes the handling of multi-day all-day events in the iCalendar format. The issue occurs when the `DTEND` property does not correctly reflect the last day of the event, causing calendar applications to exclude the final day. This change ensures compliance with the iCalendar standard, where the `DTEND` field is **exclusive**, and the last day of an **all-day** event is properly included

### What has changed
The `DTEND` field for multi-day all-day events is updated to include the day after the last event date (i.e., adding one day to `DTEND`).

### Steps to test

1. Create a multi-day all-day event (e.g., from November 18–20, 2024).
2. Generate the iCalendar output and check that DTEND is set to November 21 (one day after the last day).
3. Confirm that the event shows correctly in calendar applications like Google Calendar or Outlook

Resolves: #[CPCN-840]


[CPCN-840]: https://sofab.atlassian.net/browse/CPCN-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ