### PR TITLE
[NHUB-611] fix: Exception raised when selecting all products when value is currently null

### DIFF
--- a/assets/interfaces/user.ts
+++ b/assets/interfaces/user.ts
@@ -35,7 +35,7 @@ export interface IUser {
 
     original_creator?: IUser['_id'];
     version_creator?: IUser['_id'];
-    products: Array<{
+    products?: Array<{
         _id: string;
         section: 'wire' | 'agenda';
     }>;

--- a/assets/users/utils.ts
+++ b/assets/users/utils.ts
@@ -89,5 +89,5 @@ export function hasSeatsAvailable(companyId: ICompany['_id'], seats: ISeats, pro
 }
 
 export function seatOccupiedByUser(user: IUser, product: IProduct) {
-    return user.products.find((userProduct: {section: string; _id: string}) => userProduct._id === product._id);
+    return (user.products || []).find((userProduct) => userProduct._id === product._id);
 }


### PR DESCRIPTION
### Purpose
In front-end code we're assuming `User.products` always has a value, which is not always the case, it may sometimes be `null`. This causes an issue with the `Select All` button in Company Admin -> EditUser form.

**Notes:**
* This is not caused by the async changes, but discovered during testing of.
* I know this can be solved on the backend, but it was causing multiple tests to fail by defaulting to an empty list, so I decided to fix it in the front-end where it is used.

### What has changed
* Update typescript IUser interface to reflect optional value for `products` field
* Fix user util to check if User occupies seat for a Product

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: [NHUB-611](https://sofab.atlassian.net/browse/NHUB-611)


[NHUB-611]: https://sofab.atlassian.net/browse/NHUB-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ