### PR TITLE
[CPCN-1095] fix: query_string URL arg not working in Agenda

### DIFF
--- a/newsroom/agenda/filters.py
+++ b/newsroom/agenda/filters.py
@@ -257,18 +257,19 @@ def apply_product_planning_filters(request: NewshubSearchRequest[AgendaSearchReq
 
 
 def apply_agenda_query_string(request: NewshubSearchRequest[AgendaSearchRequestArgs]) -> None:
-    if not request.args.q:
+    search_text = request.args.q.strip() if request.args.q else None
+    if not search_text:
         return
 
     q_dict: dict[str, Any] | None = None
     try:
-        q_dict = json.loads(request.args.q)
+        q_dict = json.loads(search_text)
     except ValueError:
         pass
 
-    if q_dict is None:
+    if not isinstance(q_dict, dict):
         # Normal query string query
-        query = query_string_for_section(SectionEnum.AGENDA, request.args.q)
+        query = query_string_for_section(SectionEnum.AGENDA, search_text)
         if request.args.item_type == AgendaItemType.EVENT:
             # Events Only
             request.search.query.filter.append(query)
@@ -280,7 +281,7 @@ def apply_agenda_query_string(request: NewshubSearchRequest[AgendaSearchRequestA
                             query,
                             nested_query(
                                 "planning_items",
-                                planning_items_query_string(request.args.q, nested=True),
+                                planning_items_query_string(search_text, nested=True),
                                 name="query",
                             ),
                         ],

--- a/newsroom/search/filters.py
+++ b/newsroom/search/filters.py
@@ -141,14 +141,15 @@ def apply_date_range(request: NewshubSearchRequest) -> None:
 def apply_query_string(request: NewshubSearchRequest) -> None:
     """Applies query_string filter based on request args"""
 
-    if not request.args.q:
+    search_text = request.args.q.strip() if request.args.q else None
+    if not search_text:
         return
 
     fields_config_key = "AGENDA_SEARCH_FIELDS" if request.section == SectionEnum.AGENDA else "WIRE_SEARCH_FIELDS"
     fields = get_app_config(fields_config_key, ["*"])
     request.search.query.must.append(
         query_string(
-            request.args.q,
+            search_text,
             default_operator=request.args.default_operator,
             fields=fields,
         )


### PR DESCRIPTION
### Purpose
`q` URL arg was not working properly in Agenda page when using quoted strings, such as `"Test Event"`.

### What has changed
* Strip `q` URL arg to remove whitespace
* In Agenda, test if json.loads returns a dict before processing the more complex `q` value supported

### Steps to test
1. Navigate to the Agenda page
2. Enter a quoted search in the main search bar

The query should execute and return with matched items (previously an exception was being raised)

Resolves: [CPCN-1095](https://sofab.atlassian.net/browse/CPCN-1095)


[CPCN-1095]: https://sofab.atlassian.net/browse/CPCN-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ