### PR TITLE
fix: Race condition when checking login attempt count

### DIFF
--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -115,7 +115,7 @@ def email_has_exceeded_max_login_attempts(email):
     app = get_current_app().as_any()
     login_attempt = app.cache.get(email)
 
-    if not login_attempt:
+    if not login_attempt or not login_attempt.get("attempt_count"):
         app.cache.set(email, {"attempt_count": 0})
         return False
 
@@ -123,7 +123,7 @@ def email_has_exceeded_max_login_attempts(email):
     app.cache.set(email, login_attempt)
     max_attempt_allowed = get_app_config("MAXIMUM_FAILED_LOGIN_ATTEMPTS")
 
-    if login_attempt["attempt_count"] == max_attempt_allowed:
+    if login_attempt["attempt_count"] >= max_attempt_allowed:
         if login_attempt.get("user_id"):
             get_resource_service("auth_user").patch(
                 id=ObjectId(login_attempt["user_id"]), updates={"is_enabled": False}

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -115,7 +115,7 @@ def email_has_exceeded_max_login_attempts(email):
     app = get_current_app().as_any()
     login_attempt = app.cache.get(email)
 
-    if not login_attempt or not login_attempt.get("attempt_count"):
+    if not login_attempt or "attempt_count" not in login_attempt:
         app.cache.set(email, {"attempt_count": 0})
         return False
 


### PR DESCRIPTION
### Purpose
There is an occasional exception raised when attempting to check the user email login vs the number of allowed.
```
An unhandled exception was raised
Traceback (most recent call last):
  File "quart/app.py", line 1442, in full_dispatch_request
    result = await self.dispatch_request(request_context)
  File "quart/app.py", line 1538, in dispatch_request
    return await self.ensure_async(handler)(**request_.view_args)  # type: ignore
  File "superdesk/factory/app.py", line 382, in _process_async_endpoint
    response = await request.endpoint(
  File "superdesk/core/web/endpoints.py", line 52, in __call__
    response = await response
  File "newsroom/auth/views.py", line 67, in login
    if email_has_exceeded_max_login_attempts(form.email.data):
  File "newsroom/auth/views.py", line 122, in email_has_exceeded_max_login_attempts
    login_attempt["attempt_count"] += 1
KeyError: 'attempt_count'
```

Although this shouldn't happen in production, thought we should fix it

### What has changed
* Check the `login_attempt` redis cache value to see if it has the `attempt_count` set or not
* When checking against max number, use `>=` (as it catches unlikely scenario when count is greater than max allowed

