### PR TITLE
[CPCN-1106] fix: Remove CV item translations if it not a dict

### DIFF
--- a/newsroom/agenda/agenda_service.py
+++ b/newsroom/agenda/agenda_service.py
@@ -46,7 +46,7 @@ class AgendaItemService(AsyncResourceService[AgendaItem]):
         """
         Sets agenda metadata from a given event
         """
-        from newsroom.push.utils import format_qcode_items, set_dates, get_event_dates
+        from newsroom.push.utils import format_qcode_items, set_dates, get_event_dates, fix_translation_value
 
         app = get_current_wsgi_app()
         if event.get("files"):
@@ -72,7 +72,7 @@ class AgendaItemService(AsyncResourceService[AgendaItem]):
         agenda["definition_long"] = event.get("definition_long")
         agenda["version"] = event.get("version")
         agenda["versioncreated"] = event.get("versioncreated")
-        agenda["calendars"] = event.get("calendars")
+        agenda["calendars"] = fix_translation_value(event.get("calendars") or [])
         agenda["location"] = event.get("location", [])
         agenda["ednote"] = event.get("ednote")
         agenda["state_reason"] = event.get("state_reason")

--- a/newsroom/push/utils.py
+++ b/newsroom/push/utils.py
@@ -45,6 +45,20 @@ async def fix_updates(doc: dict[str, Any], next_item: WireItem):
         logger.warning("Didn't fix ancestors in 50 iterations", extra={"guid": doc["guid"]})
 
 
+def fix_translation_value(items: list[dict]) -> list[dict]:
+    """Fix bug from Superdesk side that sometimes sends translation values as a string
+
+    Only store the ``translations`` attribute for CV items if it is a dictionary
+    otherwise it is removed.
+    """
+
+    for item in items:
+        if not isinstance(item.get("translations"), dict):
+            item.pop("translations", None)
+
+    return items
+
+
 def format_qcode_items(items: list[dict[str, Any]] | None = None):
     if not items:
         return []
@@ -53,7 +67,7 @@ def format_qcode_items(items: list[dict[str, Any]] | None = None):
         if not item.get("code"):
             item["code"] = item.get("qcode")
 
-    return items
+    return fix_translation_value(items)
 
 
 def get_display_dates(planning_items: list[dict[str, Any]]):

--- a/newsroom/types/agenda.py
+++ b/newsroom/types/agenda.py
@@ -182,7 +182,7 @@ class CalendarItem(Dataclass):
     name: fields.Keyword
     schema: fields.Keyword | None = None
     is_active: bool = True
-    translations: dict[str, Any] | None = None
+    translations: dict[str, Any] | str | None = None
 
 
 class AgendaItem(ResourceModel, ModelWithVersions):


### PR DESCRIPTION
### Purpose
There looks to be a bug in Superdesk which allows storing CV item translations as a string. This was okay before Pydantic models, but now it causes a validation error.

![image](https://github.com/user-attachments/assets/a462261a-d2c9-443c-8bfe-2877174d02a8)

### What has changed
A migration script to fix up the existing data might not work here, as in a Production environment there would be way too many documents to update. Instead I have opted to support string as a valid value for translations, but fix it in any new items published into Newshub.

Resolves: [CPCN-1106](https://sofab.atlassian.net/browse/CPCN-1106)


[CPCN-1106]: https://sofab.atlassian.net/browse/CPCN-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ