### PR TITLE
Fix: Exclude restricted fields when copying Agenda items [STTNHUB-381]

### DIFF
--- a/newsroom/tests/fixtures.py
+++ b/newsroom/tests/fixtures.py
@@ -294,7 +294,7 @@ def setup_user_company(app):
                 "email": "restrict@user.com",
                 "first_name": "Restrict",
                 "last_name": "User",
-                "company": COMPANY_1_ID,
+                "company": COMPANY_3_ID,
                 "is_enabled": True,
                 "is_approved": True,
                 "_created": utcnow(),

--- a/newsroom/tests/fixtures.py
+++ b/newsroom/tests/fixtures.py
@@ -13,8 +13,10 @@ PUBLIC_USER_FIRSTNAME = "Foo"
 PUBLIC_USER_LASTNAME = "Bar"
 PUBLIC_USER_NAME = "{} {}".format(PUBLIC_USER_FIRSTNAME, PUBLIC_USER_LASTNAME)
 TEST_USER_ID = ObjectId("5cc94454bc43165c045ffec9")
+NEW_USER_ID = ObjectId("59b4c5c61d41c8d736852f44")
 COMPANY_1_ID = ObjectId("6215cbf55fc14ebe18e175a5")
 COMPANY_2_ID = ObjectId("6215ce6ed2943dec3725afde")
+COMPANY_3_ID = ObjectId("6215ce6ed2943dec3725af3f")
 PRODUCT_1_ID = ObjectId()
 PRODUCT_2_ID = ObjectId()
 PRODUCT_3_ID = ObjectId()
@@ -242,6 +244,14 @@ def setup_user_company(app):
                 "name": "Paper Co.",
                 "is_enabled": True,
             },
+            {
+                "_id": COMPANY_3_ID,
+                "sd_subscriber_id": "12345",
+                "name": "News Co.",
+                "is_enabled": True,
+                "contact_name": "Ketan",
+                "restrict_coverage_info": True,
+            },
         ],
     )
 
@@ -278,6 +288,21 @@ def setup_user_company(app):
                 "password": "$2b$12$HGyWCf9VNfnVAwc2wQxQW.Op3Ejk7KIGE6urUXugpI0KQuuK6RWIG",
                 "manage_company_topics": False,
             },
+            {
+                "_id": NEW_USER_ID,
+                "user_type": "adminstrator",
+                "email": "restrict@user.com",
+                "first_name": "Restrict",
+                "last_name": "User",
+                "company": COMPANY_1_ID,
+                "is_enabled": True,
+                "is_approved": True,
+                "_created": utcnow(),
+                "receive_email": True,
+                "receive_app_notifications": True,
+                "password": "$2b$12$HGyWCf9VNfnVAwc2wQxQW.Op3Ejk7KIGE6urUXugpI0KQuuK6RWIG",
+                "manage_company_topics": False,
+            },
         ],
     )
 
@@ -295,6 +320,11 @@ def public_company(app, init_company):
 @fixture
 def public_user(app, init_company):
     return app.data.find_one("users", req=None, _id=PUBLIC_USER_ID)
+
+
+@fixture
+def restrict_user(app, init_company):
+    return app.data.find_one("users", req=None, _id=NEW_USER_ID)
 
 
 @fixture

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -56,6 +56,8 @@ from newsroom.public.views import (
 from .search import get_bookmarks_count
 from .items import get_items_for_dashboard
 from ..upload import ASSETS_RESOURCE, get_upload
+from newsroom.companies.utils import restrict_coverage_info
+from newsroom.agenda.utils import remove_fields_for_public_user, remove_restricted_coverage_info
 
 HOME_ITEMS_CACHE_KEY = "home_items"
 HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
@@ -458,6 +460,8 @@ def bookmark():
 def copy(_id):
     item_type = get_type()
     item = get_entity_or_404(_id, item_type)
+    user = get_user()
+    company = get_company(user)
 
     template_filename = "copy_agenda_item" if item_type == "agenda" else "copy_wire_item"
     locale = (get_session_locale() or "en").lower()
@@ -465,17 +469,24 @@ def copy(_id):
 
     template_kwargs = {"item": item}
     if item_type == "agenda":
+        if not is_admin_or_internal(user):
+            remove_fields_for_public_user(item)
+
+        if restrict_coverage_info(company):
+            remove_restricted_coverage_info([item])
+
         template_kwargs.update(
             {
                 "location": "" if item_type != "agenda" else get_location_string(item),
                 "contacts": get_public_contacts(item),
                 "calendars": ", ".join([calendar.get("name") for calendar in item.get("calendars") or []]),
+                "item": item,
             }
         )
     copy_data = flask.render_template(template_name, **template_kwargs).strip()
 
     update_action_list([_id], "copies", item_type=item_type)
-    get_resource_service("history").create_history_record([item], "copy", get_user(), request.args.get("type", "wire"))
+    get_resource_service("history").create_history_record([item], "copy", user, request.args.get("type", "wire"))
     return flask.jsonify({"data": copy_data}), 200
 
 

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -56,8 +56,6 @@ from newsroom.public.views import (
 from .search import get_bookmarks_count
 from .items import get_items_for_dashboard
 from ..upload import ASSETS_RESOURCE, get_upload
-from newsroom.companies.utils import restrict_coverage_info
-from newsroom.agenda.utils import remove_fields_for_public_user, remove_restricted_coverage_info
 
 HOME_ITEMS_CACHE_KEY = "home_items"
 HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
@@ -458,9 +456,13 @@ def bookmark():
 @blueprint.route("/wire/<_id>/copy", methods=["POST"])
 @login_required
 def copy(_id):
+    # Import here to prevent circular imports
+    from newsroom.companies.utils import restrict_coverage_info
+    from newsroom.agenda.utils import remove_fields_for_public_user, remove_restricted_coverage_info
+
     item_type = get_type()
     item = get_entity_or_404(_id, item_type)
-    user = get_user()
+    user = get_user(True)
     company = get_company(user)
 
     template_filename = "copy_agenda_item" if item_type == "agenda" else "copy_wire_item"

--- a/tests/core/test_copy_items.py
+++ b/tests/core/test_copy_items.py
@@ -1,5 +1,6 @@
 from flask import json
 from ..utils import load_fixture, add_fixture_to_db
+from tests import utils
 
 
 def fix_spaces(input):
@@ -27,4 +28,19 @@ def test_copy_wire(client, app):
     assert resp.status_code == 200
 
     expected_text = load_fixture("item_copy_text.txt")
+    assert fix_spaces(data["data"]) == expected_text
+
+
+def test_copy_agenda_with_restricted_coverage_details(client, app, restrict_user):
+    item = add_fixture_to_db("agenda", "agenda_copy_fixture.json")
+    item_id = item["_id"]
+
+    utils.login(client, restrict_user)
+
+    resp = client.post(f"/wire/{item_id}/copy?type=agenda", content_type="application/json")
+    data = json.loads(resp.get_data())
+    assert resp.status_code == 200
+
+    expected_text = load_fixture("agenda_copy_text_2.txt")
+
     assert fix_spaces(data["data"]) == expected_text

--- a/tests/core/test_reports.py
+++ b/tests/core/test_reports.py
@@ -119,7 +119,7 @@ def test_company_products(client):
     resp = client.get("reports/company-products")
     report = json.loads(resp.get_data())
     assert report["name"] == "Products per company"
-    assert len(report["results"]) == 4
+    assert len(report["results"]) == 5
     assert report["results"][0]["name"] == "Example 2 Company"
     assert len(report["results"][0]["products"]) == 1
     assert report["results"][1]["name"] == "Example Company"
@@ -165,10 +165,11 @@ def test_companies(client):
     resp = client.get("reports/company")
     report = json.loads(resp.get_data())
     assert report["name"] == "Company"
-    assert len(report["results"]) == 4
+    assert len(report["results"]) == 5
     assert report["results"][0]["name"] == "Example 2 Company"
     assert report["results"][1]["name"] == "Example Company"
-    assert report["results"][2]["name"] == "Paper Co."
+    assert report["results"][2]["name"] == "News Co."
+    assert report["results"][3]["name"] == "Paper Co."
 
 
 def test_content_activity_csv(client):

--- a/tests/core/test_users.py
+++ b/tests/core/test_users.py
@@ -659,7 +659,7 @@ def test_create_user_inherit_sections(app):
 
 def test_filter_and_sorting_user(app, client):
     users = client.get("/users/search?q=").get_json()
-    assert len(users) == 3
+    assert len(users) == 4
     response = client.get("/users/search?q=admin")
     assert "admin" in response.get_data(as_text=True)
     user_data = response.get_json()[0]
@@ -676,7 +676,7 @@ def test_filter_and_sorting_user(app, client):
     # sort by First_name
     users = client.get("/users/search?q=&sort=[('first_name', 1)]").get_json()
     assert users[0]["first_name"] == "Foo"
-    assert users[2]["first_name"] == "Zoe"
+    assert users[3]["first_name"] == "Zoe"
 
     # sort by Last_name
     users = client.get("/users/search?q=&sort=[('last_name', 1)]").get_json()

--- a/tests/fixtures/agenda_copy_text_2.txt
+++ b/tests/fixtures/agenda_copy_text_2.txt
@@ -1,0 +1,34 @@
+Copy Test
+Dates: 3/23/23, 12:00 AM - 3/23/23, 1:00 AM
+Location: Sydney Harbour Bridge, Hickson Road, Sydney, New South Wales, 2000, Australia
+Ednote: Editorial note to make sure our partners are doing the right thing
+Description: This is a test for copying Data to/from the API and Browser clipboard.
+Invitation Details: Doing stuff about stuff
+Registration Details: Rego details
+Doing stuff about stuff
+And this is the quote.
+
+
+Contacts
+Name: Bob Brown
+Email: bob@brown.org
+Phone: 12345678
+Mobile: 987654321
+
+Name: Mark Pittaway
+Email: bob@bob.com
+Phone: 112233
+Mobile: 44556678
+
+
+Calendars: Sports
+
+
+Planning Item
+Coverage Type: text
+
+
+Planning Item
+Coverage Type: picture
+
+Coverage Type: video


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[STTNHUB-381]


[STTNHUB-381]: https://sofab.atlassian.net/browse/STTNHUB-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ