### PR TITLE
Monitoring profile management fixes

### DIFF
--- a/assets/monitoring/components/EditMonitoringProfile.tsx
+++ b/assets/monitoring/components/EditMonitoringProfile.tsx
@@ -32,8 +32,8 @@ class EditMonitoringProfile extends React.Component<any, any> {
     }
 
     handleTabClick(event: any) {
-        this.setState({activeTab: event.target.name});
-        if (event.target.name === 'users' && get(this.props, 'item.company')) {
+        this.setState({activeTab: event.target.title});
+        if (event.target.title === 'users' && get(this.props, 'item.company')) {
             this.props.fetchCompanyUsers(this.props.item.company);
         }
     }

--- a/newsroom/factcheck/views.py
+++ b/newsroom/factcheck/views.py
@@ -28,7 +28,7 @@ async def get_view_data():
     company = get_company_from_request(None)
     ui_config_service = UiConfigResourceService()
     return {
-        "user": str(user.id),
+        "user": user.to_dict(),
         "company": str(company.id) if company else None,
         "navigations": [],
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),

--- a/newsroom/market_place/views.py
+++ b/newsroom/market_place/views.py
@@ -42,7 +42,7 @@ async def get_view_data():
     await get_story_count(navigations, user, company)
     ui_config_service = UiConfigResourceService()
     return {
-        "user": str(user.id),
+        "user": user.to_dict(),
         "user_type": user.user_type,
         "company": str(company.id) if company else None,
         "topics": [t for t in topics if t.get("topic_type") == SECTION_ID],

--- a/newsroom/media_releases/views.py
+++ b/newsroom/media_releases/views.py
@@ -28,7 +28,7 @@ async def get_view_data():
     company = get_company_from_request(None)
     ui_config_service = UiConfigResourceService()
     return {
-        "user": str(user.id),
+        "user": user.to_dict(),
         "company": str(company.id) if company else None,
         "navigations": [],
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),

--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -16,7 +16,7 @@ from newsroom.auth.utils import get_user_from_request, get_company_from_request
 from newsroom.formatters import get_formatters_id_and_names, get_formatter
 from newsroom.email import send_user_email
 from newsroom.wire.utils import update_action_list
-from newsroom.wire.views import item as wire_print, WireItemRouteArgs, WireItemUrlParams
+from newsroom.wire.views import item_view_endpoint as wire_print, WireItemRouteArgs, WireItemUrlParams
 from newsroom.notifications import push_user_notification
 from newsroom.wire import WireSearchServiceAsync
 
@@ -42,7 +42,7 @@ async def get_view_data():
     ui_config_service = UiConfigResourceService()
 
     return {
-        "user": str(user.id),
+        "user": user.to_dict(),
         "company": str(company.id) if company else None,
         "navigations": await get_monitoring_for_company(user),
         "context": "monitoring",
@@ -149,7 +149,7 @@ async def create(request: Request) -> Response:
 
 
 class EditMonitoringUrlParams(WireItemUrlParams):
-    context: SectionEnum = SectionEnum.WIRE
+    context: SectionEnum = SectionEnum.MONITORING
 
     @field_validator("print", mode="before")
     def parse_print(cls, value: str | bool | None) -> bool | str | None:
@@ -185,6 +185,7 @@ async def edit(args: WireItemRouteArgs, params: EditMonitoringUrlParams, request
             date_items_dict=get_date_items_dict(items),
             monitoring_profile=monitoring_profile,
             monitoring_report_name=get_app_config("MONITORING_REPORT_NAME", "Newsroom"),
+            print=True,
         )
 
     profile = await MonitoringProfileService().find_by_id(args.item_id)
@@ -210,6 +211,7 @@ async def edit(args: WireItemRouteArgs, params: EditMonitoringUrlParams, request
                     return Response({"error": gettext("Bad request")}, 400)
 
             process_form_request(updates, request_updates, form)
+            updates.pop("id")
             await MonitoringProfileService().update(args.item_id, updates)
             return Response({"success": True})
         return Response(form.errors, 400)

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -577,6 +577,12 @@ class WireItemUrlParams(BaseModel):
 
 @wire_endpoints.endpoint("/wire/<item_id>")
 async def item(args: WireItemRouteArgs, params: WireItemUrlParams, request: Request, **kwargs) -> Response | str:
+    return await item_view_endpoint(args, params, request, **kwargs)
+
+
+async def item_view_endpoint(
+    args: WireItemRouteArgs, params: WireItemUrlParams, request: Request, **kwargs
+) -> Response | str:
     wire_service = WireSearchServiceAsync()
 
     wire_item = await wire_service.service.find_by_id(args.item_id)


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
Fix the ability to update Monitoring Profiles, fix printing monitoring items, fix the return of the user record in Marketplace, Media Releases and Factcheck.

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
Any attempt to update an existing Monitoring profile would generate an error and the 
users tab would not populate.

The Monitoring view not display all of the available actions for an item (along with Marketplace, Media Releases and Factcheck)

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] This pull request is not adding new forms that use redux
- [ x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
