### PR TITLE
fix(notifications): Make `data` attribute optional

### DIFF
--- a/newsroom/types/notifications.py
+++ b/newsroom/types/notifications.py
@@ -18,7 +18,7 @@ class Notification(ResourceModel):
 
     user: user_validated_type
     action: str
-    data: dict = Field(default_factory=dict)
+    data: dict | None = None
 
 
 class NotificationTopic(Dataclass):


### PR DESCRIPTION
### Purpose
The following exception was being raised on cpcn-uat:
```
1 validation error for Notification
data
  Input should be a valid dictionary [type=dict_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/dict_type
```

After looking at the code, we're sometimes storing [None in data](https://github.com/superdesk/newsroom-core/blob/async/newsroom/push/notifications.py#L128). This would mean that existing data before upgrading could possibly have a `None` value.

### What has changed
Rather then keeping the default dict factory and creating a data migration script, I changed the schema to allow a value of `None`.