### PR TITLE
[STTNHUB-380] improve: Expose coverage schedule when restrict_coverage_info is on

### DIFF
--- a/features/web_api/agenda_restrict_coverage_details.feature
+++ b/features/web_api/agenda_restrict_coverage_details.feature
@@ -209,14 +209,14 @@ Feature: Agenda Restricted Coverage Details
             "coverages": [{
                 "coverage_id": "plan1_cov1",
                 "coverage_type": "text",
-                "scheduled": "__no_value__",
+                "scheduled": "2018-05-28T10:51:52+0000",
                 "slugline": "__no_value__",
                 "workflow_status": "__no_value__",
                 "coverage_status": "__no_value__"
             }, {
                 "coverage_id": "plan1_cov2",
                 "coverage_type": "text",
-                "scheduled": "__no_value__",
+                "scheduled": "2018-05-28T10:51:52+0000",
                 "slugline": "__no_value__",
                 "workflow_status": "__no_value__",
                 "coverage_status": "__no_value__"
@@ -234,7 +234,7 @@ Feature: Agenda Restricted Coverage Details
                         "g2_content_type": "text",
                         "ednote": "__no_value__",
                         "internal_note": "__no_value__",
-                        "scheduled": "__no_value__",
+                        "scheduled": "2018-05-28T10:51:52+0000",
                         "slugline": "__no_value__"
                     }
                 }, {
@@ -245,7 +245,7 @@ Feature: Agenda Restricted Coverage Details
                         "g2_content_type": "text",
                         "ednote": "__no_value__",
                         "internal_note": "__no_value__",
-                        "scheduled": "__no_value__",
+                        "scheduled": "2018-05-28T10:51:52+0000",
                         "slugline": "__no_value__"
                     }
                 }]
@@ -276,7 +276,7 @@ Feature: Agenda Restricted Coverage Details
             "coverages": [{
                 "coverage_id": "plan1_cov1",
                 "coverage_type": "text",
-                "scheduled": "__no_value__",
+                "scheduled": "2018-05-28T10:51:52+0000",
                 "slugline": "__no_value__",
                 "workflow_status": "__no_value__",
                 "coverage_status": "__no_value__"
@@ -299,7 +299,7 @@ Feature: Agenda Restricted Coverage Details
                         "g2_content_type": "text",
                         "ednote": "__no_value__",
                         "internal_note": "__no_value__",
-                        "scheduled": "__no_value__",
+                        "scheduled": "2018-05-28T10:51:52+0000",
                         "slugline": "__no_value__"
                     }
                 }, {
@@ -366,14 +366,14 @@ Feature: Agenda Restricted Coverage Details
             "coverages": [{
                 "coverage_id": "plan1_cov1",
                 "coverage_type": "text",
-                "scheduled": "__no_value__",
+                "scheduled": "2018-05-28T10:51:52+0000",
                 "slugline": "__no_value__",
                 "workflow_status": "__no_value__",
                 "coverage_status": "__no_value__"
             }, {
                 "coverage_id": "plan1_cov2",
                 "coverage_type": "text",
-                "scheduled": "__no_value__",
+                "scheduled": "2018-05-28T10:51:52+0000",
                 "slugline": "__no_value__",
                 "workflow_status": "__no_value__",
                 "coverage_status": "__no_value__"

--- a/newsroom/agenda/utils.py
+++ b/newsroom/agenda/utils.py
@@ -222,6 +222,8 @@ def remove_restricted_coverage_info(items):
         "delivery_id",
         "delivery_href",
         "deliveries",
+        "scheduled",
+        "g2_content_type",
     )
 
     planning_keys_to_copy = (
@@ -266,7 +268,9 @@ def remove_restricted_coverage_info(items):
             ]
             for coverage in plan["coverages"]:
                 if not coverage_is_completed(coverage):
-                    coverage["planning"] = {"g2_content_type": coverage["planning"]["g2_content_type"]}
+                    coverage["planning"] = {
+                        key: val for key, val in coverage["planning"].items() if key in coverage_keys_to_copy
+                    }
 
     return items
 


### PR DESCRIPTION
### Purpose
When the `restrict_coverage_info` is turned on for a Company, Coverages are all shown on the 1 day regardless of their due date. This causes confusion as end users would then expect multiple coverages to be completed on that day.

### What has changed
* Expose Coverage Scheduled field when `restrict_coverage_info` is turned on

Resolves: [STTNHUB-380](https://sofab.atlassian.net/browse/STTNHUB-380)


[STTNHUB-380]: https://sofab.atlassian.net/browse/STTNHUB-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ