### PR TITLE
fix printing on factcheck, market place and media releases

### DIFF
--- a/newsroom/factcheck/search.py
+++ b/newsroom/factcheck/search.py
@@ -1,4 +1,6 @@
 from newsroom.wire.search import WireSearchResource, WireSearchService
+from newsroom.wire import WireSearchServiceAsync
+from newsroom.types import SectionEnum
 
 
 class FactCheckSearchResource(WireSearchResource):
@@ -7,3 +9,7 @@ class FactCheckSearchResource(WireSearchResource):
 
 class FactCheckSearchService(WireSearchService):
     section = "factcheck"
+
+
+class FactCheckSearchServiceAsync(WireSearchServiceAsync):
+    section = SectionEnum.FACTCHECK

--- a/newsroom/factcheck/views.py
+++ b/newsroom/factcheck/views.py
@@ -57,7 +57,7 @@ async def search():
 @blueprint.route("/bookmarks_factcheck")
 @login_required
 async def bookmarks():
-    data = get_view_data()
+    data = await get_view_data()
     data["bookmarks"] = True
     return await render_template("factcheck_bookmarks.html", data=data)
 

--- a/newsroom/factcheck/views.py
+++ b/newsroom/factcheck/views.py
@@ -57,7 +57,7 @@ async def search():
 @blueprint.route("/bookmarks_factcheck")
 @login_required
 async def bookmarks():
-    data = await get_view_data()
+    data = get_view_data()
     data["bookmarks"] = True
     return await render_template("factcheck_bookmarks.html", data=data)
 

--- a/newsroom/factcheck/views.py
+++ b/newsroom/factcheck/views.py
@@ -9,7 +9,7 @@ from newsroom.auth.utils import get_user_from_request, get_company_from_request
 from newsroom.formatters import get_formatters_id_and_names
 from newsroom.factcheck import blueprint
 from newsroom.decorator import login_required, section
-from newsroom.wire import WireSearchServiceAsync
+from .search import FactCheckSearchServiceAsync
 from newsroom.wire.views import (
     update_action_list,
     get_previous_versions,
@@ -32,7 +32,7 @@ async def get_view_data():
         "company": str(company.id) if company else None,
         "navigations": [],
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),
-        "saved_items": await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.FACTCHECK),
+        "saved_items": await FactCheckSearchServiceAsync().get_current_user_bookmarks_count(),
         "context": "factcheck",
         "ui_config": await ui_config_service.get_section_config("factcheck"),
     }
@@ -73,9 +73,7 @@ async def bookmark():
     data = await get_json_or_400()
     assert data.get("items")
     await update_action_list(data.get("items"), "bookmarks", item_type="items")
-    push_user_notification(
-        "saved_items", count=await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.FACTCHECK)
-    )
+    push_user_notification("saved_items", count=await FactCheckSearchServiceAsync().get_current_user_bookmarks_count())
     return jsonify(), 200
 
 
@@ -99,16 +97,22 @@ async def versions(_id):
 @blueprint.route("/factcheck/<_id>")
 @login_required
 async def item(_id):
-    item = get_entity_or_404(_id, "items")
-    await set_permissions(item, "factcheck")
+    factcheck_service = FactCheckSearchServiceAsync()
+
+    factcheck_item = await factcheck_service.service.find_by_id(_id)
+    if not factcheck_item:
+        await request.abort(404)
+
+    await set_permissions(factcheck_item, service=factcheck_service)
+
     ui_config_service = UiConfigResourceService()
-    config = await ui_config_service.get_section_config("factcheck")
+    config = await ui_config_service.get_section_config(SectionEnum.FACTCHECK)
     display_char_count = config.get("char_count", False)
     if is_json_request(request):
-        return jsonify(item)
-    if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item)
-    previous_versions = get_previous_versions(item)
+        return jsonify(factcheck_item.to_dict())
+    if not factcheck_item.user_has_access:
+        return await render_template("wire_item_access_restricted.html", item=factcheck_item.to_dict())
+    previous_versions = await get_previous_versions(factcheck_item)
     if "print" in request.args:
         template = "wire_item_print.html"
         await update_action_list([_id], "prints", force_insert=True)
@@ -116,7 +120,7 @@ async def item(_id):
         template = "wire_item.html"
     return await render_template(
         template,
-        item=item,
+        item=factcheck_item.to_dict(),
         previous_versions=previous_versions,
         display_char_count=display_char_count,
     )

--- a/newsroom/market_place/search.py
+++ b/newsroom/market_place/search.py
@@ -1,6 +1,8 @@
 import logging
 
 from newsroom.wire.search import WireSearchResource, WireSearchService
+from newsroom.wire import WireSearchServiceAsync
+from newsroom.types import SectionEnum
 
 logger = logging.getLogger(__name__)
 
@@ -11,4 +13,9 @@ class MarketPlaceSearchResource(WireSearchResource):
 
 class MarketPlaceSearchService(WireSearchService):
     section = "aapX"
+    limit_days_setting = "aapx_time_limit_days"
+
+
+class MarketPlaceSearchServiceAsync(WireSearchServiceAsync):
+    section = SectionEnum.MARKET_PLACE
     limit_days_setting = "aapx_time_limit_days"

--- a/newsroom/market_place/views.py
+++ b/newsroom/market_place/views.py
@@ -48,7 +48,7 @@ async def get_view_data():
         "topics": [t for t in topics if t.get("topic_type") == SECTION_ID],
         "navigations": navigations,
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),
-        "saved_items": await MarketPlaceSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MARKET_PLACE),
+        "saved_items": await MarketPlaceSearchServiceAsync().get_current_user_bookmarks_count(),
         "context": SECTION_ID,
         "ui_config": await ui_config_service.get_section_config(SECTION_ID),
         "home_page": False,

--- a/newsroom/market_place/views.py
+++ b/newsroom/market_place/views.py
@@ -10,7 +10,7 @@ from newsroom.market_place import blueprint, SECTION_ID, SECTION_NAME
 from newsroom.decorator import login_required, section
 from newsroom.topics import get_user_topics
 from newsroom.navigations import get_navigations_by_company
-from newsroom.wire import WireSearchServiceAsync
+from .search import MarketPlaceSearchServiceAsync
 from newsroom.wire.views import (
     update_action_list,
     get_previous_versions,
@@ -48,7 +48,7 @@ async def get_view_data():
         "topics": [t for t in topics if t.get("topic_type") == SECTION_ID],
         "navigations": navigations,
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),
-        "saved_items": await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MARKET_PLACE),
+        "saved_items": await MarketPlaceSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MARKET_PLACE),
         "context": SECTION_ID,
         "ui_config": await ui_config_service.get_section_config(SECTION_ID),
         "home_page": False,
@@ -57,7 +57,9 @@ async def get_view_data():
 
 
 async def get_story_count(navigations: list[Navigation], user: UserResourceModel, company: CompanyResource):
-    await WireSearchServiceAsync().get_navigation_story_count(navigations, SectionEnum(SECTION_ID), company, user)
+    await MarketPlaceSearchServiceAsync().get_navigation_story_count(
+        navigations, SectionEnum(SECTION_ID), company, user
+    )
 
 
 async def get_home_page_data():
@@ -75,7 +77,7 @@ async def get_home_page_data():
         "company": str(company.id) if company else None,
         "navigations": navigations,
         "cards": await (await CardsResourceService().find({"dashboard": SECTION_ID})).to_list_raw(),
-        "saved_items": await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MARKET_PLACE),
+        "saved_items": await MarketPlaceSearchServiceAsync().get_current_user_bookmarks_count(),
         "context": SECTION_ID,
         "home_page": True,
         "title": SECTION_NAME,
@@ -126,7 +128,7 @@ async def bookmark():
     await update_action_list(data.get("items"), "bookmarks", item_type="items")
     push_user_notification(
         "saved_items",
-        count=await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MARKET_PLACE),
+        count=await MarketPlaceSearchServiceAsync().get_current_user_bookmarks_count(),
     )
     return jsonify(), 200
 
@@ -151,16 +153,21 @@ async def versions(_id):
 @blueprint.route("/{}/<_id>".format(SECTION_ID))
 @login_required
 async def item(_id):
-    item = get_entity_or_404(_id, "items")
-    set_permissions(item, "aapX")
+    marketplace_service = MarketPlaceSearchServiceAsync()
+    marketplace_item = await marketplace_service.service.find_by_id(_id)
+    if not marketplace_item:
+        await request.abort(404)
+
+    await set_permissions(marketplace_item, service=marketplace_service)
+
     ui_config_service = UiConfigResourceService()
-    config = await ui_config_service.get_section_config(SECTION_ID)
+    config = await ui_config_service.get_section_config(SectionEnum.MARKET_PLACE)
     display_char_count = config.get("char_count", False)
     if is_json_request(request):
-        return jsonify(item)
-    if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item)
-    previous_versions = get_previous_versions(item)
+        return jsonify(marketplace_item.to_dict())
+    if not marketplace_item.user_has_access:
+        return await render_template("wire_item_access_restricted.html", item=marketplace_item.to_dict())
+    previous_versions = await get_previous_versions(marketplace_item)
     if "print" in request.args:
         template = "wire_item_print.html"
         await update_action_list([_id], "prints", force_insert=True)
@@ -168,7 +175,7 @@ async def item(_id):
         template = "wire_item.html"
     return await render_template(
         template,
-        item=item,
+        item=marketplace_item.to_dict(),
         previous_versions=previous_versions,
         display_char_count=display_char_count,
     )

--- a/newsroom/media_releases/search.py
+++ b/newsroom/media_releases/search.py
@@ -1,4 +1,6 @@
 from newsroom.wire.search import WireSearchResource, WireSearchService
+from newsroom.wire import WireSearchServiceAsync
+from newsroom.types import SectionEnum
 
 
 class MediaReleasesSearchResource(WireSearchResource):
@@ -7,4 +9,9 @@ class MediaReleasesSearchResource(WireSearchResource):
 
 class MediaReleasesSearchService(WireSearchService):
     section = "media_releases"
+    limit_days_setting = "media_releases_time_limit_days"
+
+
+class MediaReleasesSearchServiceAsync(WireSearchServiceAsync):
+    section = SectionEnum.MEDIA_RELEASES
     limit_days_setting = "media_releases_time_limit_days"

--- a/newsroom/media_releases/views.py
+++ b/newsroom/media_releases/views.py
@@ -9,7 +9,7 @@ from newsroom.auth.utils import get_user_from_request, get_company_from_request
 from newsroom.formatters import get_formatters_id_and_names
 from newsroom.media_releases import blueprint
 from newsroom.decorator import login_required, section
-from newsroom.wire import WireSearchServiceAsync
+from .search import MediaReleasesSearchServiceAsync
 from newsroom.wire.views import (
     update_action_list,
     get_previous_versions,
@@ -32,7 +32,9 @@ async def get_view_data():
         "company": str(company.id) if company else None,
         "navigations": [],
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),
-        "saved_items": await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MEDIA_RELEASES),
+        "saved_items": await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(
+            SectionEnum.MEDIA_RELEASES
+        ),
         "context": "media_releases",
         "ui_config": await ui_config_service.get_section_config("media_releases"),
     }
@@ -74,7 +76,8 @@ async def bookmark():
     assert data.get("items")
     await update_action_list(data.get("items"), "bookmarks", item_type="items")
     push_user_notification(
-        "saved_items", count=await WireSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MEDIA_RELEASES)
+        "saved_items",
+        count=await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MEDIA_RELEASES),
     )
     return jsonify(), 200
 
@@ -99,16 +102,21 @@ async def versions(_id):
 @blueprint.route("/media_releases/<_id>")
 @login_required
 async def item(_id):
-    item = get_entity_or_404(_id, "items")
-    set_permissions(item, "media_releases")
+    media_release_service = MediaReleasesSearchServiceAsync()
+    media_release_item = await media_release_service.service.find_by_id(_id)
+    if not media_release_item:
+        await request.abort(404)
+
+    await set_permissions(media_release_item, service=media_release_service)
+
     ui_config_service = UiConfigResourceService()
-    config = await ui_config_service.get_section_config("media_releases")
+    config = await ui_config_service.get_section_config(SectionEnum.MEDIA_RELEASES)
     display_char_count = config.get("char_count", False)
     if is_json_request(request):
-        return jsonify(item)
-    if not item.get("_access"):
-        return await render_template("wire_item_access_restricted.html", item=item)
-    previous_versions = get_previous_versions(item)
+        return jsonify(media_release_item.to_dict())
+    if not media_release_item.user_has_access:
+        return await render_template("wire_item_access_restricted.html", item=media_release_item.to_dict())
+    previous_versions = await get_previous_versions(media_release_item)
     if "print" in request.args:
         template = "wire_item_print.html"
         await update_action_list([_id], "prints", force_insert=True)
@@ -116,7 +124,7 @@ async def item(_id):
         template = "wire_item.html"
     return await render_template(
         template,
-        item=item,
+        item=media_release_item.to_dict(),
         previous_versions=previous_versions,
         display_char_count=display_char_count,
     )

--- a/newsroom/media_releases/views.py
+++ b/newsroom/media_releases/views.py
@@ -32,9 +32,7 @@ async def get_view_data():
         "company": str(company.id) if company else None,
         "navigations": [],
         "formats": get_formatters_id_and_names(SectionEnum.WIRE),
-        "saved_items": await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(
-            SectionEnum.MEDIA_RELEASES
-        ),
+        "saved_items": await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(),
         "context": "media_releases",
         "ui_config": await ui_config_service.get_section_config("media_releases"),
     }
@@ -77,7 +75,7 @@ async def bookmark():
     await update_action_list(data.get("items"), "bookmarks", item_type="items")
     push_user_notification(
         "saved_items",
-        count=await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(SectionEnum.MEDIA_RELEASES),
+        count=await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(),
     )
     return jsonify(), 200
 

--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -744,6 +744,13 @@ class BaseSearchService(Service):
                 self.query_string(search.args["q"], search.args.get("default_operator") or "AND")
             )
 
+        if search.args.get("bookmarks"):
+            search.query["bool"]["must"].append(
+                {
+                    "term": {"bookmarks": str(search.args["bookmarks"])},
+                }
+            )
+
         if search.args.get("ids"):
             search.query["bool"]["must"].append({"ids": {"values": search.args["ids"]}})
 

--- a/newsroom/search/service.py
+++ b/newsroom/search/service.py
@@ -744,13 +744,6 @@ class BaseSearchService(Service):
                 self.query_string(search.args["q"], search.args.get("default_operator") or "AND")
             )
 
-        if search.args.get("bookmarks"):
-            search.query["bool"]["must"].append(
-                {
-                    "term": {"bookmarks": str(search.args["bookmarks"])},
-                }
-            )
-
         if search.args.get("ids"):
             search.query["bool"]["must"].append({"ids": {"values": search.args["ids"]}})
 

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict, Optional
+from typing import Any, TypedDict
 import io
 import zipfile
 
@@ -78,7 +78,7 @@ HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
 
 
 async def set_permissions(
-    wire_item: WireItem, ignore_latest: bool = False, service: Optional[WireSearchServiceAsync] = None
+    wire_item: WireItem, ignore_latest: bool = False, service: WireSearchServiceAsync | None = None
 ):
     try:
         if not service:

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, TypedDict, Optional
 import io
 import zipfile
 
@@ -77,9 +77,13 @@ HOME_ITEMS_CACHE_KEY = "home_items"
 HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
 
 
-async def set_permissions(wire_item: WireItem, ignore_latest=False):
+async def set_permissions(
+    wire_item: WireItem, ignore_latest: bool = False, service: Optional[WireSearchServiceAsync] = None
+):
     try:
-        cursor = await WireSearchServiceAsync().get_items_by_id(
+        if not service:
+            service = WireSearchServiceAsync()
+        cursor = await service.get_items_by_id(
             [wire_item.id],
             WireSearchRequestArgs(
                 ignore_latest=ignore_latest,


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
Fix the print endpoint in factcheck and media releases and market place.

### What has changed
<!--- Explain what has changed and how -->
The mechanism to verify that the user had the right to print the selected item was broken, now uses the function to verify the item is accessible to the user.

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
Try to print an item from the sections above, if you can then it is fixed.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] This pull request is not adding new forms that use redux
- [x ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
