### PR TITLE
[NHUB-625] fix: Users with empty string for locale

### DIFF
--- a/data_updates/00000_20250429-101000_users.py
+++ b/data_updates/00000_20250429-101000_users.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Mark Pittaway
+# Creation: 2025-04-29 10:10
+
+from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorDatabase
+from superdesk.commands.data_updates import BaseDataUpdate
+
+
+class DataUpdate(BaseDataUpdate):
+    """Removes the ``locale`` field from users where the value is an empty string"""
+
+    resource = "users"
+    use_async_resources = True
+
+    async def forwards(self, collection: AsyncIOMotorCollection, database: AsyncIOMotorDatabase) -> None:
+        await collection.update_many({"locale": ""}, {"$unset": {"locale": 1}})
+
+    async def backwards(self, collection: AsyncIOMotorCollection, database: AsyncIOMotorDatabase) -> None:
+        pass

--- a/newsroom/data_updates.py
+++ b/newsroom/data_updates.py
@@ -32,17 +32,18 @@ DATA_UPDATE_TEMPLATE = """
 # Author  : $user
 # Creation: $current_date
 
-from superdesk.commands.data_updates import DataUpdate as _DataUpdate
+from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorDatabase
+from superdesk.commands.data_updates import BaseDataUpdate
 
 
-class DataUpdate(_DataUpdate):
+class DataUpdate(BaseDataUpdate):
+    resource = "$resource"
+    use_async_resources = True
 
-    resource = '$resource'
-
-    def forwards(self, mongodb_collection, mongodb_database):
+    async def forwards(self, collection: AsyncIOMotorCollection, database: AsyncIOMotorDatabase) -> None:
         $default_fw_implementation
 
-    def backwards(self, mongodb_collection, mongodb_database):
+    async def backwards(self, collection: AsyncIOMotorCollection, database: AsyncIOMotorDatabase) -> None:
         $default_bw_implementation
 """.lstrip(
     "\n"

--- a/newsroom/types/users.py
+++ b/newsroom/types/users.py
@@ -120,6 +120,10 @@ class UserResourceModel(NewshubResourceModel):
     @field_validator("locale", mode="before")
     @classmethod
     def validate_locale(cls, value: str | None) -> str | None:
+        if value == "":
+            # If any empty value is supplied, change it to ``None`` instead
+            value = None
+
         if value is not None and value not in get_app_config("LANGUAGES", []):
             raise SuperdeskApiError.badRequestError("Locale is not in configured list of locales.")
         return value


### PR DESCRIPTION
### Purpose
`superdesk.errors.SuperdeskApiError: 400: Locale is not in configured list of locales.` is raised when a User has an empty string `""` for the locale field.

### What has changed
* Create a data migration script that removes the `locale` field from users that have an empty string as it's value
* Improve User validation by setting the value to `None` if an empty string is supplied (to stop this happening in the future)
* Update migration script template to use async resources and types

Resolves: [NHUB-625](https://sofab.atlassian.net/browse/NHUB-625)


[NHUB-625]: https://sofab.atlassian.net/browse/NHUB-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ