### PR TITLE
[CPCN-1089] fix: Agenda pagination using invalid logic

### DIFF
--- a/newsroom/agenda/agenda_search.py
+++ b/newsroom/agenda/agenda_search.py
@@ -106,7 +106,7 @@ class AgendaSearchServiceAsync(BaseWebSearchService[AgendaSearchRequestArgs, Age
             matching_event_ids: set[str] = (
                 set() if args.item_type is not None else await self._get_event_ids_matching_query(args)
             )
-            date_range = {} if not args.start_date and args.end_date else get_date_filters(args)
+            date_range = {} if not (args.start_date and args.end_date) else get_date_filters(args)
             for item in response["_items"]:
                 if item["_id"] in matching_event_ids:
                     item["_search_matched_event"] = True

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -1,6 +1,7 @@
 from typing import Any
 from urllib.parse import urlencode
 
+from pydantic import AliasChoices
 from werkzeug.datastructures import ImmutableMultiDict
 
 from content_api.errors import UnexpectedParameterError
@@ -72,10 +73,13 @@ class NewsApiSearchServiceAsync(BaseNewshubSearchService[NewsApiSearchRequestArg
         url_args: ImmutableMultiDict = flask_request.args
         allowed_fields = set(model.model_fields.keys())
 
-        for field in model.model_fields.values():
-            if field.validation_alias:
-                for alias in field.validation_alias.choices:
-                    allowed_fields.add(alias)
+        for field, info in model.model_fields.items():
+            if isinstance(info.validation_alias, AliasChoices):
+                # Exclude `AliasPath` instances from choices, as we won't be able to
+                # translate that into a field name
+                allowed_fields |= set([choice for choice in info.validation_alias.choices if isinstance(choice, str)])
+            else:
+                allowed_fields.add(info.alias or field)
 
         unknown_fields = set(url_args.keys()) - allowed_fields
         if unknown_fields:

--- a/newsroom/search/filters.py
+++ b/newsroom/search/filters.py
@@ -476,5 +476,6 @@ def validate_request(request: NewshubSearchRequest) -> None:
                 403, gettext(f"User does not have access to {request.section} section"), title=gettext("403. Forbidden")
             )
 
-    if request.args.page > 1000:
-        raise AuthorizationError(400, gettext("Page limit exceeded"), title=gettext("403. Forbidden"))
+    if request.args.page_size >= 1000 or (request.args.page - 1) * request.args.page_size >= 1000:
+        # https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html#pagination
+        raise BadParameterValueError(gettext("Page limit exceeded"))

--- a/newsroom/search/types.py
+++ b/newsroom/search/types.py
@@ -2,8 +2,9 @@ from typing import Literal, Any, TypeVar, Generic, Callable, Awaitable
 from typing_extensions import TypedDict
 from dataclasses import dataclass, field
 from enum import Enum, unique
+import math
 
-from pydantic import Field, AliasChoices, field_validator
+from pydantic import Field, AliasChoices, field_validator, model_validator
 from quart_babel import gettext
 
 from superdesk.core.types import ProjectedFieldArg, Request, SearchRequest, SortListParam, ESQuery
@@ -181,7 +182,10 @@ class BaseSearchRequestArgs(BaseModel):
     page_size: int = Field(validation_alias=AliasChoices("page_size", "size", "max_results"), default=25)
 
     #: Pagination, the page number to return
-    page: int = Field(validation_alias=AliasChoices("page", "from"), default=0)
+    page: int = 0
+
+    #: Pagination, the item number to return from - internally is converted to a page number
+    from_item_number: int | None = Field(alias="from", default=None)
 
     #: An elasticsearch query_string to be added to the filter
     q: str | None = None
@@ -317,6 +321,13 @@ class BaseSearchRequestArgs(BaseModel):
             return json.loads(value) if isinstance(value, str) else value
         except (ValueError, TypeError):
             raise BadParameterValueError(gettext("Incorrect type supplied for projection parameter"))
+
+    @model_validator(mode="after")
+    def parse_model(self):
+        if self.from_item_number is not None:
+            # Convert the ``from`` search argument to a page number
+            self.page = (math.floor(self.from_item_number / self.page_size) + 1) if self.page_size > 0 else 0
+        return self
 
 
 SearchArgsType = TypeVar("SearchArgsType", bound=BaseSearchRequestArgs)


### PR DESCRIPTION
### Purpose
Agenda pagination was using `from` in the front-end for pagination. This was mistakenly interpreted as `page` on the back-end.

### What has changed
* As we don't have support for `from` param in new async search services, I opted to convert it to a `page` param instead, rather than update an older alpha version of Superdesk to add this support.
* Fixed an issue where the `_display_from` and `_display_to` attributes were set on agenda items without a date search being in place, which restricted the days the items would be shown up to (`_display_from` + 10 days).

Resolves: [CPCN-1094](https://sofab.atlassian.net/browse/CPCN-1094)


[CPCN-1094]: https://sofab.atlassian.net/browse/CPCN-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ