### PR TITLE
fix: Support more states in AgendaItem model

### DIFF
--- a/newsroom/types/agenda.py
+++ b/newsroom/types/agenda.py
@@ -40,6 +40,8 @@ class AgendaWorkflowState(str, Enum):
     CANCELLED = "cancelled"
     RESCHEDULED = "rescheduled"
     POSTPONED = "postponed"
+    INGESTED = "ingested"
+    ACTIVE = "active"
 
 
 class AgendaCVItem(Dataclass):


### PR DESCRIPTION
### Purpose
Changes in Superdesk/Planning now support publishing an Agenda item with state `ingested`, which throws an exception in Newshub due to the value not in the enum.

### What has changed
Add `ingested` and `active` to the enum. The other values are `draft` and `spiked` which should never be received by Newshub.
