### PR TITLE
[STT-47] - Adds location.details searchability and fixes name required error

### DIFF
--- a/newsroom/types/agenda.py
+++ b/newsroom/types/agenda.py
@@ -120,7 +120,7 @@ class AgendaCoverage(Dataclass):
 
 
 class EventLocation(Dataclass):
-    name: fields.TextWithKeyword
+    name: fields.TextWithKeyword | None = None
     address: Annotated[dict | None, fields.dynamic_mapping()] = None
     location: fields.Geopoint | None = None
     qcode: fields.Keyword | None = None

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -686,6 +686,7 @@ AGENDA_SEARCH_FIELDS = [
     "definition_long",
     "description_text",
     "location.name",
+    "location.details",
 ]
 
 


### PR DESCRIPTION
### Purpose
This PR adds `location.details` to AGENDA_SEARCH_FIELDS and also makes location.name optional so that an event can be posted with location details and no location name.

### What has changed
- Added `location.details` to AGENDA_SEARCH_FIELDS to make it searchable.
- To fix `location.0.name : Field is required` error, location.name field has been made optional. Hence, an event can be posted with location details but without location name.


Resolves: #[STT-47]


[STT-47]: https://sofab.atlassian.net/browse/STT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ