### PR TITLE
[NHUB-594] fix(dashboard): Remove validation for card_item requests

### DIFF
--- a/newsroom/types/cards.py
+++ b/newsroom/types/cards.py
@@ -31,7 +31,7 @@ class DashboardCardType(str, Enum):
 class DashboardCardConfig(TypedDict, total=False):
     product: str
     size: int
-    events: dict
+    events: list[dict]
     sources: list[dict]
 
 

--- a/newsroom/wire/service.py
+++ b/newsroom/wire/service.py
@@ -29,7 +29,6 @@ from newsroom.search.filters import (
     apply_section_filter,
     apply_company_filter,
     apply_products_filter,
-    validate_request,
     apply_ids_filter,
 )
 
@@ -345,8 +344,6 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
                 apply_item_type_filter,
                 apply_company_filter,
                 apply_products_filter,
-                # Make sure the request has been validated
-                validate_request,
             ],
         )
         return await cursor.to_list()


### PR DESCRIPTION
### Purpose
Request for card_items was failing for public users with a Product permission error. This is invalid, as the dashboard is meant to gives users a preview of the items that could be available to them, separate to the Wire page which only shows items they have permission for.

### What has changed
* Remove product permission validation when getting card items
* Fix type error with card dashboard event attribute (should be a list not a dict)

Resolves: [NHUB-594](https://sofab.atlassian.net/browse/NHUB-594)


[NHUB-594]: https://sofab.atlassian.net/browse/NHUB-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ