### PR TITLE
Don't show empty metadata sections and create an empty state for metadata in general

### DIFF
--- a/assets/agenda/components/AgendaTags.tsx
+++ b/assets/agenda/components/AgendaTags.tsx
@@ -42,7 +42,7 @@ function AgendaTagsComponent({item, plan, isItemDetail, displayConfig, filterGro
             label={gettext('Metadata')}
             top={!isItemDetail}
         >
-            {metadataFields.length
+            {metadataFields.length > 0
                 ? (
                     metadataFields.map((field, index) => <React.Fragment key={index}>{field}</React.Fragment>)
                 )

--- a/assets/agenda/components/AgendaTags.tsx
+++ b/assets/agenda/components/AgendaTags.tsx
@@ -2,37 +2,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
-
 import {gettext, isDisplayed} from 'utils';
 import {filterGroupsToLabelMap} from 'search/selectors';
-
 import InfoBox from 'wire/components/InfoBox';
 import PreviewTagsBlock from 'wire/components/PreviewTagsBlock';
 import {PreviewTagsLinkList} from 'wire/components/PreviewTagsLinkList';
 import {PreviewTagsSubjects} from 'wire/components/PreviewTagsSubjects';
 import {getSubjects} from '../utils';
 
-
 function AgendaTagsComponent({item, plan, isItemDetail, displayConfig, filterGroupLabels}: any) {
-    const services = !isDisplayed('services', displayConfig) ? null : (
-        <PreviewTagsLinkList
-            urlPrefix="/agenda?filter="
-            items={[...(get(item, 'service') || []), ...(get(plan, 'service') || [])]}
-            field="service"
-        />
-    );
+    const metadataFields = [];
+    const subject = [...getSubjects(item), ...getSubjects(plan)];
 
-    const subjects = (
-        <PreviewTagsSubjects
-            subjects={[...getSubjects(item), ...getSubjects(plan)]}
-            displayConfig={displayConfig}
-            urlPrefix="/agenda?filter="
-            filterGroupLabels={filterGroupLabels}
-        />
-    );
+    if ((isDisplayed('services', displayConfig) && item.service.length)) {
+        metadataFields.push(
+            <PreviewTagsBlock label={get(filterGroupLabels, 'service', gettext('Category'))}>
+                <PreviewTagsLinkList
+                    urlPrefix="/agenda?filter="
+                    items={[...(get(item, 'service') || []), ...(get(plan, 'service') || [])]}
+                    field="service"
+                />
+            </PreviewTagsBlock>
+        );
+    }
 
-    if (!subjects && !services) {
-        return null;
+    if(subject.length) {
+        metadataFields.push(
+            <PreviewTagsSubjects
+                subjects={subject}
+                displayConfig={displayConfig}
+                urlPrefix="/agenda?filter="
+                filterGroupLabels={filterGroupLabels}
+            />
+        );
     }
 
     return (
@@ -40,12 +42,16 @@ function AgendaTagsComponent({item, plan, isItemDetail, displayConfig, filterGro
             label={gettext('Metadata')}
             top={!isItemDetail}
         >
-            {!services ? null : (
-                <PreviewTagsBlock label={get(filterGroupLabels, 'service', gettext('Category'))}>
-                    {services}
-                </PreviewTagsBlock>
-            )}
-            {subjects}
+            {metadataFields.length
+                ? (
+                    metadataFields.map((field, index) => <React.Fragment key={index}>{field}</React.Fragment>)
+                )
+                : (
+                    <div className='nh-container nh-container--highlight'>
+                        <p className='nh-container__text--small'>No available Metadata</p>
+                    </div>
+                )
+            }
         </InfoBox>
     );
 }

--- a/assets/wire/components/PreviewTags.tsx
+++ b/assets/wire/components/PreviewTags.tsx
@@ -2,58 +2,72 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
-
 import {gettext, isDisplayed} from 'utils';
 import {filterGroupsToLabelMap} from 'search/selectors';
-
 import InfoBox from './InfoBox';
 import PreviewTagsBlock from './PreviewTagsBlock';
 import {PreviewTagsSubjects} from './PreviewTagsSubjects';
 import {PreviewTagsLinkList} from './PreviewTagsLinkList';
 import ArticleSlugline from 'ui/components/ArticleSlugline';
 
-
 function PreviewTagsComponent({item, isItemDetail, displayConfig, filterGroupLabels}: any) {
-    const services = !isDisplayed('services', displayConfig) ? null : (
-        <PreviewTagsLinkList
-            urlPrefix="/wire?filter="
-            items={item.service}
-            field="service"
-        />
-    );
-    const genres = !isDisplayed('genre', displayConfig) ? null : (
-        <PreviewTagsLinkList
-            urlPrefix="/wire?filter="
-            items={item.genre}
-            field="genre"
-        />
-    );
+    const metadataFields = [];
 
-    return (
-        <InfoBox label={gettext('Metadata')} top={!isItemDetail}>
-            {isDisplayed('slugline', displayConfig) && (
-                <PreviewTagsBlock label={gettext('Slugline')}>
-                    <ArticleSlugline item={item}/>
-                </PreviewTagsBlock>)}
+    if (isDisplayed('slugline', displayConfig)) {
+        metadataFields.push(
+            <PreviewTagsBlock label={gettext('Slugline')}>
+                <ArticleSlugline item={item}/>
+            </PreviewTagsBlock>
+        );
+    }
 
-            {!services ? null : (
-                <PreviewTagsBlock label={get(filterGroupLabels, 'service', gettext('Category'))}>
-                    {services}
-                </PreviewTagsBlock>
-            )}
+    if ((isDisplayed('services', displayConfig) && item.service != null)) {
+        metadataFields.push(
+            <PreviewTagsBlock label={get(filterGroupLabels, 'service', gettext('Category'))}>
+                <PreviewTagsLinkList
+                    urlPrefix="/wire?filter="
+                    items={item.service}
+                    field="service"
+                />
+            </PreviewTagsBlock>
+        );
+    }
 
+    if ((isDisplayed('genre', displayConfig) && item.genre != null)) {
+        metadataFields.push(
+            <PreviewTagsBlock label={get(filterGroupLabels, 'genre', gettext('Content Type'))}>
+                <PreviewTagsLinkList
+                    urlPrefix="/wire?filter="
+                    items={item.genre}
+                    field="genre"
+                />
+            </PreviewTagsBlock>
+        );
+    }
+
+    if (item.subject) {
+        metadataFields.push(
             <PreviewTagsSubjects
-                subjects={item.subject || []}
+                subjects={item.subject}
                 displayConfig={displayConfig}
                 urlPrefix="/wire?filter="
                 filterGroupLabels={filterGroupLabels}
             />
+        );
+    }
 
-            {!genres ? null : (
-                <PreviewTagsBlock label={get(filterGroupLabels, 'genre', gettext('Content Type'))}>
-                    {genres}
-                </PreviewTagsBlock>
-            )}
+    return (
+        <InfoBox label={gettext('Metadata')} top={!isItemDetail}>
+            {metadataFields.length
+                ? (
+                    metadataFields.map((field, index) => <React.Fragment key={index}>{field}</React.Fragment>)
+                )
+                : (
+                    <div className='nh-container nh-container--highlight'>
+                        <p className='nh-container__text--small'>No available Metadata</p>
+                    </div>
+                )
+            }
         </InfoBox>
     );
 }

--- a/assets/wire/components/PreviewTags.tsx
+++ b/assets/wire/components/PreviewTags.tsx
@@ -58,7 +58,7 @@ function PreviewTagsComponent({item, isItemDetail, displayConfig, filterGroupLab
 
     return (
         <InfoBox label={gettext('Metadata')} top={!isItemDetail}>
-            {metadataFields.length
+            {metadataFields.length > 0
                 ? (
                     metadataFields.map((field, index) => <React.Fragment key={index}>{field}</React.Fragment>)
                 )


### PR DESCRIPTION
NHUB-610

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
For the ‘Category’ section we show the label even if there are no values available. This is not consistent wit other metadata fields. The sections should be hidded if there is no data available

### What has changed
<!--- Explain what has changed and how -->
Rendering of metadata fields

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
1. Open an article panel
2. Scroll to the metadata section

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
