### PR TITLE
improve: Use new async signal system

### DIFF
--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -8,7 +8,6 @@ from superdesk import get_resource_service
 import newsroom
 
 from newsroom.types import SectionEnum
-from newsroom.signals import company_create
 
 from .utils import get_company_section_names, get_company_product_ids
 
@@ -108,7 +107,6 @@ class CompaniesService(newsroom.Service):
         super().on_create(docs)
         for doc in docs:
             self.validate_auth_provider(doc)
-            company_create.send(self, company=doc)
 
     def on_update(self, updates, original):
         self.validate_auth_provider(updates)

--- a/newsroom/companies/companies_async/service.py
+++ b/newsroom/companies/companies_async/service.py
@@ -17,7 +17,7 @@ class CompanyService(NewshubAsyncResourceService[CompanyResource]):
     async def on_create(self, docs: List[CompanyResource]) -> None:
         await super().on_create(docs)
         for company in docs:
-            company_create.send(self, company=company.to_dict())
+            await company_create.send(company)
 
     def _get_products(self, updates: Dict[str, Any], original: CompanyResource) -> Iterable[dict[str, Any]]:
         """

--- a/newsroom/push/publishing.py
+++ b/newsroom/push/publishing.py
@@ -103,7 +103,7 @@ class Publisher:
                 if subject.get("scheme") in get_app_config("WIRE_SUBJECT_SCHEME_WHITELIST")
             ]
 
-        signals.publish_item.send(app, item=doc, is_new=original is None)
+        await signals.publish_item.send(doc, original is None)
 
         doc_id = await self.publish_doc_to_content_api(doc)
         if "evolvedfrom" in doc and parent_item:
@@ -161,7 +161,7 @@ class Publisher:
                     # This can happen when pushing a Planning item before linking to an Event
                     await service.system_update(plan["_id"], {"event_id": agenda_id})
 
-            signals.publish_event.send(app.as_any(), item=agenda, is_new=True)
+            await signals.publish_event.send(agenda, None, None, True)
             agenda_id = (await service.create([agenda]))[0]
         else:
             # replace the original document
@@ -214,7 +214,7 @@ class Publisher:
             if updates:
                 updated = orig.copy()
                 updated.update(updates)
-                signals.publish_event.send(app.as_any(), item=updated, updates=updates, orig=orig, is_new=False)
+                await signals.publish_event.send(updated, updates, orig, False)
                 await service.update(orig["_id"], updates)
                 updates["_id"] = orig["_id"]
                 await notify_agenda_update(updates, orig)
@@ -230,17 +230,16 @@ class Publisher:
 
         # Add the planning item to the list
         await agenda_manager.set_agenda_planning_items(agenda, orig, planning, action="add" if new_plan else "update")
-        app = get_current_wsgi_app()
 
         if not orig.get("_id"):
             # Setting ``_id`` of Agenda to be equal to the Planning item if there's no Event ID
             agenda.setdefault("_id", planning["guid"])
             agenda.setdefault("guid", planning["guid"])
-            signals.publish_planning.send(app.as_any(), item=agenda, is_new=new_plan)
+            await signals.publish_planning.send(agenda, new_plan)
             return (await service.create([agenda]))[0]
         else:
             # Replace the original
-            signals.publish_planning.send(app.as_any(), item=agenda, is_new=new_plan)
+            await signals.publish_planning.send(agenda, new_plan)
             await service.update(agenda["_id"], agenda)
             return agenda["_id"]
 

--- a/newsroom/push/views.py
+++ b/newsroom/push/views.py
@@ -106,8 +106,7 @@ async def push(request: Request):
         await request.abort(503)
 
     try:
-        app = get_current_wsgi_app()
-        signals.push.send(app, item=item)
+        await signals.push.send(item)
 
         item_type = item.get("type")
         publish_fn = get_publish_handler(item_type)

--- a/newsroom/signals.py
+++ b/newsroom/signals.py
@@ -1,25 +1,64 @@
-from blinker import Namespace
+from typing import Any
+from superdesk.core import AsyncSignal
 
-signals = Namespace()
+from newsroom.types import UserResourceModel, CompanyResource
 
-publish_item = signals.signal("publish-item")
-publish_event = signals.signal("publish-event")
-publish_planning = signals.signal("publish-planning")
+#: Signal for when a wire item is about to be added to the DB
+#: param item: New wire item dictionary
+#: param is_new: Boolean indicating if this Event is to be created or updated
+publish_item = AsyncSignal[dict[str, Any], bool]("publish-item")
 
 
+#: Signal for when an Event is about to be created or updated in the DB
+#: param updated: New event dictionary
+#: param updates: A dictionary containing the fields to be updated, or ``None`` if being created
+#: param original: A dictionary for the original item, or ``None`` if being created
+#: param is_new: Boolean indicating if this Event is to be created or updated
+publish_event = AsyncSignal[dict[str, Any], dict[str, Any] | None, dict[str, Any] | None, bool]("publish-event")
+
+
+#: Signal for when a Planning item is about to be created or updated in the DB
+#: param item: New planning item dictionary
+#: param is_new: Boolean indicating if this Event is to be created or updated
+publish_planning = AsyncSignal[dict[str, Any], bool]("publish-planning")
+
+
+#: Signal fired before an item is about to be ingested into the system
+#: param item: A dictionary of the item to be ingested
 #:
 #: ..versionadded:: 2.4
 #:
-push = signals.signal("push")
+push = AsyncSignal[dict[str, Any]]("push")
 
+
+#: Signal fired after a user has been created
+#: param user: The UserResourceModel of the user that was created
 #:
 #: ..versionadded:: 2.4
 #:
-user_created = signals.signal("user-created")
-user_updated = signals.signal("user-updated")
-user_deleted = signals.signal("user-deleted")
+user_created = AsyncSignal[UserResourceModel]("user-created")
 
+
+#: Signal fired after a user has been updated
+#: param user: The UserResourceModel of the user that was updated (contains the updated values)
+#: param updates: A dictionary containing the fields that were updated
+#:
+#: ..versionadded:: 2.4
+#:
+user_updated = AsyncSignal[UserResourceModel, dict[str, Any]]("user-updated")
+
+
+#: Signal fired after a user has been deleted from the system
+#: param user: The UserResourceModel of the user that was deleted
+#:
+#: ..versionadded:: 2.4
+#:
+user_deleted = AsyncSignal[UserResourceModel]("user-deleted")
+
+
+#: Signal fired when a company is about to be created
+#: param company: The CompanyResource instance of the company to be created
 #:
 #: ..versionadded:: 2.5.0
 #:
-company_create = signals.signal("company-create")
+company_create = AsyncSignal[CompanyResource]("company-create")

--- a/newsroom/topics/__init__.py
+++ b/newsroom/topics/__init__.py
@@ -8,6 +8,7 @@ from .topics_async import (
     get_agenda_notification_topics_for_query_by_id,
     get_topics_with_subscribers,
     get_topics_with_subscribers_async,
+    init_module,
 )
 from . import topics
 
@@ -30,6 +31,7 @@ module = Module(
     name="newsroom.topics",
     resources=[topic_resource_config],
     endpoints=[topic_endpoints],
+    init=init_module,
 )
 
 from . import views  # noqa

--- a/newsroom/topics/topics.py
+++ b/newsroom/topics/topics.py
@@ -11,7 +11,6 @@ from bson import ObjectId
 from newsroom.auth.utils import get_user_or_none_from_request
 from newsroom.types import Topic, User, UserRole
 from newsroom.utils import set_original_creator, set_version_creator
-from newsroom.signals import user_deleted
 
 
 class TopicNotificationType(enum.Enum):
@@ -71,10 +70,6 @@ class TopicsResource(newsroom.Resource):
 
 
 class TopicsService(newsroom.Service):
-    def __init__(self, datasource: Optional[str] = None, backend=None):
-        super().__init__(datasource, backend)
-        user_deleted.connect(self.on_user_deleted)
-
     def on_create(self, docs):
         super().on_create(docs)
         for doc in docs:

--- a/newsroom/topics/topics_async.py
+++ b/newsroom/topics/topics_async.py
@@ -1,22 +1,20 @@
 from bson import ObjectId
 from typing import Optional, List, Dict, Any, Union
 
+from superdesk.core.module import SuperdeskAsyncApp
 from superdesk.core.resources import ResourceConfig, MongoResourceConfig, RestEndpointConfig, RestParentLink
+from superdesk.core.web import EndpointGroup
 
 from newsroom import MONGO_PREFIX
 from newsroom.types import TopicResourceModel, UserResourceModel, NotificationType
 from newsroom.exceptions import AuthorizationError
 from newsroom.auth.utils import get_user_from_request
 
-# from newsroom.signals import user_deleted
+from newsroom.signals import user_deleted
 
 from newsroom.users.service import UsersService
 from newsroom.core.resources.service import NewshubAsyncResourceService
-from newsroom.types import User, Topic
-
-from superdesk.core.web import EndpointGroup
-
-# from superdesk.core.module import SuperdeskAsyncApp
+from newsroom.types import Topic
 
 
 class TopicService(NewshubAsyncResourceService[TopicResourceModel]):
@@ -69,36 +67,35 @@ class TopicService(NewshubAsyncResourceService[TopicResourceModel]):
             updates["dashboards"] = updated_dashboards
             await UsersService().system_update(user.id, updates=updates)
 
-    async def on_user_deleted(self, sender, user: User, **kwargs):
-        """
-        Handle the cleanup of user-related topics when a user is deleted.
 
-        This function is tbriggered by the `user_deleted` signal
+async def update_topics_on_user_deleted(user: UserResourceModel) -> None:
+    """
+    Handle the cleanup of user-related topics when a user is deleted.
 
-        """
-        # delete user private topics
-        await self.delete_many(lookup={"is_global": False, "user": user["_id"]})
+    This function is triggered by the `user_deleted` signal
 
-        # remove user topic subscriptions from existing topics
+    """
 
-        topics = await self.search(lookup={"subscribers.user_id": user["_id"]})
+    # delete user private topics
+    service = TopicService()
+    await service.delete_many({"is_global": False, "user": user.id})
 
-        user_object_id = ObjectId(user["_id"])
+    # remove user topic subscriptions from existing topics
+    topics = await service.search({"subscribers.user_id": user.id})
+    async for topic in topics:
+        updates: dict[str, Any] = dict(
+            subscribers=[s.to_dict() for s in topic.subscribers if s.user_id != user.id],
+        )
 
-        async for topic in topics:
-            updates = dict(
-                subscribers=[s for s in topic.subscribers if s["user_id"] != user_object_id],
-            )
+        if topic.user == user.id:
+            updates["user"] = None
 
-            if topic.user == user_object_id:
-                topic.user = None
+        await service.update(topic.id, updates)
 
-            await self.update(topic.id, updates)
-
-        # remove user as a topic creator for the rest
-        user_topics = await self.search(lookup={"user": user["_id"]})
-        async for topic in user_topics:
-            await self.update(topic.id, {"user": None})
+    # remove user as a topic creator for the rest
+    user_topics = await service.search({"user": user.id})
+    async for topic in user_topics:
+        await service.update(topic.id, {"user": None})
 
 
 async def get_user_topics(user_id: Union[ObjectId, str, None]) -> List[Topic]:
@@ -229,10 +226,8 @@ async def auto_enable_user_emails(
     await UsersService().update(user.id, updates={"receive_email": True})
 
 
-# TODO-ASYNC, need to wait for SDESK-7376
-
-# async def init(app: SuperdeskAsyncApp):
-#     user_deleted.connect(await TopicService().on_user_deleted)  # type: ignore
+def init_module(_app: SuperdeskAsyncApp):
+    user_deleted.connect(update_topics_on_user_deleted)
 
 
 topic_resource_config = ResourceConfig(

--- a/newsroom/topics_folders/__init__.py
+++ b/newsroom/topics_folders/__init__.py
@@ -8,12 +8,14 @@ from .folders import (
     topic_folders_resource_config,
     CompanyFoldersResourceService,
     UserFoldersResourceService,
+    init_module,
 )
 
 
 module = Module(
     name="newsroom.topics_folders",
     resources=[company_topic_folder_resource_config, user_topic_folders_resource_config, topic_folders_resource_config],
+    init=init_module,
 )
 
 

--- a/newsroom/topics_folders/folders.py
+++ b/newsroom/topics_folders/folders.py
@@ -4,7 +4,7 @@ from pymongo.errors import DuplicateKeyError
 from bson import ObjectId
 from quart_babel import gettext
 
-# from superdesk.core.module import SuperdeskAsyncApp
+from superdesk.core.module import SuperdeskAsyncApp
 from superdesk.core.resources import (
     ResourceConfig,
     MongoIndexOptions,
@@ -14,12 +14,16 @@ from superdesk.core.resources import (
 )
 
 from newsroom import MONGO_PREFIX
-from newsroom.types import TopicFolderResourceModel, UserTopicFoldersResourceModel, CompanyTopicFoldersResourceModel
+from newsroom.types import (
+    TopicFolderResourceModel,
+    UserTopicFoldersResourceModel,
+    CompanyTopicFoldersResourceModel,
+    UserResourceModel,
+)
 from newsroom.auth import auth_rules
 from newsroom.core.resources import NewshubAsyncResourceService, raise_custom_validation_error
 from newsroom.topics.topics_async import TopicService
-
-# from newsroom.signals import user_deleted
+from newsroom.signals import user_deleted
 
 
 class FolderResourceService(NewshubAsyncResourceService[TopicFolderResourceModel]):
@@ -39,14 +43,13 @@ class FolderResourceService(NewshubAsyncResourceService[TopicFolderResourceModel
         await self.delete_many(lookup={"parent": doc.id})
         await TopicService().delete_many(lookup={"folder": doc.id})
 
-    async def on_user_deleted(self, sender, user, **kwargs):
-        await self.delete_many(lookup={"user": user["_id"]})
+
+async def delete_folders_on_user_deleted(user: UserResourceModel) -> None:
+    await FolderResourceService().delete_many({"user": user.id})
 
 
-# TODO-ASYNC, need to wait for SDESK-7376
-
-# async def init(app: SuperdeskAsyncApp):
-#     user_deleted.connect(await FolderResourceService().on_user_deleted)  # type: ignore
+def init_module(_app: SuperdeskAsyncApp) -> None:
+    user_deleted.connect(delete_folders_on_user_deleted)
 
 
 topic_folders_resource_config = ResourceConfig(

--- a/newsroom/users/service.py
+++ b/newsroom/users/service.py
@@ -62,7 +62,7 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
     async def on_created(self, docs):
         await super().on_created(docs)
         for doc in docs:
-            user_created.send(self, user=doc)
+            await user_created.send(doc)
 
     async def on_update(self, updates, original):
         await super().on_update(updates, original)
@@ -97,11 +97,11 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
                     current_request.storage.session.set("locale", updated_user.locale)
 
         updated = original.model_copy(update=updates)
-        user_updated.send(self, user=updated, updates=updates)
+        await user_updated.send(updated, updates)
 
     async def on_deleted(self, doc):
         get_current_wsgi_app().cache.delete(str(doc.id))
-        user_deleted.send(self, user=doc.to_dict())
+        await user_deleted.send(doc)
 
     async def on_delete(self, doc):
         if doc.id == get_user_id_from_request(None):
@@ -205,7 +205,7 @@ class UsersAuthService(NewshubAsyncResourceService[UserAuthResourceModel]):
     async def on_created(self, docs):
         await super().on_created(docs)
         for doc in docs:
-            user_created.send(self, user=doc)
+            await user_created.send(doc)
 
     async def on_update(self, updates: dict[str, Any], original: UserAuthResourceModel) -> None:
         await super().on_update(updates, original)
@@ -218,11 +218,11 @@ class UsersAuthService(NewshubAsyncResourceService[UserAuthResourceModel]):
 
     async def on_updated(self, updates: dict[str, Any], original: UserAuthResourceModel):
         updated = original.model_copy(update=updates)
-        user_updated.send(self, user=updated, updates=updates)
+        await user_updated.send(updated, updates)
 
     async def on_deleted(self, doc):
         get_current_wsgi_app().cache.delete(str(doc.id))
-        user_deleted.send(self, user=doc.to_dict())
+        await user_deleted.send(doc)
 
     def _get_password_hash(self, password):
         return get_hash(password, get_app_config("BCRYPT_GENSALT_WORK_FACTOR", 12))

--- a/tests/core/test_push_events.py
+++ b/tests/core/test_push_events.py
@@ -1399,7 +1399,7 @@ async def test_push_plan_with_date_before_event_start(client, app):
 
 
 async def test_push_planning_signal(client, app):
-    def on_push_planning(sender, item, is_new, **kwargs):
+    def on_push_planning(item, is_new):
         item["dates"]["all_day"] = True
         assert is_new
 
@@ -1413,7 +1413,7 @@ async def test_push_planning_signal(client, app):
 
 
 async def test_push_events_signal(client, app):
-    def on_push_event(sender, item, is_new, **kwargs):
+    def on_push_event(item, _updates, _original, is_new):
         item["dates"]["all_day"] = True
         assert is_new
 

--- a/tests/core/test_topics.py
+++ b/tests/core/test_topics.py
@@ -452,26 +452,25 @@ async def test_remove_user_topics_on_user_delete(client, app):
     folders = await cursor.to_list_raw()
     assert 2 == len(folders)
 
-    # TODO-ASYNC:- Test cases based on signal
+    response = await client.delete(f"/users/{PUBLIC_USER_ID}")
+    assert 200 == response.status_code
 
-    # await client.delete(f"/users/{PUBLIC_USER_ID}")
+    # make sure it's NOT editable later, as user no longer exists in the system
+    resp = await client.get(f"/api/users/{PUBLIC_USER_ID}/topics")
+    assert 404 == resp.status_code
 
-    # # make sure it's editable later
-    # resp = await client.get(f"/api/users/{PUBLIC_USER_ID}/topics")
-    # assert 200 == resp.status_code
+    cursor = await TopicService().search(lookup={})
+    topics = await cursor.to_list_raw()
+    assert 2 == len(topics)
+    assert "test2" == topics[0]["label"]
+    assert 1 == len(topics[0]["subscribers"])
+    assert "test3" == topics[1]["label"]
+    assert None is topics[1].get("user")
 
-    # cursor = await TopicService().search(lookup={})
-    # topics = await cursor.to_list_raw()
-    # assert 2 == len(topics)
-    # assert "test2" == topics[0]["label"]
-    # assert 1 == len(topics[0]["subscribers"])
-    # assert "test3" == topics[1]["label"]
-    # assert None is topics[1].get("user")
-
-    # cursor = await UserFoldersResourceService().search(lookup={})
-    # folders = await cursor.to_list_raw()
-    # assert 1 == len(folders)
-    # assert "skip" == folders[0]["name"]
+    cursor = await UserFoldersResourceService().search(lookup={})
+    folders = await cursor.to_list_raw()
+    assert 1 == len(folders)
+    assert "skip" == folders[0]["name"]
 
 
 async def test_created_field_in_topic_url(client):

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -487,9 +487,9 @@ async def test_signals(client, app):
     deleted_listener = mock.Mock(return_value=None)
 
     # use weak to fix issue with weak ref and mock
-    user_created.connect(created_listener, weak=False)
-    user_updated.connect(updated_listener, weak=False)
-    user_deleted.connect(deleted_listener, weak=False)
+    user_created.connect(created_listener)
+    user_updated.connect(updated_listener)
+    user_deleted.connect(deleted_listener)
 
     company_ids = await create_entries_for("companies", [{"name": "test", "sections": {"wire": True, "agenda": True}}])
 
@@ -508,13 +508,13 @@ async def test_signals(client, app):
     assert resp.status_code == 201, await resp.get_data(as_text=True)
 
     created_listener.assert_called_once()
-    created_user = created_listener.call_args.kwargs["user"].model_dump(by_alias=True)
-    assert "_id" in created_user
-    assert user["email"] == created_user["email"]
+    created_user = created_listener.call_args[0][0]
+    assert created_user.id
+    assert user["email"] == created_user.email
 
     user["email"] = "foo@example.com"
     user["is_enabled"] = True
-    user_id = created_user["_id"]
+    user_id = created_user.id
     resp = await client.post(
         f"/users/{user_id}",
         form=user,
@@ -522,9 +522,9 @@ async def test_signals(client, app):
     assert resp.status_code == 200, await resp.get_data(as_text=True)
 
     updated_listener.assert_called_once()
-    updated_user = updated_listener.call_args.kwargs["user"].model_dump(by_alias=True)
-    assert user_id == updated_user["_id"]
-    assert user["email"] == updated_user["email"]
+    updated_user = updated_listener.call_args[0][0]
+    assert user_id == updated_user.id
+    assert user["email"] == updated_user.email
     updated_listener.reset_mock()
 
     token = (await find_one_by_id("auth_user", user_id))["token"]
@@ -553,8 +553,9 @@ async def test_signals(client, app):
     assert resp.status_code == 200, await resp.get_data(as_text=True)
 
     deleted_listener.assert_called_once()
-    assert user_id == deleted_listener.call_args.kwargs["user"]["_id"]
-    assert user["email"] == deleted_listener.call_args.kwargs["user"]["email"]
+    deleted_user = deleted_listener.call_args[0][0]
+    assert user_id == deleted_user.id
+    assert user["email"] == deleted_user.email
 
 
 async def test_user_can_update_notification_schedule(app, client):

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -486,7 +486,6 @@ async def test_signals(client, app):
     updated_listener = mock.Mock(return_value=None)
     deleted_listener = mock.Mock(return_value=None)
 
-    # use weak to fix issue with weak ref and mock
     user_created.connect(created_listener)
     user_updated.connect(updated_listener)
     user_deleted.connect(deleted_listener)


### PR DESCRIPTION
### Purpose
Use the new async signal system from core, and fix usage for user delete and topic resource

### What has changed
* Convert the existing signals to `superdesk.core.AsyncSignal`
* Update where signals are sent to
* Re-connect signals that were commented out due to compatibility with old system
* Uncomment tests that were disabled due to old signals not used

Depends on: https://github.com/superdesk/superdesk-core/pull/2760
