### PR TITLE
[NHUB-550|NHUB-549] fix: NewsAPI audit report & time limit setting

### DIFF
--- a/newsroom/news_api/news/item/item.py
+++ b/newsroom/news_api/news/item/item.py
@@ -31,10 +31,11 @@ async def get_item(args: RouteArguments, params: RouteParams, request: Request) 
     formatter = get_formatter_by_classname(params.format)
 
     item = await WireItem.get_service().find_by_id(args.item_id)
+    time_limit = int(get_setting("news_api_time_limit_days") or 0)
     if not item:
         return await request.abort(404)
     # Ensure that the item has not expired
-    elif utcnow() - timedelta(days=int(get_setting("news_api_time_limit_days"))) > item.versioncreated:
+    elif time_limit > 0 and utcnow() - timedelta(days=time_limit) > item.versioncreated:
         return await request.abort(404)
 
     item_dict = item.to_dict()

--- a/newsroom/reports/reports.py
+++ b/newsroom/reports/reports.py
@@ -341,7 +341,7 @@ async def get_company_api_usage():
     date_range = get_date_filters(
         BaseSearchRequestArgs(
             start_date=args["date_from"],
-            end_date=args["date_from"],
+            end_date=args["date_to"],
             timezone_offset=args.get("timezone_offset"),
         )
     )
@@ -365,7 +365,7 @@ async def get_company_api_usage():
                 "query": {
                     "bool": {
                         "filter": [
-                            {"range": {"created": date_range.get("gt")}},
+                            {"range": {"created": date_range}},
                             {"terms": {"subscriber": company_ids}},
                         ],
                     },
@@ -375,8 +375,8 @@ async def get_company_api_usage():
                 "from": page_from,
                 "aggs": {
                     "items": {
-                        "aggs": {"endpoints": {"terms": {"size": 0, "field": "endpoint"}}},
-                        "terms": {"size": 0, "field": "subscriber"},
+                        "aggs": {"endpoints": {"terms": {"size": MAX_TERMS_SIZE, "field": "endpoint"}}},
+                        "terms": {"size": MAX_TERMS_SIZE, "field": "subscriber"},
                     },
                 },
             }


### PR DESCRIPTION
### Purpose
* Elasticsearch query exception being raised when running report from the NewsAPI access audit log
* User unable to retrieve single item from NewsAPI using news/item endpoint

### What has changed
* Fix elasticsearch query for reports using the NewsAPI access audit log
* Disable checking of NewsAPI time limit if the value `is not > 0`

Resolves: [NHUB-549](https://sofab.atlassian.net/browse/NHUB-549) [NHUB-550](https://sofab.atlassian.net/browse/NHUB-550)


[NHUB-549]: https://sofab.atlassian.net/browse/NHUB-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NHUB-550]: https://sofab.atlassian.net/browse/NHUB-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ