### PR TITLE
fix errors from logs

### DIFF
--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -134,10 +134,11 @@ class WireSearchService(BaseSearchService):
         try:
             search.query = {
                 "bool": {
+                    "must": [{"terms": {"_id": item_ids}}],
                     "must_not": [
                         {"term": {"type": "composite"}},
                     ],
-                    "filter": [{"terms": {"_id": item_ids}}],
+                    "filter": [],
                     "should": [],
                 }
             }
@@ -162,7 +163,7 @@ class WireSearchService(BaseSearchService):
 
         except Exception as exc:
             logger.error(
-                "Error in get_items for query: {}".format(json.dumps(search.source)),
+                "Error in get_items for query: {}".format(json.dumps(search.query)),
                 exc,
                 exc_info=True,
             )


### PR DESCRIPTION
```
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         | --- Logging error ---
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         | Traceback (most recent call last):
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         |   File "/opt/newsroom/server/env/lib/python3.10/site-packages/newsroom/wire/search.py", line 148, in get_items
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         |     self.apply_filters(search)
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         |   File "/opt/newsroom/server/env/lib/python3.10/site-packages/newsroom/search/service.py", line 303, in apply_filters
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         |     self.apply_request_filter(search)
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         |   File "/opt/newsroom/server/env/lib/python3.10/site-packages/newsroom/wire/search.py", line 349, in apply_request_filter
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         |     search.query["bool"]["must"].append({"range": {"versioncreated": date_range_query}})
Dec  6 15:58:43 nh-cpcn-uat sh[1477]: 15:58:43 web.1         | KeyError: 'must'
```

### Purpose
Fixing error from uat logs.

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
