### PR TITLE
[CPCN-1101] - Download options for Calendar are incorrect and those new options do not work

### DIFF
--- a/newsroom/agenda/formatters/csv_formatter.py
+++ b/newsroom/agenda/formatters/csv_formatter.py
@@ -10,7 +10,7 @@ from werkzeug.utils import secure_filename
 from superdesk.core import get_app_config
 
 from newsroom.types import SectionEnum
-from newsroom.formatters import BaseFormatter
+from newsroom.formatters import BaseFormatter, FormatterAssetType
 from newsroom.utils import parse_dates
 from newsroom.agenda.utils import get_filtered_subject
 
@@ -19,6 +19,7 @@ class CSVFormatter(BaseFormatter):
     format_id = "Csv"
     name = lazy_gettext("CSV")
     sections = [SectionEnum.AGENDA]
+    assets = [FormatterAssetType.TEXT]
 
     VERSION = "1.0"
     PRODID = "Newshub"

--- a/newsroom/agenda/formatters/ical_formatter.py
+++ b/newsroom/agenda/formatters/ical_formatter.py
@@ -9,7 +9,7 @@ from superdesk.flask import url_for
 from superdesk.utc import utcnow
 
 from newsroom.types import SectionEnum
-from newsroom.formatters import BaseFormatter
+from newsroom.formatters import BaseFormatter, FormatterAssetType
 from newsroom.agenda.contacts import get_contact_name, get_contact_email
 
 
@@ -38,6 +38,7 @@ class iCalFormatter(BaseFormatter):
     format_id = "ical"
     name = lazy_gettext("iCalendar")
     sections = [SectionEnum.AGENDA]
+    assets = [FormatterAssetType.TEXT]
 
     VERSION = "2.0"
     PRODID = "Newshub"

--- a/newsroom/monitoring/formatters/base_monitoring_formatter.py
+++ b/newsroom/monitoring/formatters/base_monitoring_formatter.py
@@ -8,7 +8,7 @@ from newsroom.wire.formatters.text import TextFormatter
 
 
 class BaseMonitoringFormatter(TextFormatter):
-    section = [SectionEnum.MONITORING]
+    sections = [SectionEnum.MONITORING]
 
     async def get_monitoring_file(
         self,


### PR DESCRIPTION
### Purpose

This PR addresses an issue in the download modal under the Agenda section, where expected download formats (iCalendar and CSV) were missing, and incorrect formats (PDF and RTF) were showing. 

### What has changed
- Added `assets = [FormatterAssetType.TEXT]` to both CSV and iCal formatters to ensure they are recognized as text-based formats and included in Agenda download options.
- Replaced `section` with the correct attribute `sections` in `BaseMonitoringFormatter`, limiting PDF and RTF formatters to only appear in the Monitoring context.

Resolves: [CPCN-1101](https://sofab.atlassian.net/browse/CPCN-1101)


[CPCN-1101]: https://sofab.atlassian.net/browse/CPCN-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ