### PR TITLE
[NHUB-598] fix(push): Support unknown fields for Wire & Agenda

### DIFF
--- a/features/web_api/agenda_push.feature
+++ b/features/web_api/agenda_push.feature
@@ -132,3 +132,105 @@ Feature: Agenda Push
             }
         }]
         """
+
+    @auth @admin
+    Scenario: Support unknown fields on push agenda
+        When we post json to "/push"
+        """
+        {
+            "_id": "8642dfc8-0772-447f-9433-ee757dc065de",
+            "type": "event",
+            "occur_status": {
+                "qcode": "eocstat:eos5",
+                "name": "Planned, occurs certainly",
+                "label": "Planned, occurs certainly"
+            },
+            "dates": {
+                "start": "2024-11-25T05:00:00+0000",
+                "end": "2024-11-26T04:59:59+0000",
+                "tz": "America/Toronto"
+            },
+            "calendars": [],
+            "state": "scheduled",
+            "language": "nl",
+            "languages": ["nl"],
+            "place": [],
+            "_time_to_be_confirmed": false,
+            "translations": [{"field": "name", "language": "nl", "value": "eve2"}],
+            "name": "eve2",
+            "anpa_category": [
+                {
+                    "name": "FIXME1",
+                    "qcode": "f1",
+                    "subject": "",
+                    "translations": {"name": {"fr": "FIXME1-fr", "es": "FIXME1-es"}}
+                },
+                {
+                    "name": "FIXME2",
+                    "qcode": "f2",
+                    "subject": "",
+                    "translations": {"name": {"fr": "FIXME2-fr", "es": "FIXME2-es"}}
+                }
+            ],
+            "_updated": "2024-11-26T01:51:07+0000",
+            "_created": "2024-11-26T01:51:05+0000",
+            "guid": "8642dfc8-0772-447f-9433-ee757dc065de",
+            "firstcreated": "2024-11-26T01:51:05+0000",
+            "versioncreated": "2024-11-26T01:51:07+0000",
+            "pubstatus": "usable",
+            "state_reason": null,
+            "actioned_date": null,
+            "item_id": "8642dfc8-0772-447f-9433-ee757dc065de",
+            "plans": [],
+            "event_contact_info": [],
+            "products": [{"code": "65fb3b7c884e530196d08512", "name": "prod_all_events"}]
+        }
+        """
+        When we get "/agenda/8642dfc8-0772-447f-9433-ee757dc065de?format=json"
+        Then we get existing resource
+        """
+        {
+            "_id": "8642dfc8-0772-447f-9433-ee757dc065de",
+            "item_type": "event",
+            "dates": {
+                "start": "2024-11-25T05:00:00+0000",
+                "end": "2024-11-26T04:59:59+0000",
+                "tz": "America/Toronto",
+                "all_day": false,
+                "no_end_time": false
+            },
+            "products": [{"code": "65fb3b7c884e530196d08512", "name": "prod_all_events"}],
+            "service": [
+                {
+                    "name": "FIXME1",
+                    "qcode": "f1",
+                    "subject": "",
+                    "translations": {"name": {"fr": "FIXME1-fr", "es": "FIXME1-es"}}
+                },
+                {
+                    "name": "FIXME2",
+                    "qcode": "f2",
+                    "subject": "",
+                    "translations": {"name": {"fr": "FIXME2-fr", "es": "FIXME2-es"}}
+                }
+            ],
+            "event": {
+                "_id": "8642dfc8-0772-447f-9433-ee757dc065de",
+                "translations": [{"field": "name", "language": "nl", "value": "eve2"}],
+                "anpa_category": [
+                    {
+                        "name": "FIXME1",
+                        "qcode": "f1",
+                        "subject": "",
+                        "translations": {"name": {"fr": "FIXME1-fr", "es": "FIXME1-es"}}
+                    },
+                    {
+                        "name": "FIXME2",
+                        "qcode": "f2",
+                        "subject": "",
+                        "translations": {"name": {"fr": "FIXME2-fr", "es": "FIXME2-es"}}
+                    }
+                ]
+            }
+        }
+        """

--- a/features/web_api/wire_push.feature
+++ b/features/web_api/wire_push.feature
@@ -34,3 +34,100 @@ Feature: Wire Push
             }
         }]
         """
+
+    @auth @admin
+    Scenario: Support unknown fields on push wire
+        When we post json to "/push"
+        """
+        {
+            "guid": "c84653b1-f42c-4b67-9573-f348dfb58791",
+            "version": "2",
+            "type": "text",
+            "byline": "mk",
+            "located": "Prague",
+            "versioncreated": "2024-11-25T16:15:02+0000",
+            "language": "en",
+            "headline": "test place cv",
+            "urgency": 3,
+            "pubstatus": "usable",
+            "ednote": "test  place cv",
+            "body_html": "<p>test &nbsp;place cv</p>",
+            "slugline": "test place cv",
+            "firstcreated": "2024-11-25T16:14:17+0000",
+            "firstpublished": "2024-11-25T16:15:02+0000",
+            "source": "test_desk",
+            "annotations": [],
+            "place": [{
+                "scheme": "geonames",
+                "code": "3067696",
+                "name": "Prague",
+                "state": "Prague",
+                "country": "Czechia",
+                "state_code": "52",
+                "country_code": "CZ",
+                "geometry_point": {
+                    "type": "Point",
+                    "coordinates": [50.08804, 14.42076]
+                }
+            }],
+            "profile": "mk_profile",
+            "priority": 6,
+            "subject": [{"code": "01001000", "name": "archaeology"}],
+            "service": [{"code": "f1", "name": "FIXME1"}],
+            "description_html": "<p>test place cv</p>",
+            "description_text": "test place cv",
+            "copyrightholder": "",
+            "copyrightnotice": "",
+            "usageterms": "",
+            "genre": [{"code": "Article", "name": "Article (news)"}],
+            "charcount": 13,
+            "wordcount": 3,
+            "readtime": 0,
+            "authors": [{
+                "code": "65f9fb38884e530196d0841e",
+                "name": "Mikayel Karapetyan",
+                "role": "writer",
+                "biography": "",
+                "uri": "urn:sd-uat.test.superdesk.org:user:65f9fb38884e530196d0841e"
+            }],
+            "products": [
+                {"code": "66083127884e530196d08944", "name": "text"},
+                {"code": "67325ba5dba99664698eafa7", "name": "prod subj arch"}
+            ]
+        }
+        """
+        Then we get OK response
+        When we get "/wire/c84653b1-f42c-4b67-9573-f348dfb58791?format=json"
+        Then we get existing resource
+        """
+        {
+            "_id": "c84653b1-f42c-4b67-9573-f348dfb58791",
+            "authors": [{
+                "code": "65f9fb38884e530196d0841e",
+                "name": "Mikayel Karapetyan",
+                "role": "writer",
+                "biography": "",
+                "uri": "urn:sd-uat.test.superdesk.org:user:65f9fb38884e530196d0841e"
+            }],
+            "genre": [{"code": "Article", "name": "Article (news)"}],
+            "place": [{
+                "scheme": "geonames",
+                "code": "3067696",
+                "name": "Prague",
+                "state": "Prague",
+                "country": "Czechia",
+                "state_code": "52",
+                "country_code": "CZ",
+                "geometry_point": {
+                    "type": "Point",
+                    "coordinates": [50.08804, 14.42076]
+                }
+            }],
+            "products": [
+                {"code": "66083127884e530196d08944", "name": "text"},
+                {"code": "67325ba5dba99664698eafa7", "name": "prod subj arch"}
+            ],
+            "service": [{"code": "f1", "name": "FIXME1"}],
+            "subject": [{"code": "01001000", "name": "archaeology"}]
+        }
+        """

--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -77,6 +77,7 @@ class AgendaItemParams(BaseModel):
     print: bool = False
     map: str | None = None
     type: str = "agenda"
+    format: str | None = None
 
     @field_validator("print", mode="before")
     def parse_print(cls, value: str | bool | None) -> bool | str | None:

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -1,5 +1,5 @@
 import re
-from typing import Tuple, cast
+from typing import Tuple
 
 from bson import ObjectId, errors
 from pydantic import BaseModel
@@ -10,7 +10,7 @@ from superdesk.core.types import Request, Response
 
 from newsroom.auth import auth_rules
 from newsroom.core import get_current_wsgi_app
-from newsroom.types import Product, ProductRef
+from newsroom.types import ProductResourceModel, CompanyProduct
 from newsroom.utils import get_json_or_400_async
 from newsroom.products.service import ProductsService
 from newsroom.navigations import get_navigations_as_list
@@ -30,13 +30,12 @@ async def get_settings_data():
     }
 
 
-def get_product_ref(product: Product, seats=0) -> ProductRef:
-    assert "_id" in product
-    return {
-        "_id": product["_id"],
-        "section": product.get("product_type") or "wire",
-        "seats": seats or 0,
-    }
+def get_product_ref(product: ProductResourceModel, seats=0) -> CompanyProduct:
+    return CompanyProduct(
+        _id=product.id,
+        section=product.product_type,
+        seats=seats,
+    )
 
 
 class SearchParams(BaseModel):
@@ -104,8 +103,8 @@ async def edit(args: ProductsArgs, _p: None, request: Request):
 
 
 async def update_company_products(
-    company: CompanyResource, product_id: ObjectId, selected_companies: list[ObjectId], product_ref: ProductRef
-) -> Tuple[list[ProductRef], bool]:
+    company: CompanyResource, product_id: ObjectId, selected_companies: list[ObjectId], product_ref: CompanyProduct
+) -> Tuple[list[CompanyProduct], bool]:
     """
     Updates the company's product list by either adding or removing a product reference.
 
@@ -121,16 +120,16 @@ async def update_company_products(
 
 
 def add_product_to_company(
-    company: CompanyResource, product_id: ObjectId, product_ref: ProductRef
-) -> Tuple[list[ProductRef], bool]:
+    company: CompanyResource, product_id: ObjectId, product_ref: CompanyProduct
+) -> Tuple[list[CompanyProduct], bool]:
     """
     Adds a product to the company's product list if it doesn't already exist.
     """
     if not product_in_company(company, product_id):
-        company_products: list[ProductRef] = (cast(list[ProductRef], company.products)).copy()
+        company_products = company.products.copy()
         company_products.append(product_ref)
         return company_products, True
-    return cast(list[ProductRef], company.products), False
+    return company.products, False
 
 
 def product_in_company(company: CompanyResource, product_id: ObjectId) -> bool:
@@ -138,12 +137,12 @@ def product_in_company(company: CompanyResource, product_id: ObjectId) -> bool:
     Checks if a product is already in a given Company products list.
     """
     for product in company.products:
-        if str(product._id) == str(product_id):
+        if product._id == product_id:
             return True
     return False
 
 
-def remove_product_from_company(company: CompanyResource, product_id: ObjectId) -> Tuple[list[ProductRef], bool]:
+def remove_product_from_company(company: CompanyResource, product_id: ObjectId) -> Tuple[list[CompanyProduct], bool]:
     """
     Removes a product from the company's product list if it exists.
 
@@ -151,16 +150,16 @@ def remove_product_from_company(company: CompanyResource, product_id: ObjectId) 
         A tuple with the list of products of the company and a boolean to indicate if an update is
         required or not.
     """
-    company_products = [p for p in company.products if str(p._id) != str(product_id)]
+    company_products = [product for product in company.products if product._id != product_id]
     is_update_required = len(company_products) != len(company.products)
 
-    return cast(list[ProductRef], company_products), is_update_required
+    return company_products, is_update_required
 
 
-def update_company_sections(company: CompanyResource, company_products: list[ProductRef]) -> dict[str, bool]:
+def update_company_sections(company: CompanyResource, company_products: list[CompanyProduct]) -> dict[str, bool]:
     sections = company.sections
     for product in company_products:
-        sections.setdefault(product["section"], True)
+        sections.setdefault(product.section, True)
     return sections
 
 
@@ -174,7 +173,7 @@ async def update_companies(args: ProductsArgs, _p: None, request: Request):
 
     updates = await request.get_json()
     selected_companies = [await parse_objectid_or_abort(request, x) for x in updates.get("companies", [])]
-    product_ref = get_product_ref(product.to_dict())
+    product_ref = get_product_ref(product)
 
     async for company in CompanyService().get_all():
         company_products, update_required = await update_company_products(

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -15,7 +15,7 @@ from newsroom.utils import get_json_or_400_async
 from newsroom.products.service import ProductsService
 from newsroom.navigations import get_navigations_as_list
 from newsroom.companies.companies_async import CompanyService
-from newsroom.types.company import CompanyProduct, CompanyResource
+from newsroom.types.company import CompanyResource
 
 products_endpoints = EndpointGroup("products_views", __name__)
 

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -160,8 +160,6 @@ def remove_product_from_company(company: CompanyResource, product_id: ObjectId) 
 def update_company_sections(company: CompanyResource, company_products: list[ProductRef]) -> dict[str, bool]:
     sections = company.sections
     for product in company_products:
-        if isinstance(product, CompanyProduct):
-            product = product.to_dict()
         sections.setdefault(product["section"], True)
     return sections
 

--- a/newsroom/topics/topics_async.py
+++ b/newsroom/topics/topics_async.py
@@ -59,7 +59,7 @@ class TopicService(NewshubAsyncResourceService[TopicResourceModel]):
             updated_dashboards = []
 
             for dashboard in updates["dashboards"]:
-                dashboard_dict = dashboard.to_dict()
+                dashboard_dict = dashboard.to_dict(context={"use_objectid": True})
                 # Remove the deleted topic id from topic_ids
                 dashboard_dict["topic_ids"] = [
                     topic_id for topic_id in dashboard_dict["topic_ids"] if topic_id != doc.id

--- a/newsroom/types/agenda.py
+++ b/newsroom/types/agenda.py
@@ -4,7 +4,7 @@ from enum import Enum, unique
 
 from pydantic import Field, field_validator, model_validator
 
-from superdesk.core.resources import ResourceModel, fields, dataclass, ModelWithVersions
+from superdesk.core.resources import ResourceModel, fields, dataclass, Dataclass, ModelWithVersions
 from superdesk.utc import utcnow
 from content_api.items.model import Place, CVItemWithCode, CVItem, PubStatusType
 
@@ -43,7 +43,7 @@ class AgendaWorkflowState(str, Enum):
 
 
 @dataclass
-class AgendaCVItem:
+class AgendaCVItem(Dataclass):
     code: fields.Keyword
     name: fields.Keyword
     qcode: fields.Keyword | None = None
@@ -53,7 +53,7 @@ class AgendaCVItem:
 
 
 @dataclass
-class EventRecurringRule:
+class EventRecurringRule(Dataclass):
     frequency: str | None = None
     interval: int | None = None
     endRepeatMode: str | None = None
@@ -63,7 +63,7 @@ class EventRecurringRule:
 
 
 @dataclass
-class AgendaDates:
+class AgendaDates(Dataclass):
     start: datetime
     end: datetime
     tz: str | None = None
@@ -76,12 +76,12 @@ class AgendaDates:
 
 
 @dataclass
-class AgendaDisplayDates:
+class AgendaDisplayDates(Dataclass):
     date: datetime
 
 
 @dataclass
-class AgendaCoverageDelivery:
+class AgendaCoverageDelivery(Dataclass):
     delivery_id: fields.Keyword | None = None
     delivery_href: fields.Keyword | None = None
     sequence_no: Annotated[int, fields.keyword_mapping()] = 0
@@ -90,7 +90,7 @@ class AgendaCoverageDelivery:
 
 
 @dataclass
-class AgendaCoverage:
+class AgendaCoverage(Dataclass):
     planning_id: fields.Keyword
     coverage_id: fields.Keyword
     scheduled: datetime
@@ -126,7 +126,7 @@ class AgendaCoverage:
 
 
 @dataclass
-class EventLocation:
+class EventLocation(Dataclass):
     name: fields.TextWithKeyword
     address: Annotated[dict | None, fields.dynamic_mapping()] = None
     location: fields.Geopoint | None = None
@@ -137,13 +137,13 @@ class EventLocation:
 
 
 @dataclass
-class PlanningItemAgenda:
+class PlanningItemAgenda(Dataclass):
     _id: fields.Keyword
     name: fields.Keyword
 
 
 @dataclass
-class AgendaPlanningItem:
+class AgendaPlanningItem(Dataclass):
     _id: fields.Keyword
     guid: fields.Keyword
     planning_date: datetime
@@ -185,7 +185,7 @@ class AgendaPlanningItem:
 
 
 @dataclass
-class CalendarItem:
+class CalendarItem(Dataclass):
     qcode: fields.Keyword
     name: fields.Keyword
     schema: fields.Keyword | None = None

--- a/newsroom/types/company.py
+++ b/newsroom/types/company.py
@@ -1,6 +1,5 @@
 from typing import Annotated, Optional
 from datetime import datetime
-from dataclasses import asdict
 
 from superdesk.core.resources import dataclass, Dataclass
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
@@ -16,9 +15,6 @@ class CompanyProduct(Dataclass):
     _id: Annotated[ObjectId, validate_data_relation_async("products")]
     section: SectionEnum
     seats: int = 0
-
-    def to_dict(self):
-        return asdict(self)
 
 
 class CompanyResource(NewshubResourceModel):

--- a/newsroom/types/company.py
+++ b/newsroom/types/company.py
@@ -2,7 +2,7 @@ from typing import Annotated, Optional
 from datetime import datetime
 from dataclasses import asdict
 
-from superdesk.core.resources import dataclass
+from superdesk.core.resources import dataclass, Dataclass
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
 from superdesk.core.resources.fields import ObjectId, Field
 
@@ -12,7 +12,7 @@ from .common import SectionEnum
 
 
 @dataclass
-class CompanyProduct:
+class CompanyProduct(Dataclass):
     _id: Annotated[ObjectId, validate_data_relation_async("products")]
     section: SectionEnum
     seats: int = 0

--- a/newsroom/types/monitoring.py
+++ b/newsroom/types/monitoring.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum, unique
 
-from superdesk.core.resources import dataclass
+from superdesk.core.resources import dataclass, Dataclass
 from superdesk.core.resources.fields import ObjectId
 from newsroom.core.resources import NewshubResourceModel
 
@@ -17,7 +17,7 @@ class MonitoringScheduleInterval(str, Enum):
 
 
 @dataclass
-class MonitoringSchedule:
+class MonitoringSchedule(Dataclass):
     interval: MonitoringScheduleInterval
     time: str | None = None
     day: str | None = None

--- a/newsroom/types/notifications.py
+++ b/newsroom/types/notifications.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Annotated
 from pydantic import Field
 
-from superdesk.core.resources import ResourceModel, dataclass
+from superdesk.core.resources import ResourceModel, dataclass, Dataclass
 from superdesk.core.resources.fields import ObjectId
 from superdesk.core.resources.validators import validate_data_relation_async
 
@@ -22,7 +22,7 @@ class Notification(ResourceModel):
 
 
 @dataclass
-class NotificationTopic:
+class NotificationTopic(Dataclass):
     topic_id: Annotated[ObjectId, validate_data_relation_async("topics")]
     last_item_arrived: datetime
     section: str

--- a/newsroom/types/topics.py
+++ b/newsroom/types/topics.py
@@ -3,7 +3,7 @@ from pydantic import Field
 from typing import Any, Annotated
 
 
-from superdesk.core.resources import dataclass
+from superdesk.core.resources import dataclass, Dataclass
 from superdesk.core.resources.fields import ObjectId as ObjectIdField
 from superdesk.core.resources.validators import validate_data_relation_async
 
@@ -21,13 +21,13 @@ class NotificationType(str, Enum):
 
 
 @dataclass
-class TopicSubscriberModel:
+class TopicSubscriberModel(Dataclass):
     user_id: Annotated[ObjectIdField, validate_data_relation_async("users")]
     notification_type: NotificationType = NotificationType.REAL_TIME
 
 
 @dataclass
-class TopicCreatedFilters:
+class TopicCreatedFilters(Dataclass):
     created_from: Annotated[str | None, Field(alias="from")] = None
     created_to: Annotated[str | None, Field(alias="to")] = None
     date_filter: str | None = None

--- a/newsroom/types/users.py
+++ b/newsroom/types/users.py
@@ -4,12 +4,11 @@ import pytz
 from pydantic import Field
 
 from typing import Annotated, List, Optional
-from dataclasses import asdict
 from quart_babel import lazy_gettext
 
 from superdesk.core import get_app_config
 from superdesk.core.resources.fields import ObjectId as ObjectIdField
-from superdesk.core.resources import dataclass
+from superdesk.core.resources import dataclass, Dataclass
 from superdesk.core.resources.validators import (
     validate_email,
     validate_iunique_value_async,
@@ -23,17 +22,14 @@ from .user_roles import UserRole
 
 
 @dataclass
-class DashboardModel:
+class DashboardModel(Dataclass):
     name: str
     type: str
     topic_ids: Annotated[list[ObjectIdField], validate_data_relation_async("topics")]
 
-    def to_dict(self):
-        return asdict(self)
-
 
 @dataclass
-class NotificationScheduleModel:
+class NotificationScheduleModel(Dataclass):
     timezone: str | None = None
     times: list[str] = Field(default_factory=list)
     last_run_time: Optional[datetime] = None

--- a/newsroom/types/wire.py
+++ b/newsroom/types/wire.py
@@ -3,12 +3,12 @@ from datetime import datetime
 
 from pydantic import Field
 
-from superdesk.core.resources import fields, dataclass
+from superdesk.core.resources import fields, dataclass, Dataclass
 from content_api.items.model import ContentAPIItem, CVItemWithCode
 
 
 @dataclass
-class PublishedProduct:
+class PublishedProduct(Dataclass):
     code: fields.Keyword
     name: fields.Keyword | None = None
 

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -559,6 +559,7 @@ class WireItemUrlParams(BaseModel):
     print: bool = False
     monitoring_profile: str | None = None
     type: SectionEnum = SectionEnum.WIRE
+    format: str | None = None
 
     @field_validator("print", mode="before")
     def parse_print(cls, value: str | bool | None) -> bool | str | None:

--- a/tests/core/test_navigations.py
+++ b/tests/core/test_navigations.py
@@ -8,7 +8,7 @@ from newsroom.products.views import get_product_ref
 from newsroom.tests.users import test_login_succeeds_for_admin  # noqa
 from newsroom.tests.fixtures import COMPANY_1_ID
 from newsroom.navigations import get_navigations
-from newsroom.types import Product
+from newsroom.types import ProductResourceModel, SectionEnum
 from tests.core.utils import add_company_products, create_entries_for, find_one_by_id
 
 NAV_ID = ObjectId("59b4c5c61d41c8d736852fbf")
@@ -305,24 +305,27 @@ async def test_get_navigations_for_user(public_user, public_company, app):
     assert 0 == len(navigations)
 
     products = [
-        Product(
-            _id=ObjectId(),
+        ProductResourceModel(
+            id=ObjectId(),
             name="Wire",
             navigations=[NAV_ID],
             is_enabled=True,
-            product_type="wire",
+            product_type=SectionEnum.WIRE,
         ),
-        Product(
-            _id=ObjectId(),
+        ProductResourceModel(
+            id=ObjectId(),
             name="Agenda",
             navigations=[AGENDA_NAV_ID],
             is_enabled=True,
-            product_type="agenda",
+            product_type=SectionEnum.AGENDA,
         ),
     ]
 
     await create_entries_for("products", products)
-    public_user["products"] = [get_product_ref(products[0]), get_product_ref(products[1])]
+    public_user["products"] = [
+        get_product_ref(products[0]).to_dict(context={"use_objectid": True}),
+        get_product_ref(products[1]).to_dict(context={"use_objectid": True}),
+    ]
 
     navigations = await get_navigations(public_user, public_company, "wire")
     assert 1 == len(navigations)

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -97,7 +97,7 @@ async def test_delete_all_notifications(client, service):
                 "user": TEST_USER,
                 "resource": "test-resources",
                 "action": "test-action",
-                "_created": utcnow() - datetime.timedelta(days=1),
+                "_created": utcnow() - datetime.timedelta(hours=12),
             },
         ]
     )

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -74,7 +74,9 @@ async def create_entries_for(resource: str, items: list[Any]) -> list[ObjectId |
         return ids
 
 
-async def update_entries_for(resource: str, item_id: str | ObjectId, updates: dict[str, Any], original: Any):
+async def update_entries_for(
+    resource: str, item_id: str | ObjectId, updates: dict[str, Any], original: Any | None = None
+):
     """
     Attempts to update existing resource entries. First tries with async, otherwise it falls back to
     sync resources.


### PR DESCRIPTION
### Purpose
Support unknown fields on push for Wire & Agenda items

### What has changed
* Make sure `@dataclass` models inherit from `superdesk.core.resources.Dataclass` class

Depends on: https://github.com/superdesk/superdesk-core/pull/2759
Resolves: [NHUB-598](https://sofab.atlassian.net/browse/NHUB-598)

[NHUB-598]: https://sofab.atlassian.net/browse/NHUB-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ