### PR TITLE
[NHUB-592] fix: User profile not showing if user has no product permissions

### DIFF
--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -19,7 +19,6 @@ from newsroom.auth.utils import (
 )
 from newsroom.ui_config_async import UiConfigResourceService
 from newsroom.formatters import get_formatters_id_and_names
-from newsroom.users import get_user_profile_data
 from newsroom.products import get_products_by_company
 from newsroom.topics import get_user_topics_async
 from newsroom.topics_folders import get_company_folders, get_user_folders
@@ -56,17 +55,15 @@ from .filters import AgendaSearchRequestArgs
 
 @agenda_endpoints.endpoint("/agenda", auth=[auth_rules.section_required("agenda")])
 async def index() -> str:
-    user_profile_data = await get_user_profile_data()
     data = await get_view_data()
-    return await render_template("agenda_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("agenda_index.html", data=data)
 
 
 @agenda_endpoints.endpoint("/bookmarks_agenda")
 async def bookmarks() -> str:
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
     data["bookmarks"] = True
-    return await render_template("agenda_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("agenda_bookmarks.html", data=data)
 
 
 class AgendaItemViewArgs(BaseModel):
@@ -113,7 +110,6 @@ async def item(args: AgendaItemViewArgs, params: AgendaItemParams, request: Requ
     if is_json_request(request):
         return Response(agenda_item_dict)
 
-    user_profile_data = await get_user_profile_data()
     if params.print:
         template = "agenda_item_print.html"
         await update_action_list([args.item_id], "prints", force_insert=True)
@@ -127,7 +123,6 @@ async def item(args: AgendaItemViewArgs, params: AgendaItemParams, request: Requ
             contacts=get_public_contacts(agenda_item_dict),
             links=get_links(agenda_item_dict),
             is_admin=user.is_admin_or_internal(),
-            user_profile_data=user_profile_data,
         )
 
     data = await get_view_data()
@@ -136,7 +131,6 @@ async def item(args: AgendaItemViewArgs, params: AgendaItemParams, request: Requ
         "agenda_index.html",
         data=data,
         title=agenda_item_dict.get("name", agenda_item_dict.get("headline")),
-        user_profile_data=user_profile_data,
     )
 
 

--- a/newsroom/am_news/views.py
+++ b/newsroom/am_news/views.py
@@ -20,7 +20,6 @@ from newsroom.wire.views import (
 from newsroom.utils import get_json_or_400, get_entity_or_404, is_json_request, get_type
 from newsroom.notifications import push_user_notification
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +49,7 @@ async def get_view_data():
 @section("am_news")
 async def index():
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("am_news_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("am_news_index.html", data=data)
 
 
 @blueprint.route("/am_news/search")
@@ -65,9 +63,8 @@ async def search():
 @login_required
 async def bookmarks():
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
     data["bookmarks"] = True
-    return await render_template("am_news_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("am_news_bookmarks.html", data=data)
 
 
 @blueprint.route("/am_news_bookmark", methods=["POST", "DELETE"])
@@ -109,7 +106,6 @@ async def versions(_id):
 @login_required
 async def item(_id):
     item = get_entity_or_404(_id, "items")
-    user_profile_data = await get_user_profile_data()
     set_permissions(item, "am_news")
     ui_config_service = UiConfigResourceService()
     config = await ui_config_service.get_section_config("am_news")
@@ -117,7 +113,7 @@ async def item(_id):
     if is_json_request(request):
         return jsonify(item)
     if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item, user_profile_data=user_profile_data)
+        return await render_template("wire_item_access_restricted.html", item=item)
     previous_versions = get_previous_versions(item)
     if "print" in request.args:
         template = "wire_item_print.html"
@@ -129,5 +125,4 @@ async def item(_id):
         item=item,
         previous_versions=previous_versions,
         display_char_count=display_char_count,
-        user_profile_data=user_profile_data,
     )

--- a/newsroom/company_admin/views.py
+++ b/newsroom/company_admin/views.py
@@ -13,7 +13,6 @@ from newsroom.auth import auth_rules
 from newsroom.types import Company, Product
 from newsroom.core import get_current_wsgi_app
 from newsroom.email import send_template_email
-from newsroom.users import get_user_profile_data
 from newsroom.companies.utils import get_users_by_company
 from newsroom.utils import get_json_or_400_async, query_resource
 from newsroom.settings import get_settings_collection, GENERAL_SETTINGS_LOOKUP
@@ -24,10 +23,7 @@ blueprint = EndpointGroup("company_admin", __name__)
 
 @blueprint.endpoint("/company_admin", auth=[auth_rules.company_admin_only])
 async def index():
-    user_profile_data = await get_user_profile_data()
-    return await render_template(
-        "company_admin_index.html", data=(await get_view_data()), user_profile_data=user_profile_data
-    )
+    return await render_template("company_admin_index.html", data=(await get_view_data()))
 
 
 def filter_disabled_products(company: Company, products: List[Product]) -> Company:

--- a/newsroom/factcheck/views.py
+++ b/newsroom/factcheck/views.py
@@ -18,7 +18,6 @@ from newsroom.wire.views import (
 from newsroom.utils import get_json_or_400, get_entity_or_404, is_json_request, get_type
 from newsroom.notifications import push_user_notification
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +43,7 @@ async def get_view_data():
 @section("factcheck")
 async def index():
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("factcheck_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("factcheck_index.html", data=data)
 
 
 @blueprint.route("/factcheck/search")
@@ -61,8 +59,7 @@ async def search():
 async def bookmarks():
     data = get_view_data()
     data["bookmarks"] = True
-    user_profile_data = await get_user_profile_data()
-    return await render_template("factcheck_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("factcheck_bookmarks.html", data=data)
 
 
 @blueprint.route("/factcheck_bookmark", methods=["POST", "DELETE"])
@@ -102,7 +99,6 @@ async def versions(_id):
 @blueprint.route("/factcheck/<_id>")
 @login_required
 async def item(_id):
-    user_profile_data = await get_user_profile_data()
     item = get_entity_or_404(_id, "items")
     await set_permissions(item, "factcheck")
     ui_config_service = UiConfigResourceService()
@@ -111,7 +107,7 @@ async def item(_id):
     if is_json_request(request):
         return jsonify(item)
     if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item, user_profile_data=user_profile_data)
+        return await render_template("wire_item_access_restricted.html", item=item)
     previous_versions = get_previous_versions(item)
     if "print" in request.args:
         template = "wire_item_print.html"
@@ -123,5 +119,4 @@ async def item(_id):
         item=item,
         previous_versions=previous_versions,
         display_char_count=display_char_count,
-        user_profile_data=user_profile_data,
     )

--- a/newsroom/market_place/views.py
+++ b/newsroom/market_place/views.py
@@ -25,7 +25,6 @@ from newsroom.utils import (
 )
 from newsroom.notifications import push_user_notification
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data
 from newsroom.cards import CardsResourceService
 
 search_endpoint_name = "{}_search".format(SECTION_ID)
@@ -89,18 +88,14 @@ async def get_home_page_data():
 @section(SECTION_ID)
 async def index():
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("market_place_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("market_place_index.html", data=data)
 
 
 @blueprint.route("/{}/home".format(SECTION_ID))
 @login_required
 @section(SECTION_ID)
 async def home():
-    user_profile_data = await get_user_profile_data()
-    return await render_template(
-        "market_place_home.html", data=get_home_page_data(), user_profile_data=user_profile_data
-    )
+    return await render_template("market_place_home.html", data=get_home_page_data())
 
 
 @blueprint.route("/{}/search".format(SECTION_ID))
@@ -116,8 +111,7 @@ async def search():
 async def bookmarks():
     data = await get_view_data()
     data["bookmarks"] = True
-    user_profile_data = await get_user_profile_data()
-    return await render_template("market_place_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("market_place_bookmarks.html", data=data)
 
 
 @blueprint.route("/{}_bookmark".format(SECTION_ID), methods=["POST", "DELETE"])
@@ -163,11 +157,10 @@ async def item(_id):
     ui_config_service = UiConfigResourceService()
     config = await ui_config_service.get_section_config(SECTION_ID)
     display_char_count = config.get("char_count", False)
-    user_profile_data = await get_user_profile_data()
     if is_json_request(request):
         return jsonify(item)
     if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item, user_profile_data=user_profile_data)
+        return await render_template("wire_item_access_restricted.html", item=item)
     previous_versions = get_previous_versions(item)
     if "print" in request.args:
         template = "wire_item_print.html"
@@ -179,5 +172,4 @@ async def item(_id):
         item=item,
         previous_versions=previous_versions,
         display_char_count=display_char_count,
-        user_profile_data=user_profile_data,
     )

--- a/newsroom/media_releases/views.py
+++ b/newsroom/media_releases/views.py
@@ -18,7 +18,6 @@ from newsroom.wire.views import (
 from newsroom.utils import get_json_or_400, get_entity_or_404, is_json_request, get_type
 from newsroom.notifications import push_user_notification
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +43,7 @@ async def get_view_data():
 @section("media_releases")
 async def index():
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("media_releases_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("media_releases_index.html", data=data)
 
 
 @blueprint.route("/media_releases/search")
@@ -61,8 +59,7 @@ async def search():
 async def bookmarks():
     data = await get_view_data()
     data["bookmarks"] = True
-    user_profile_data = await get_user_profile_data()
-    return await render_template("media_releases_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("media_releases_bookmarks.html", data=data)
 
 
 @blueprint.route("/media_releases_bookmark", methods=["POST", "DELETE"])
@@ -107,11 +104,10 @@ async def item(_id):
     ui_config_service = UiConfigResourceService()
     config = await ui_config_service.get_section_config("media_releases")
     display_char_count = config.get("char_count", False)
-    user_profile_data = await get_user_profile_data()
     if is_json_request(request):
         return jsonify(item)
     if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item, user_profile_data=user_profile_data)
+        return await render_template("wire_item_access_restricted.html", item=item)
     previous_versions = get_previous_versions(item)
     if "print" in request.args:
         template = "wire_item_print.html"
@@ -123,5 +119,4 @@ async def item(_id):
         item=item,
         previous_versions=previous_versions,
         display_char_count=display_char_count,
-        user_profile_data=user_profile_data,
     )

--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -21,7 +21,7 @@ from newsroom.notifications import push_user_notification
 from newsroom.wire import WireSearchServiceAsync
 
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data, UsersService
+from newsroom.users import UsersService
 from newsroom.companies import CompanyServiceAsync
 from newsroom.history_async import HistoryService
 
@@ -230,8 +230,7 @@ async def delete(args: MonitoringIdUrlArg, params: None, request: Request) -> Re
 @monitoring_endpoints.endpoint("/monitoring", auth=[auth_rules.section_required("monitoring")])
 async def index():
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("monitoring_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("monitoring_index.html", data=data)
 
 
 class ExportMonitoringUrlArgs(BaseModel):
@@ -360,5 +359,4 @@ async def bookmark(request: Request) -> Response:
 async def bookmarks():
     data = await get_view_data()
     data["bookmarks"] = True
-    user_profile_data = await get_user_profile_data()
-    return await render_template("monitoring_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("monitoring_bookmarks.html", data=data)

--- a/newsroom/public/views.py
+++ b/newsroom/public/views.py
@@ -11,7 +11,6 @@ from newsroom.auth.utils import is_valid_session
 from newsroom.types import Article, CardResourceModel
 from newsroom.wire.items import get_items_for_dashboard
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data
 from newsroom.cards import CardsResourceService
 
 PUBLIC_DASHBOARD_CONFIG_CACHE_KEY = "public-dashboard-config"
@@ -68,7 +67,6 @@ async def page(args: PageArgs, _p: None, _r: None):
 
 
 async def render_public_dashboard():
-    user_profile_data = await get_user_profile_data()
     return await render_template(
         "public_dashboard.html",
         data={
@@ -77,7 +75,6 @@ async def render_public_dashboard():
             "items_by_card": await get_public_items_by_cards(),
             "groups": get_app_config("WIRE_GROUPS", []),
         },
-        user_profile_data=user_profile_data,
     )
 
 

--- a/newsroom/reports/views.py
+++ b/newsroom/reports/views.py
@@ -14,7 +14,6 @@ from newsroom.auth.utils import get_user_from_request
 from newsroom.utils import query_resource
 
 from .utils import get_current_user_reports
-from newsroom.users import get_user_profile_data
 
 
 class RouteArguments(BaseModel):
@@ -49,7 +48,6 @@ async def print_reports(args: RouteArguments, params: None, request: Request):
 )
 async def company_reports(request: Request):
     companies = list(query_resource("companies"))
-    user_profile_data = await get_user_profile_data()
     user = get_user_from_request(request)
     data = {
         "companies": companies,
@@ -57,9 +55,7 @@ async def company_reports(request: Request):
         "api_enabled": get_app_config("NEWS_API_ENABLED", False),
         "current_user_type": user.user_type,
     }
-    return await render_template(
-        "company_reports.html", setting_type="company_reports", data=data, user_profile_data=user_profile_data
-    )
+    return await render_template("company_reports.html", setting_type="company_reports", data=data)
 
 
 @blueprint.endpoint(

--- a/newsroom/settings/views.py
+++ b/newsroom/settings/views.py
@@ -25,18 +25,13 @@ class SettingsAppRouteParams(BaseModel):
 
 @settings_endpoints.endpoint("/settings/<app_id>", methods=["GET"], auth=[auth_rules.account_manager_only])
 async def settings_app(args: SettingsAppRouteParams, params: None, request: Request):
-    from newsroom.users import get_user_profile_data  # noqa
-
-    user_profile_data = await get_user_profile_data()
     app = get_current_wsgi_app()
 
     for app in app.settings_apps:
         if app._id == args.app_id:
             value = app.data()
             data = await value if iscoroutine(value) else value
-            return await render_template(
-                "settings.html", setting_type=args.app_id, data=data, user_profile_data=user_profile_data
-            )
+            return await render_template("settings.html", setting_type=args.app_id, data=data)
 
     await request.abort(404)
 

--- a/newsroom/templates/authorization_error.html
+++ b/newsroom/templates/authorization_error.html
@@ -8,3 +8,7 @@
     </div>
 </section>
 {% endblock %}
+
+{% block script %}
+    {{ javascript_tag('user_profile_js') | safe }}
+{% endblock %}

--- a/newsroom/templates/scripts.html
+++ b/newsroom/templates/scripts.html
@@ -14,7 +14,7 @@
 
     {% if session.get("user") %}
         window.notificationData = {{ get_initial_notifications() | tojson | safe }};
-        window.profileData = {{ user_profile_data | tojson | safe }};
+        window.profileData = {{ get_user_profile_data() | tojson | safe }};
         window.searchTipsHtml = {
             regular: `{{ render_search_tips_html('regular') | safe }}`,
             advanced: `{{ render_search_tips_html('advanced') | safe }}`,

--- a/newsroom/users/__init__.py
+++ b/newsroom/users/__init__.py
@@ -22,6 +22,7 @@ def init_app(app):
         data=views.get_settings_data,
         allow_account_mgr=True,
     )
+    app.add_template_global(get_user_profile_data)
 
 
 async def get_user_profile_data():

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -67,7 +67,6 @@ from newsroom.public.views import (
 
 from newsroom.assets import get_upload, get_media_file
 from newsroom.ui_config_async import UiConfigResourceService
-from newsroom.users import get_user_profile_data
 from newsroom.history_async import HistoryService
 
 from .items import get_items_for_dashboard
@@ -262,8 +261,7 @@ async def index():
         data = await render_public_dashboard() if get_app_config("PUBLIC_DASHBOARD") else redirect_to_login()
         return data
     data = await get_home_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("home.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("home.html", data=data)
 
 
 class MediaCardRouteArguments(BaseModel):
@@ -298,16 +296,14 @@ async def get_card_items() -> Response:
 @wire_endpoints.endpoint("/wire", auth=[auth_rules.section_required("wire")])
 async def wire() -> str:
     data = await get_view_data()
-    user_profile_data = await get_user_profile_data()
-    return await render_template("wire_index.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("wire_index.html", data=data)
 
 
 @wire_endpoints.endpoint("/bookmarks_wire")
 async def bookmarks() -> str:
     data = await get_view_data()
     data["bookmarks"] = True
-    user_profile_data = await get_user_profile_data()
-    return await render_template("wire_bookmarks.html", data=data, user_profile_data=user_profile_data)
+    return await render_template("wire_bookmarks.html", data=data)
 
 
 @wire_endpoints.endpoint("/wire/search", auth=[auth_rules.section_required("wire")])
@@ -534,7 +530,6 @@ async def copy(args: WireItemRouteArgs, params: ItemActionUrlParams, request: Re
                 "location": "" if item_type != "agenda" else get_location_string(item_to_copy),
                 "contacts": get_public_contacts(item_to_copy),
                 "calendars": ", ".join([calendar.get("name") for calendar in item_to_copy.get("calendars") or []]),
-                "user_profile_data": await get_user_profile_data(),
             }
         )
     copy_data = (await render_template(template_name, **template_kwargs)).strip()
@@ -579,14 +574,11 @@ async def item(args: WireItemRouteArgs, params: WireItemUrlParams, request: Requ
     ui_config_service = UiConfigResourceService()
     config = await ui_config_service.get_section_config("wire")
     display_char_count = config.get("char_count", False)
-    user_profile_data = await get_user_profile_data()
     if is_json_request(request):
         return Response(wire_item)
 
     if not wire_item.user_has_access:
-        return await render_template(
-            "wire_item_access_restricted.html", item=wire_item, user_profile_data=user_profile_data
-        )
+        return await render_template("wire_item_access_restricted.html", item=wire_item)
 
     previous_versions = await get_previous_versions(wire_item)
     template = "wire_item.html"
@@ -609,7 +601,6 @@ async def item(args: WireItemRouteArgs, params: WireItemUrlParams, request: Requ
         **data,
         previous_versions=previous_versions,
         display_char_count=display_char_count,
-        user_profile_data=user_profile_data,
     )
 
 


### PR DESCRIPTION
### Purpose
If the user does not have any product permissions, the user profile react app was not being rendered (which includes the logout menu). This was caused by the auth error template not rendering the user-profile react app not providing user session details.

### What has changed
* Move user_profile_data to a template global function, and remove from all views (let the template call it instead)
* Add `user_profile_js` file to the auth error template

Resolves: [NHUB-592](https://sofab.atlassian.net/browse/NHUB-592)


[NHUB-592]: https://sofab.atlassian.net/browse/NHUB-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ