### PR TITLE
send emails via `newsroom.push` celery queue

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -433,6 +433,10 @@ CELERY_TASK_ROUTES = {
         "queue": celery_queue("newsroom.push"),
         "routing_key": "newsroom.push",
     },
+    "newsroom.email.*": {
+        "queue": celery_queue("newsroom.push"),
+        "routing_key": "newsroom.push",
+    },
     "newsroom.*": {
         "queue": celery_queue("newsroom"),
         "routing_key": "newsroom.task",


### PR DESCRIPTION
atm emails might get blocked by other tasks

CPCN-983

### What has changed
use `newsroom.push` queue for sending emails instead of the default `newsroom`

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: CPCN-983