### PR TITLE
[NHUB-595] fix(command): Get User ID from ResourceModel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,6 @@ jobs:
       - name: behave (Web)
         run: behave --format progress2 --logging-level=ERROR features/web_api
 
-      - name: black
-        run: black --check .
-
   client:
     runs-on: ubuntu-latest
 

--- a/newsroom/notifications/commands.py
+++ b/newsroom/notifications/commands.py
@@ -112,9 +112,7 @@ class SendScheduledNotificationEmails:
                     user.notification_schedule.times = get_app_config("DEFAULT_SCHEDULED_NOTIFICATION_TIMES")
 
                 company = companies.get(user.company)
-                await self.process_schedule(
-                    schedule, user, company, now_utc, user_topic_map.get(user.id) or {}, force
-                )
+                await self.process_schedule(schedule, user, company, now_utc, user_topic_map.get(user.id) or {}, force)
             except Exception as e:
                 logger.exception(e)
                 logger.error("Failed to run schedule for user %s", schedule.user)

--- a/newsroom/notifications/commands.py
+++ b/newsroom/notifications/commands.py
@@ -113,7 +113,7 @@ class SendScheduledNotificationEmails:
 
                 company = companies.get(user.company)
                 await self.process_schedule(
-                    schedule, user, company, now_utc, user_topic_map.get(user["_id"]) or {}, force
+                    schedule, user, company, now_utc, user_topic_map.get(user.id) or {}, force
                 )
             except Exception as e:
                 logger.exception(e)


### PR DESCRIPTION
### Purpose
The SendScheduledNotificationEmails command failed to run, as the user ID was attempting to be accessed via dictionary notation, not dot notation (from the ResourceModel).

This was causing the following exception to be thrown:
```
  File "/opt/newsroom/env/lib/python3.10/site-packages/newsroom/notifications/commands.py", line 116, in run_schedules
    schedule, user, company, now_utc, user_topic_map.get(user["_id"]) or {}, force
TypeError: 'UserResourceModel' object is not subscriptable
```

Resolves: [NHUB-595](https://sofab.atlassian.net/browse/NHUB-595)


[NHUB-595]: https://sofab.atlassian.net/browse/NHUB-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ