### PR TITLE
fix stray 0 for list items with single version

### DIFF
--- a/assets/wire/components/WireListItem.tsx
+++ b/assets/wire/components/WireListItem.tsx
@@ -306,7 +306,7 @@ class WireListItem extends React.Component<IProps, IState> {
                             </div>
                         )}
 
-                        {showItemVersions(item) && (
+                        {!!showItemVersions(item) && (
                             <div
                                 className="no-bindable wire-articles__item__versions-btn"
                             >


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
Stray 0's were being displayed in the item list entries when only a single version of the item exists

### What has changed
<!--- Explain what has changed and how -->
Stray 0's no longer appear

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
Look at a list of items with only a single version!

<!-- [For UI changes]
### Screenshots
-->
![Screenshot from 2025-06-04 15-30-02](https://github.com/user-attachments/assets/04e8735d-8fb3-485f-9982-42c6c87c5eef)


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
