### PR TITLE
[SDESK-7557] Use new async media I/O

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,14 +4,23 @@
 #
 #    pip-compile dev-requirements.in
 #
+aioboto3==14.1.0
+    # via superdesk-core
+aiobotocore[boto3]==2.21.1
+    # via aioboto3
 aiofiles==24.1.0
     # via
+    #   aioboto3
     #   quart
     #   quart-uploads
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.14
-    # via elasticsearch
+aiohttp==3.11.16
+    # via
+    #   aiobotocore
+    #   elasticsearch
+aioitertools==0.12.0
+    # via aiobotocore
 aiosignal==1.3.2
     # via aiohttp
 amqp==5.3.1
@@ -57,10 +66,13 @@ blinker==1.9.0
     #   quart
     #   sentry-sdk
     #   superdesk-core
-boto3==1.37.20
-    # via superdesk-core
-botocore==1.37.20
+boto3==1.37.1
     # via
+    #   aiobotocore
+    #   superdesk-core
+botocore==1.37.1
+    # via
+    #   aiobotocore
     #   boto3
     #   s3transfer
 cachelib==0.13.0
@@ -107,7 +119,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-coverage[toml]==7.7.1
+coverage[toml]==7.8.0
     # via pytest-cov
 croniter==6.0.0
     # via superdesk-core
@@ -150,7 +162,7 @@ exceptiongroup==1.2.2
     #   taskgroup
 feedparser==6.0.11
     # via superdesk-core
-flake8==7.1.2
+flake8==7.2.0
     # via -r dev-requirements.in
 flask==3.1.0
     # via
@@ -223,6 +235,7 @@ jinja2==3.1.6
     #   quart
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jwcrypto==1.5.6
@@ -235,7 +248,7 @@ kombu==5.4.2
     #   superdesk-core
 ldap3==2.9.1
     # via superdesk-core
-lxml==5.3.1
+lxml==5.3.2
     # via
     #   draftjs-exporter
     #   lxml-html-clean
@@ -258,6 +271,7 @@ motor==3.7.0
     # via superdesk-core
 multidict==6.2.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 mypy==1.15.0
@@ -270,7 +284,7 @@ oauth2client==4.1.3
     # via flask-oidc-ex
 oauthlib==3.2.2
     # via requests-oauthlib
-orderly-set==5.3.0
+orderly-set==5.3.1
     # via deepdiff
 oscrypto==1.3.0
     # via pyhanko-certvalidator
@@ -309,21 +323,21 @@ pyasn1==0.6.1
     #   oauth2client
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via
     #   google-auth
     #   oauth2client
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via flake8
 pycparser==2.22
     # via cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -r mypy-requirements.txt
     #   superdesk-core
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via pydantic
-pyflakes==3.2.0
+pyflakes==3.3.2
     # via flake8
 pyhanko==0.26.0
     # via xhtml2pdf
@@ -356,7 +370,7 @@ pytest==8.3.5
     #   pytest-mock
 pytest-asyncio==0.26.0
     # via -r dev-requirements.in
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r dev-requirements.in
 pytest-mock==3.14.0
     # via -r dev-requirements.in
@@ -366,6 +380,7 @@ python-bidi==0.4.2
     #   xhtml2pdf
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
     #   celery
@@ -392,7 +407,7 @@ pyyaml==6.0.2
     #   pyhanko
     #   responses
     #   superdesk-core
-qrcode==8.0
+qrcode==8.1
     # via pyhanko
 quart @ git+https://github.com/MarkLark86/quart@fix-test-client-with-utf8-url
     # via
@@ -443,7 +458,7 @@ rsa==4.9
     # via
     #   google-auth
     #   oauth2client
-s3transfer==0.11.4
+s3transfer==0.11.3
     # via boto3
 sentry-sdk[quart]==1.45.1
     # via
@@ -462,7 +477,7 @@ six==1.17.0
     #   parse-type
     #   python-bidi
     #   python-dateutil
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@release/3.0
+superdesk-core @ git+https://github.com/MarkLark86/superdesk-core.git@CPCN-1057
     # via -r requirements.txt
 superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@release/3.0
     # via -r requirements.txt
@@ -493,7 +508,7 @@ types-jinja2==2.11.9
     #   types-flask
 types-markupsafe==1.1.10
     # via types-jinja2
-types-protobuf==5.29.1.20250315
+types-protobuf==5.29.1.20250403
     # via -r mypy-requirements.txt
 types-python-dateutil==2.9.0.20241206
     # via
@@ -514,7 +529,7 @@ types-werkzeug==1.0.9
     # via
     #   -r mypy-requirements.txt
     #   types-flask
-typing-extensions==4.13.0
+typing-extensions==4.13.1
     # via
     #   -r mypy-requirements.txt
     #   asgiref
@@ -527,6 +542,9 @@ typing-extensions==4.13.0
     #   pydantic-core
     #   pypdf
     #   taskgroup
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via pydantic
 tzdata==2025.2
     # via
     #   celery
@@ -569,7 +587,9 @@ werkzeug==3.1.3
 wooper==0.4.4
     # via -r dev-requirements.in
 wrapt==1.17.2
-    # via elastic-apm
+    # via
+    #   aiobotocore
+    #   elastic-apm
 wsproto==1.2.0
     # via hypercorn
 wtforms[email]==3.2.1
@@ -583,7 +603,7 @@ xmlsec==1.3.14
     # via
     #   python3-saml
     #   superdesk-core
-yarl==1.18.3
+yarl==1.19.0
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -477,7 +477,7 @@ six==1.17.0
     #   parse-type
     #   python-bidi
     #   python-dateutil
-superdesk-core @ git+https://github.com/MarkLark86/superdesk-core.git@CPCN-1057
+superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@release/3.0
     # via -r requirements.txt
 superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@release/3.0
     # via -r requirements.txt

--- a/newsroom/assets/utils.py
+++ b/newsroom/assets/utils.py
@@ -2,10 +2,10 @@ import os
 import bson
 
 from werkzeug.utils import secure_filename
-from motor.motor_asyncio import AsyncIOMotorGridOut
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any
 
 from newsroom.core import get_current_wsgi_app
+from superdesk.core.types import SuperdeskAsyncFile
 from superdesk.flask import url_for
 from superdesk.upload import upload_url as _upload_url
 from superdesk.media.media_operations import guess_media_extension
@@ -15,7 +15,7 @@ from .module import ASSETS_ENDPOINT_GROUP_NAME, ASSETS_RESOURCE
 CACHE_MAX_AGE = 3600 * 24 * 7  # 7 days
 
 
-async def get_media_file(media_id: str):
+async def get_media_file(media_id: str, begin: int = 0, end: int | None = None) -> SuperdeskAsyncFile | None:
     """
     Asynchronously retrieves a media file from the database using its media ID.
 
@@ -24,13 +24,13 @@ async def get_media_file(media_id: str):
     """
     app = get_current_wsgi_app()
     try:
-        result = await app.media_async.get(media_id, ASSETS_RESOURCE)
+        result = await app.media.get_async(media_id, ASSETS_RESOURCE, begin=begin, end=end)
         return result
     except bson.errors.InvalidId:
         return None
 
 
-def get_content_disposition(filename: Optional[str], metadata: Mapping[str, Any] = {}) -> str:
+def get_content_disposition(filename: str | None, content_type: str = "") -> str:
     """
     Generates the Content-Disposition header value based on the filename and metadata.
 
@@ -40,37 +40,14 @@ def get_content_disposition(filename: Optional[str], metadata: Mapping[str, Any]
     if filename:
         _filename, ext = os.path.splitext(filename)
         if not ext:
-            ext = guess_media_extension(metadata.get("contentType"))
+            ext = guess_media_extension(content_type)
         filename = secure_filename(f"{_filename}{ext}")
         return f'attachment; filename="{filename}"'
 
     return "inline"
 
 
-def generate_response_headers(media_file: AsyncIOMotorGridOut) -> Sequence:
-    """
-    Generates a sequence of HTTP headers for a media file based on its properties.
-
-    Args:
-        media_file (AsyncIOMotorGridOut): The media file object retrieved from a database.
-
-    Returns:
-        Sequence[Tuple[str, Any]]: A list of tuples representing HTTP response headers
-    """
-    metadata = media_file.metadata or {}
-
-    return [
-        ("Content-Disposition", get_content_disposition(media_file.filename, metadata)),
-        ("Last-Modified", media_file.upload_date),
-        ("Cache-Control", f"max-age={CACHE_MAX_AGE}, public"),
-        ("Content-Type", metadata.get("contentType", media_file.content_type)),
-        # TODO:
-        # - set etag which not sure if it's required
-        # - find alternative to response.make_conditional(request, accept_ranges=True, complete_length=media_file.length)
-    ]
-
-
-async def save_file_and_get_url(file: Any) -> Optional[str]:
+async def save_file_and_get_url(file: Any) -> str:
     """
     Asynchronously uploads a file to the media storage service and generates a URL
     for accessing the uploaded file.
@@ -79,13 +56,13 @@ async def save_file_and_get_url(file: Any) -> Optional[str]:
         file: The file to be uploaded.
 
     Returns:
-        Optional[str]: A URL to the uploaded file if a file is found and successfully uploaded; otherwise, None.
+        str: A URL to the uploaded file if a file is found and successfully uploaded; otherwise, None.
         None is returned if no file is found for the provided key or if the file fails to upload.
     """
     app = get_current_wsgi_app()
     filename = secure_filename(file.filename)
 
-    await app.media_async.put(file, filename, resource=ASSETS_RESOURCE, _id=filename, content_type=file.content_type)
+    await app.media.put_async(file, filename, resource=ASSETS_RESOURCE, _id=filename, content_type=file.content_type)
 
     endpoint = f"{ASSETS_ENDPOINT_GROUP_NAME}.download_file"
     return url_for(endpoint, media_id=filename)

--- a/newsroom/assets/views.py
+++ b/newsroom/assets/views.py
@@ -1,17 +1,12 @@
 from pydantic import BaseModel
-from datetime import datetime, timezone, timedelta
-from os import path
-from io import BytesIO
 
-from werkzeug.utils import secure_filename
-
-from superdesk.core import get_app_config, get_current_app, get_current_async_app
+from superdesk.core import get_app_config, get_current_async_app
 from superdesk.core.types import Response, Request
 from superdesk.flask import request as flask_request
-from superdesk.media.media_operations import guess_media_extension
+from superdesk.storage.superdesk_file import get_file_request_range, generate_response_for_file
 
 from .module import assets_endpoints
-from .utils import get_media_file, CACHE_MAX_AGE
+from .utils import get_media_file, get_content_disposition
 
 
 class RouteArguments(BaseModel):
@@ -23,47 +18,19 @@ class UrlParams(BaseModel):
 
 
 async def get_upload(media_id: str, filename: str | None = None):
-    media_file = await get_media_file(media_id)
+    begin, end = get_file_request_range(flask_request.range if flask_request else None)
+    media_file = await get_media_file(media_id, begin=begin, end=end)
     if not media_file:
         return None
 
-    content = await media_file.read()
-
-    app = get_current_app()
-    metadata = media_file.metadata or {}
-    mimetype = metadata.get("contentType", media_file.content_type)
-    file_body = app.as_any().response_class.io_body_class(BytesIO(content))
-    response = app.response_class(file_body, mimetype=mimetype)
-    response.content_length = media_file.length
-    response.last_modified = media_file.upload_date
-
-    # TODO-ASYNC: Set etag from ``media_file`` (as `md5` attribute is not defined in newer PyMongo)
-    if getattr(media_file, "md5", None):
-        response.set_etag(media_file.md5)
-
-    response.cache_control.max_age = CACHE_MAX_AGE
-    response.cache_control.s_max_age = CACHE_MAX_AGE
-    response.cache_control.public = True
-    response.expires = datetime.now(timezone.utc) + timedelta(seconds=CACHE_MAX_AGE)
-
-    # Add ``accept_ranges`` & ``complete_length`` so video seeking is supported
-    await response.make_conditional(flask_request, accept_ranges=True, complete_length=media_file.length)
-
-    if filename:
-        _filename, ext = path.splitext(filename)
-        if not ext:
-            ext = guess_media_extension(mimetype)
-        filename = secure_filename(f"{_filename}{ext}")
-        response.headers["Content-Type"] = mimetype
-        response.headers["Content-Disposition"] = 'attachment; filename="{}"'.format(filename)
-    else:
-        response.headers["Content-Disposition"] = "inline"
-
-    return response
+    return await generate_response_for_file(
+        media_file, content_disposition=get_content_disposition(filename, media_file.content_type)
+    )
 
 
-@assets_endpoints.endpoint("/assets/<string:media_id>", methods=["GET"], auth=False)
+@assets_endpoints.endpoint("/assets/<path:media_id>", methods=["GET"], auth=False)
 async def download_file(args: RouteArguments, params: UrlParams, request: Request) -> Response:
+    # Allow access to ``/assets/<media_id>`` if PUBLIC_DASHBOARD is enabled or is a valid session
     if not get_app_config("PUBLIC_DASHBOARD"):
         response = await get_current_async_app().auth.authenticate(request)
         if response:

--- a/newsroom/auth/oauth.py
+++ b/newsroom/auth/oauth.py
@@ -39,7 +39,6 @@ def init_app(app):
 @blueprint.route("/login/google", methods=["GET"])
 @rate_limit(60, timedelta(hours=1))
 def google_login():
-    global oauth
     redirect_uri = url_for(".google_authorized", _external=True)
     return oauth.google.authorize_redirect(redirect_uri)
 
@@ -47,7 +46,6 @@ def google_login():
 @blueprint.route("/login/google_authorized", methods=["GET"])
 @rate_limit(60, timedelta(hours=1))
 async def google_authorized():
-    global oauth
     token = oauth.google.authorize_access_token()
 
     async def redirect_with_error(error_str):

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -25,7 +25,6 @@ from superdesk.validator import SuperdeskValidator
 from superdesk.logging import configure_logging
 from superdesk.errors import SuperdeskApiError
 from superdesk.cache import cache_backend
-from superdesk.core.storage import GridFSMediaStorageAsync
 from superdesk.factory.app import SuperdeskEve
 
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
@@ -48,8 +47,6 @@ class BaseNewsroomApp(SuperdeskEve):
     DATALAYER = SuperdeskDataLayer
     AUTH_SERVICE = SessionAuth
     INSTANCE_CONFIG = None
-
-    media_async: GridFSMediaStorageAsync
 
     def __init__(self, import_name=__package__, config=None, testing=False, **kwargs):
         """Override __init__ to do Newsroom specific config and still be able
@@ -138,8 +135,6 @@ class BaseNewsroomApp(SuperdeskEve):
         self.config.update(self.settings or {})
 
     def setup_media_storage(self):
-        self.media_async = GridFSMediaStorageAsync()
-
         if self.config.get("AMAZON_CONTAINER_NAME"):
             self.media = AmazonMediaStorage(self)
         else:

--- a/newsroom/push/views.py
+++ b/newsroom/push/views.py
@@ -146,14 +146,14 @@ async def push_binary(request: Request):
 
     media_id = (await request.get_form())["media_id"]
     app = get_current_wsgi_app()
-    await app.media_async.put(media, media_id, resource=ASSETS_RESOURCE, _id=media_id, content_type=media.content_type)
+    await app.media.put_async(media, media_id, resource=ASSETS_RESOURCE, _id=media_id, content_type=media.content_type)
     return Response({"status": "OK"}, 201)
 
 
-@push_endpoints.endpoint("/push_binary/<string:media_id>")
+@push_endpoints.endpoint("/push_binary/<path:media_id>")
 async def push_binary_get(args: RouteArguments, _: None, request: Request):
     app = get_current_wsgi_app()
-    media_file = await app.media_async.get(args.media_id, resource=ASSETS_RESOURCE)
+    media_file = await app.media.exists_async(args.media_id, resource=ASSETS_RESOURCE)
     if media_file:
         return Response({})
 

--- a/newsroom/push/views.py
+++ b/newsroom/push/views.py
@@ -153,8 +153,7 @@ async def push_binary(request: Request):
 @push_endpoints.endpoint("/push_binary/<path:media_id>")
 async def push_binary_get(args: RouteArguments, _: None, request: Request):
     app = get_current_wsgi_app()
-    media_file = await app.media.exists_async(args.media_id, resource=ASSETS_RESOURCE)
-    if media_file:
+    if await app.media.exists_async(args.media_id, resource=ASSETS_RESOURCE):
         return Response({})
 
     await request.abort(404)

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -350,7 +350,9 @@ async def download(args: None, params: ItemActionUrlParams, request: Request):
                     try:
                         media_id, file_extension = formatter.get_picture_rendition(item, item_type=item_type)
                         file = await get_media_file(media_id)
-                        zf.writestr(f"baseimage{file_extension}", file.read())
+                        if not file:
+                            return await request.abort(404)
+                        zf.writestr(f"baseimage{file_extension}", await file.read())
                     except ValueError:
                         pass
             _file.seek(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ quart-rate-limiter>=0.10.0,<0.11
 # Fix issue with xhtml2pdf not working with python-bidi>=0.5
 python-bidi<0.5
 
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@release/3.0
+superdesk-core @ git+https://github.com/MarkLark86/superdesk-core.git@CPCN-1057
 superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@release/3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ quart-rate-limiter>=0.10.0,<0.11
 # Fix issue with xhtml2pdf not working with python-bidi>=0.5
 python-bidi<0.5
 
-superdesk-core @ git+https://github.com/MarkLark86/superdesk-core.git@CPCN-1057
+superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@release/3.0
 superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@release/3.0

--- a/tests/assets/test_utils.py
+++ b/tests/assets/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 from werkzeug.datastructures import FileStorage
-from newsroom.assets.utils import get_content_disposition, generate_response_headers, save_file_and_get_url
+from newsroom.assets.utils import get_content_disposition, save_file_and_get_url
 
 
 @pytest.fixture(autouse=True)
@@ -18,8 +18,7 @@ def test_content_disposition_with_extension():
 
 def test_content_disposition_without_extension_using_metadata():
     filename = "example"
-    metadata = {"contentType": "application/pdf"}
-    disposition = get_content_disposition(filename, metadata)
+    disposition = get_content_disposition(filename, "application/pdf")
     assert disposition == 'attachment; filename="example.pdf"'
 
 
@@ -32,24 +31,6 @@ def test_content_disposition_with_unsafe_filename():
     filename = "../path/to/example.pdf"
     disposition = get_content_disposition(filename)
     assert disposition == 'attachment; filename="path_to_example.pdf"'
-
-
-def test_generate_response_headers():
-    media_file = Mock()
-    media_file.filename = "testfile.pdf"
-    media_file.upload_date = "Wed, 21 Oct 2015 07:28:00 GMT"
-    media_file.content_type = "application/pdf"
-    media_file.metadata = {"contentType": "application/pdf"}
-
-    expected_headers = [
-        ("Content-Disposition", 'attachment; filename="testfile.pdf"'),
-        ("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT"),
-        ("Cache-Control", "max-age=604800, public"),
-        ("Content-Type", "application/pdf"),
-    ]
-
-    headers = generate_response_headers(media_file)
-    assert headers == expected_headers
 
 
 async def test_save_file_and_get_url_successful():

--- a/tests/assets/test_views.py
+++ b/tests/assets/test_views.py
@@ -10,7 +10,7 @@ TEST_PNG_BLACK_DOT = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x
 
 
 async def save_black_dot_image(app):
-    media_id = await app.media_async.put(TEST_PNG_BLACK_DOT, content_type="image/png", filename="image.png")
+    media_id = await app.media.put_async(TEST_PNG_BLACK_DOT, content_type="image/png", filename="image.png")
     return media_id
 
 
@@ -30,7 +30,7 @@ async def test_media_not_found(client):
 
 
 async def test_filename_in_response_header(client, app):
-    media_id = await app.media_async.put(b"Plain text content", content_type="text/plain", filename="testfile.txt")
+    media_id = await app.media.put_async(b"Plain text content", content_type="text/plain", filename="testfile.txt")
 
     response = await client.get(f"/assets/{media_id}?filename=testfile.txt")
     assert response.status_code == 200

--- a/tests/news_api/test_api_assets.py
+++ b/tests/news_api/test_api_assets.py
@@ -10,7 +10,7 @@ def get_fixture_path(fixture):
 
 async def setup_image(app):
     with open(get_fixture_path("picture.jpg"), "rb") as f:
-        return await app.media_async.put(
+        return await app.media.put_async(
             f,
             content_type="image/jpg",
             filename="picture.jpg",


### PR DESCRIPTION
### Purpose
Use the new async media I/O methods

### What has changed
* Update lib requirements (for now uses my repo/branch so tests run, will update before merging)
* Use the new `app.media` async methods
* Remove previous async GridFS usage
* Fix lint
* Update tests

Depends on: https://github.com/superdesk/superdesk-core/pull/2874
Resolves: [SDESK-7557](https://sofab.atlassian.net/browse/SDESK-7557)


[SDESK-7557]: https://sofab.atlassian.net/browse/SDESK-7557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ