### PR TITLE
[CPCN-1058] fix(mgmt_api): Return 200 when getting company products

### DIFF
--- a/newsroom/mgmt_api/companies_products.py
+++ b/newsroom/mgmt_api/companies_products.py
@@ -97,7 +97,7 @@ async def get_company_products_endpoint(args: CompanyProductRouteArguments, para
             }
             products_data.append(item)
 
-    return Response({"_items": products_data}, 201)
+    return Response({"_items": products_data}, 200)
 
 
 module = Module(


### PR DESCRIPTION
### Purpose
When getting the Company Products through the Management API, the return code is 201 when it should be 200

Resolves: [CPCN-1058](https://sofab.atlassian.net/browse/CPCN-1058)


[CPCN-1058]: https://sofab.atlassian.net/browse/CPCN-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ