### PR TITLE
fix: Update services after core changes to create response type and validation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,9 +8,9 @@ aiofiles==24.1.0
     # via
     #   quart
     #   quart-uploads
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via elasticsearch
 aiosignal==1.3.2
     # via aiohttp
@@ -39,7 +39,7 @@ attrs==25.1.0
     # via aiohttp
 authlib==1.4.1
     # via superdesk-core
-babel==2.16.0
+babel==2.17.0
     # via quart-babel
 bcrypt==4.2.1
     # via superdesk-core
@@ -57,9 +57,9 @@ blinker==1.9.0
     #   quart
     #   sentry-sdk
     #   superdesk-core
-boto3==1.36.9
+boto3==1.36.23
     # via superdesk-core
-botocore==1.36.9
+botocore==1.36.23
     # via
     #   boto3
     #   s3transfer
@@ -75,7 +75,7 @@ cerberus==1.3.7
     # via
     #   eve
     #   superdesk-core
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   elastic-apm
     #   elasticsearch
@@ -107,11 +107,11 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via pytest-cov
 croniter==6.0.0
     # via superdesk-core
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   authlib
     #   jwcrypto
@@ -119,7 +119,7 @@ cryptography==44.0.0
     #   pyhanko-certvalidator
 cssselect2==0.7.0
     # via svglib
-deepdiff==8.1.1
+deepdiff==8.2.0
     # via superdesk-planning
 dnspython==2.7.0
     # via
@@ -148,7 +148,7 @@ exceptiongroup==1.2.2
     #   taskgroup
 feedparser==6.0.11
     # via superdesk-core
-flake8==7.1.1
+flake8==7.1.2
     # via -r dev-requirements.in
 flask==3.1.0
     # via
@@ -177,7 +177,7 @@ h11==0.14.0
     # via
     #   hypercorn
     #   wsproto
-h2==4.1.0
+h2==4.2.0
     # via hypercorn
 hachoir==3.3.0
     # via superdesk-core
@@ -233,7 +233,7 @@ kombu==5.4.2
     #   superdesk-core
 ldap3==2.9.1
     # via superdesk-core
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   draftjs-exporter
     #   lxml-html-clean
@@ -258,7 +258,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-mypy==1.14.1
+mypy==1.15.0
     # via -r mypy-requirements.txt
 mypy-extensions==1.0.0
     # via
@@ -268,7 +268,7 @@ oauth2client==4.1.3
     # via flask-oidc-ex
 oauthlib==3.2.2
     # via requests-oauthlib
-orderly-set==5.2.3
+orderly-set==5.3.0
     # via deepdiff
 oscrypto==1.3.0
     # via pyhanko-certvalidator
@@ -342,7 +342,7 @@ pyparsing==3.2.1
     # via
     #   httplib2
     #   pyrtf3
-pypdf==5.2.0
+pypdf==5.3.0
     # via xhtml2pdf
 pyrtf3==0.47.5
     # via -r requirements.txt
@@ -378,7 +378,7 @@ python-twitter==3.5
     # via superdesk-core
 python3-saml==1.16.0
     # via -r requirements.txt
-pytz==2024.2
+pytz==2025.1
     # via
     #   croniter
     #   eve-elastic
@@ -418,7 +418,7 @@ redis==5.2.1
     #   superdesk-core
 regex==2024.11.6
     # via superdesk-core
-reportlab==4.2.5
+reportlab==4.3.1
     # via
     #   superdesk-core
     #   svglib
@@ -449,7 +449,7 @@ sentry-sdk[quart]==1.45.1
     #   superdesk-core
 sgmllib3k==1.0.0
     # via feedparser
-simplejson==3.19.3
+simplejson==3.20.1
     # via eve
 six==1.17.0
     # via
@@ -491,13 +491,13 @@ types-jinja2==2.11.9
     #   types-flask
 types-markupsafe==1.1.10
     # via types-jinja2
-types-protobuf==5.29.1.20241207
+types-protobuf==5.29.1.20250208
     # via -r mypy-requirements.txt
 types-python-dateutil==2.9.0.20241206
     # via
     #   -r mypy-requirements.txt
     #   arrow
-types-pytz==2024.2.0.20241221
+types-pytz==2025.1.0.20250204
     # via
     #   -r mypy-requirements.txt
     #   quart-babel
@@ -529,7 +529,7 @@ tzdata==2025.1
     # via
     #   celery
     #   kombu
-tzlocal==5.2
+tzlocal==5.3
     # via
     #   pyhanko
     #   superdesk-core

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -270,7 +270,8 @@ async def signup(req: Request):
                     for product in await enabled_products.to_list_raw()
                 ],
             }
-            company_dict["_id"] = (await company_service.create([company_dict]))[0]
+            new_company = (await company_service.create([company_dict]))[0]
+            company_dict["_id"] = new_company.id
 
         user_service = UsersService()
         new_user_dict: User = {
@@ -287,7 +288,8 @@ async def signup(req: Request):
             "sections": {section["_id"]: True for section in app.sections},
             "user_type": UserRole.PUBLIC.value,
         }
-        new_user_dict["_id"] = ObjectId((await user_service.create([new_user_dict]))[0])
+        new_user = (await user_service.create([new_user_dict]))[0]
+        new_user_dict["_id"] = new_user.id
         await send_new_signup_email(cast(Company, company_dict), cast(User, new_user_dict), is_new_company)
 
         return await render_template("signup_success.html"), 200

--- a/newsroom/cards/views.py
+++ b/newsroom/cards/views.py
@@ -54,9 +54,9 @@ async def search(args: None, params: CardSearchParams, request: Request) -> Resp
 )
 async def create(request: Request) -> Response:
     card_data = json.loads((await request.get_form()).get("card"))
-    new_ids = await CardsResourceService().create([card_data])
+    new_cards = await CardsResourceService().create([card_data])
 
-    return Response({"success": True, "_id": new_ids[0]}, 201, ())
+    return Response({"success": True, "_id": new_cards[0].id}, 201, ())
 
 
 class CardItemUrlArgs(BaseModel):

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -82,8 +82,8 @@ async def create_company(request: Request) -> Response:
 
     company_data = get_company_updates(company)
 
-    ids = await CompanyService().create([company_data])
-    return Response({"success": True, "_id": ids[0]}, 201)
+    new_companies = await CompanyService().create([company_data])
+    return Response({"success": True, "_id": new_companies[0].id}, 201)
 
 
 def get_company_updates(data, original=None):

--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -143,8 +143,8 @@ async def create(request: Request) -> Response:
         request_updates = await request.get_json()
         process_form_request(new_data, request_updates, form)
 
-        ids = await MonitoringProfileService().create([new_data])
-        return Response({"success": True, "_id": ids[0], "users": new_data.get("users")}, 201)
+        new_items = await MonitoringProfileService().create([new_data])
+        return Response({"success": True, "_id": new_items[0].id, "users": new_data.get("users")}, 201)
     return Response(form.errors, 400)
 
 

--- a/newsroom/navigations/views.py
+++ b/newsroom/navigations/views.py
@@ -78,11 +78,11 @@ async def create(request: Request):
 
     creation_data = await prepare_navigation_data(nav_data)
     product_ids = creation_data.pop("products", [])
-    created_ids = await NavigationsService().create([creation_data])
+    new_items = await NavigationsService().create([creation_data])
 
     if product_ids is not None:
-        await add_remove_products_for_navigation(ObjectId(created_ids[0]), product_ids)
-    return Response({"success": True, "_id": created_ids[0]}, 201)
+        await add_remove_products_for_navigation(new_items[0].id, product_ids)
+    return Response({"success": True, "_id": new_items[0].id}, 201)
 
 
 @navigations_endpoints.endpoint(

--- a/newsroom/oauth_clients/views.py
+++ b/newsroom/oauth_clients/views.py
@@ -66,7 +66,7 @@ async def create(request: Request) -> Response:
         "password": bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode(),
     }
     try:
-        ids = await ClientService().create([doc])
+        new_items = await ClientService().create([doc])
     except ValidationError as error:
         return Response(
             {
@@ -77,7 +77,7 @@ async def create(request: Request) -> Response:
             (),
         )
 
-    return Response({"success": True, "_id": ids[0], "password": password}, 201)
+    return Response({"success": True, "_id": new_items[0].id, "password": password}, 201)
 
 
 @clients_endpoints.endpoint(

--- a/newsroom/products/service.py
+++ b/newsroom/products/service.py
@@ -13,7 +13,7 @@ from newsroom.core.resources.service import NewshubAsyncResourceService
 class ProductsService(NewshubAsyncResourceService[ProductResourceModel], AsyncCacheableService):
     cache_lookup = {"is_enabled": True}
 
-    async def create(self, docs: Sequence[ProductResourceModel | dict[str, Any]]) -> list[str]:
+    async def create(self, docs: Sequence[ProductResourceModel | dict[str, Any]]) -> list[ProductResourceModel]:
         company_products: dict[ObjectId, Any] = {}
 
         for doc in docs:

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -78,7 +78,7 @@ async def parse_objectid_or_abort(request: Request, value: str | ObjectId) -> Ob
 async def create(request: Request):
     creation_data = await get_json_or_400_async(request)
     products = await ProductsService().create([creation_data])
-    return Response({"success": True, "_id": products[0]}, 201)
+    return Response({"success": True, "_id": products[0].id}, 201)
 
 
 @products_endpoints.endpoint("/products/<string:product_id>", methods=["POST"], auth=[auth_rules.admin_only])

--- a/newsroom/push/publishing.py
+++ b/newsroom/push/publishing.py
@@ -127,7 +127,7 @@ class Publisher:
             await service.update(original.id, item.to_dict(context={"use_objectid": True}))
             return original.id
         else:
-            return (await service.create([item]))[0]
+            return (await service.create([item]))[0].id
 
     async def publish_event(self, event: dict[str, Any], orig: dict[str, Any]):
         logger.debug("publishing event %s", event)
@@ -162,7 +162,7 @@ class Publisher:
                     await service.system_update(plan["_id"], {"event_id": agenda_id})
 
             await signals.publish_event.send(agenda, None, None, True)
-            agenda_id = (await service.create([agenda]))[0]
+            agenda_id = (await service.create([agenda]))[0].id
         else:
             # replace the original document
             updates = None
@@ -236,7 +236,7 @@ class Publisher:
             agenda.setdefault("_id", planning["guid"])
             agenda.setdefault("guid", planning["guid"])
             await signals.publish_planning.send(agenda, new_plan)
-            return (await service.create([agenda]))[0]
+            return (await service.create([agenda]))[0].id
         else:
             # Replace the original
             await signals.publish_planning.send(agenda, new_plan)
@@ -292,7 +292,7 @@ class Publisher:
             # setting _id of agenda to be equal to planning if there's no event id
             agenda.setdefault("_id", planning.get("event_item", planning["guid"]) or planning["guid"])
             agenda.setdefault("guid", planning.get("event_item", planning["guid"]) or planning["guid"])
-            return (await service.create([agenda]))[0]
+            return (await service.create([agenda]))[0].id
         else:
             # Replace the original document
             await service.update(agenda["_id"], agenda)

--- a/newsroom/section_filters/views.py
+++ b/newsroom/section_filters/views.py
@@ -84,8 +84,8 @@ async def create():
     if section and section.get("search_type"):
         creation_data["search_type"] = section["search_type"]
 
-    section_filter_id = await SectionFiltersService().create([creation_data])
-    return Response({"success": True, "_id": section_filter_id[0]}, 201)
+    new_section_filters = await SectionFiltersService().create([creation_data])
+    return Response({"success": True, "_id": new_section_filters[0].id}, 201)
 
 
 class DetailArgs(BaseModel):

--- a/newsroom/topics/views.py
+++ b/newsroom/topics/views.py
@@ -50,7 +50,7 @@ async def post_topic(request: Request) -> Response:
         )
     )
 
-    ids = await TopicService().create([topic])
+    new_topics = await TopicService().create([topic])
     await auto_enable_user_emails(topic, None, request.user)
 
     if topic.get("is_global"):
@@ -58,7 +58,7 @@ async def post_topic(request: Request) -> Response:
     else:
         push_user_notification("topic_created")
 
-    return Response({"success": True, "_id": ids[0]}, 201)
+    return Response({"success": True, "_id": new_topics[0].id}, 201)
 
 
 @topic_endpoints.endpoint("/topics/my_topics", methods=["GET"])

--- a/newsroom/topics_folders/folders.py
+++ b/newsroom/topics_folders/folders.py
@@ -1,9 +1,10 @@
-from typing import Sequence, Any
+from typing import Sequence, Any, cast
 
 from pymongo.errors import DuplicateKeyError
 from bson import ObjectId
 from quart_babel import gettext
 
+from superdesk.core.types import Request, Response
 from superdesk.core.module import SuperdeskAsyncApp
 from superdesk.core.resources import (
     ResourceConfig,
@@ -12,6 +13,7 @@ from superdesk.core.resources import (
     RestEndpointConfig,
     RestParentLink,
 )
+from superdesk.core.web import ItemRequestViewArgs
 
 from newsroom import MONGO_PREFIX
 from newsroom.types import (
@@ -26,8 +28,48 @@ from newsroom.topics.topics_async import TopicService
 from newsroom.signals import user_deleted
 
 
+from superdesk.core.resources import ResourceRestEndpoints
+
+
+class FolderRestEndpoints(ResourceRestEndpoints):
+    def _format_error_to_newshub_style(self, response_body: dict) -> dict:
+        # Hack to provide Newshub style errors from REST Endpoints API
+        # Only needed for TopicFolders - most APIs in Newshub use Endpoints and ResourceServices directly
+        # TODO-ASYNC: Provide a better way for the App to handle validation level errors from Web REST APIs
+
+        if response_body.get("_status") == "ERR" and response_body.get("_issues"):
+            # Converts
+            # {"_issues": {"name": {"name": "Name must be unique"}}}
+            # to
+            # {"name": "Name must be unique"}
+            return {
+                field: list(field_error.values())[0]
+                for field, field_error in response_body["_issues"].items()
+                if len(field_error.values())
+            }
+
+        return response_body
+
+    async def create_item(self, request: Request) -> Response:
+        """Processes a create item request"""
+        response = await super().create_item(request)
+        response.body = self._format_error_to_newshub_style(cast(dict, response.body))
+        return response
+
+    async def update_item(
+        self,
+        args: ItemRequestViewArgs,
+        params: None,
+        request: Request,
+    ) -> Response:
+        """Processes an update item request"""
+        response = await super().update_item(args, params, request)
+        response.body = self._format_error_to_newshub_style(cast(dict, response.body))
+        return response
+
+
 class FolderResourceService(NewshubAsyncResourceService[TopicFolderResourceModel]):
-    async def create(self, docs: Sequence[TopicFolderResourceModel | dict[str, Any]]) -> list[str]:
+    async def create(self, docs: Sequence[TopicFolderResourceModel | dict[str, Any]]) -> list[TopicFolderResourceModel]:
         try:
             return await super().create(docs)
         except DuplicateKeyError:
@@ -39,9 +81,9 @@ class FolderResourceService(NewshubAsyncResourceService[TopicFolderResourceModel
         updates: dict[str, Any],
         etag: str | None = None,
         original: TopicFolderResourceModel | None = None,
-    ) -> None:
+    ) -> TopicFolderResourceModel:
         try:
-            await super().update(item_id, updates, etag, original)
+            return await super().update(item_id, updates, etag, original)
         except DuplicateKeyError:
             raise_custom_validation_error(TopicFolderResourceModel.__name__, "name", gettext("Name must be unique"), "")
 
@@ -87,6 +129,7 @@ user_topic_folders_resource_config = ResourceConfig(
     mongo=MongoResourceConfig(prefix=MONGO_PREFIX),
     datasource_name="topic_folders",
     rest_endpoints=RestEndpointConfig(
+        endpoints_class=FolderRestEndpoints,
         parent_links=[RestParentLink(resource_name="users", model_id_field="user")],
         url="topic_folders",
         auth=[auth_rules.any_user_role],
@@ -105,6 +148,7 @@ company_topic_folder_resource_config = ResourceConfig(
     mongo=MongoResourceConfig(prefix=MONGO_PREFIX),
     datasource_name="topic_folders",
     rest_endpoints=RestEndpointConfig(
+        endpoints_class=FolderRestEndpoints,
         parent_links=[RestParentLink(resource_name="companies", model_id_field="company")],
         url="topic_folders",
         auth=[auth_rules.any_user_role],

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -196,12 +196,12 @@ async def create(request: Request) -> Response:
             if auth_provider.features["verify_email"]:
                 add_token_data(new_user)
 
-        ids = await UsersAuthService().create([new_user])
+        new_users = await UsersAuthService().create([new_user])
 
         if auth_provider and auth_provider.features["verify_email"]:
             await send_token(new_user, token_type="new_account", update_token=False)
 
-        return Response({"success": True, "_id": ids[0]}, 201)
+        return Response({"success": True, "_id": new_users[0].id}, 201)
 
     return Response(form.errors, 400)
 

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -177,6 +177,9 @@ MODULES = [
     "newsroom.mgmt_api.mgmt_api_docs",
 ]
 
+ASYNC_POPULATE_HATEOAS = False
+ASYNC_RESPOND_NESTED_VALIDATION_ERRORS = False
+
 SITE_NAME = "Newshub"
 COPYRIGHT_HOLDER = "Sourcefabric"
 COPYRIGHT_NOTICE = ""

--- a/tests/core/test_saml.py
+++ b/tests/core/test_saml.py
@@ -100,7 +100,7 @@ async def test_company_auth_domains(app, client):
         await service.create([CompanyResource(id=ObjectId(), name="TEST2", auth_domains=["EXAMPLE.COM"])])
     assert_unique_domain_error(error)
 
-    ids = await service.create(
+    companies = await service.create(
         [
             CompanyResource(id=ObjectId(), name="test3", auth_domains=[]),
             CompanyResource(id=ObjectId(), name="test4", auth_domains=["foo.com", "bar.com"]),
@@ -112,5 +112,5 @@ async def test_company_auth_domains(app, client):
     assert_unique_domain_error(error)
 
     with pytest.raises(ValidationError) as error:
-        await service.update(ids[0], dict(auth_domains=["unique.com", "example.com"]))
+        await service.update(companies[0].id, dict(auth_domains=["unique.com", "example.com"]))
     assert_unique_domain_error(error)

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -64,7 +64,8 @@ async def create_entries_for(resource: str, items: list[Any]) -> list[ObjectId |
     async_app = app.async_app
 
     try:
-        return await async_app.resources.get_resource_service(resource).create(items)
+        items = await async_app.resources.get_resource_service(resource).create(items)
+        return [item.id for item in items]
     except KeyError:
         print(f"Failed to find async service for {resource}")
         ids = []


### PR DESCRIPTION
### Purpose
There were breaking changes in superdesk-core resource services and rest apis. This PR fixes those

### What has changed
* Update dev-requirements.txt
* Update service.create implementation and usage throughout code and tests to use returned instances instead of IDs
* Fix validation issue with TopicFolder REST API, validation in core is returning format used by Superdesk where as Newshub is different - Hack for now, will come up with a better implementation for this: see https://github.com/superdesk/superdesk-core/blob/8ec622888bf16617817d7e08d73a61b0525d9244/superdesk/core/resources/resource_rest_endpoints.py#L380-L404 for the change in core
