### PR TITLE
[CPCN-1052] fix: New user password email not sent for admins

### DIFF
--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -15,7 +15,6 @@ from superdesk.core.types import SearchRequest
 from superdesk.core.resources.fields import ObjectId as ObjectIdField
 
 from newsroom.types import CompanyProduct, UserResourceModel, UserAuthResourceModel, UserRole
-from newsroom.auth.providers import AuthProvider
 from newsroom.auth.utils import (
     get_auth_providers,
     send_token,

--- a/newsroom/users/views.py
+++ b/newsroom/users/views.py
@@ -189,16 +189,13 @@ async def create(request: Request) -> Response:
         new_user.receive_app_notifications = True
 
         company = await new_user.get_company()
-        auth_provider: AuthProvider | None = None
-        if company:
-            auth_provider = get_company_auth_provider(company)
-
-            if auth_provider.features["verify_email"]:
-                add_token_data(new_user)
+        auth_provider = get_company_auth_provider(company)
+        if auth_provider.features["verify_email"]:
+            add_token_data(new_user)
 
         new_users = await UsersAuthService().create([new_user])
 
-        if auth_provider and auth_provider.features["verify_email"]:
+        if auth_provider.features["verify_email"]:
             await send_token(new_user, token_type="new_account", update_token=False)
 
         return Response({"success": True, "_id": new_users[0].id}, 201)


### PR DESCRIPTION
### Purpose
When creating a new admin user without a company set, the user's token is not generated nor is the password reset email sent.

Resolves: [CPCN-1052](https://sofab.atlassian.net/browse/CPCN-1052)


[CPCN-1052]: https://sofab.atlassian.net/browse/CPCN-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ