### PR TITLE
[STT-47] - Update Agenda Event Details to string value

### DIFF
--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -280,11 +280,11 @@ export function hasLocation(item: any) {
 }
 
 export function hasLocationNotes(item: IAgendaItem) {
-    return get(item, 'location[0].details[0].length', 0) > 0;
+    return get(item, 'location[0].details', '').trim().length > 0;
 }
 
 export function getLocationDetails(item: IAgendaItem) {
-    return item.location && item.location[0] && item.location[0].details && item.location[0].details[0];
+    return item.location && item.location[0] && item.location[0].details && item.location[0].details.trim();
 }
 
 /**

--- a/assets/interfaces/agenda.ts
+++ b/assets/interfaces/agenda.ts
@@ -35,7 +35,7 @@ export interface ILocation {
     type?: string;
     qcode: string;
     location?: {lat: number; lon: number};
-    details?: string[];
+    details?: string;
     address?: {
         area?: string;
         locality?: string;

--- a/newsroom/types/agenda.py
+++ b/newsroom/types/agenda.py
@@ -126,7 +126,18 @@ class EventLocation(Dataclass):
     qcode: fields.Keyword | None = None
     geo: str | None = None
     formatted_address: str | None = None
-    details: list[str] | None = None
+    details: str | None = None
+
+    @field_validator("details", mode="before")
+    @classmethod
+    def normalize_details(cls, value: Any) -> str:
+        if isinstance(value, list):
+            return ", ".join(filter(None, value))
+        elif isinstance(value, str):
+            return value
+        elif value is None:
+            return ""
+        raise ValueError("Invalid type for 'details': must be string or list of strings.")
 
 
 class PlanningItemAgenda(Dataclass):


### PR DESCRIPTION
### Purpose

This PR updates the `EventLocation.details` field to use a `string` ensuring consistency with how notes are applied from Superdesk. It also introduces validation to safely normalize existing array data into a comma-separated string.

### What has changed
- Changed `details` field in `EventLocation` dataclass from `list[str]` to `str` and updated it's usages
- Added a `@field_validator` to normalize existing `list[str]` values into a single comma-separated string before type enforcement

Resolves: #[STT-47]


[STT-47]: https://sofab.atlassian.net/browse/STT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ