### PR TITLE
fix: Exception raised with agenda push notifications

### DIFF
--- a/newsroom/agenda/agenda_service.py
+++ b/newsroom/agenda/agenda_service.py
@@ -383,7 +383,7 @@ class AgendaItemService(AsyncResourceService[AgendaItem]):
                 }
                 await self.system_update(item["_id"], updates)
 
-            updated_agenda = self.find_by_id(item["_id"])
+            updated_agenda = await self.find_by_id(item["_id"])
             # Notify agenda to update itself with new details of coverage
             parent_coverage["publish_time"] = wire_item.get("publish_schedule") or wire_item.get("firstpublished")
             await push_agenda_item_notification("new_item", item=item)

--- a/newsroom/commands/__init__.py
+++ b/newsroom/commands/__init__.py
@@ -25,5 +25,5 @@ from .cli import commands_blueprint, newsroom_cli
 
 
 @celery.task(soft_time_limit=600)
-def async_remove_expired_agenda():
-    remove_expired_agenda()
+async def async_remove_expired_agenda():
+    await remove_expired_agenda()


### PR DESCRIPTION
### Purpose
I found the following 2 log entries in the nra-async instance:
```
newsroom/push/publishing.py:92: RuntimeWarning: coroutine 'AsyncResourceService.find_by_id' was never awaited
newsroom/commands/__init__.py:29: RuntimeWarning: coroutine 'remove_expired_agenda' was never awaited
```

### What has changed
* Add async/await to appropriate sections of code