### PR TITLE
[CPCN-1103] fix: MoreNews button have invalid `kind` param in Personal dashboard

### DIFF
--- a/assets/components/cards/render/LargePictureTextCard.tsx
+++ b/assets/components/cards/render/LargePictureTextCard.tsx
@@ -29,10 +29,10 @@ const getPictureTextPanel = (item: IArticle, picture: IArticle | null, openItem:
 };
 
 const LargePictureTextCard: React.ComponentType<ICardProps> = (props: ICardProps) => {
-    const {items, title, id, openItem, isActive, cardId, listConfig} = props;
+    const {items, title, id, openItem, isActive, cardId, listConfig, kind} = props;
 
     return (
-        <CardRow title={title} id={id} isActive={isActive} onMoreNewsClicked={props.onMoreNewsClicked}>
+        <CardRow title={title} id={id} isActive={isActive} kind={kind} onMoreNewsClicked={props.onMoreNewsClicked}>
             {items.map((item) => getPictureTextPanel(item, getPicture(item), openItem, cardId, listConfig))}
         </CardRow>
     );

--- a/assets/components/cards/render/LargeTextOnlyCard.tsx
+++ b/assets/components/cards/render/LargeTextOnlyCard.tsx
@@ -18,10 +18,10 @@ const getTextOnlyPanel = (item: IArticle, openItem: any, cardId: string, listCon
 );
 
 const LargeTextOnlyCard: React.ComponentType<ICardProps> = (props: ICardProps) => {
-    const {items, title, id, openItem, isActive, cardId, listConfig} = props;
+    const {items, title, id, openItem, isActive, cardId, listConfig, kind} = props;
 
     return (
-        <CardRow title={title} id={id} isActive={isActive} onMoreNewsClicked={props.onMoreNewsClicked}>
+        <CardRow title={title} id={id} isActive={isActive}  kind={kind} onMoreNewsClicked={props.onMoreNewsClicked}>
             {items.map((item) => getTextOnlyPanel(item, openItem, cardId, listConfig))}
         </CardRow>
     );

--- a/assets/components/cards/render/MediaGalleryCard.tsx
+++ b/assets/components/cards/render/MediaGalleryCard.tsx
@@ -31,10 +31,10 @@ const getMediaPanel = (item: IArticle, picture: IArticle | null, openItem: any, 
 };
 
 const MediaGalleryCard: React.ComponentType<ICardProps> = (props: ICardProps) => {
-    const {items, title, id, openItem, isActive, cardId} = props;
+    const {items, title, id, openItem, isActive, cardId, kind} = props;
 
     return (
-        <CardRow title={title} id={id} isActive={isActive} onMoreNewsClicked={props.onMoreNewsClicked}>
+        <CardRow title={title} id={id} isActive={isActive} kind={kind} onMoreNewsClicked={props.onMoreNewsClicked}>
             {items.map((item: any) => getMediaPanel(item, getPicture(item), openItem, cardId))}
         </CardRow>
     );

--- a/assets/components/cards/render/TextOnlyCard.tsx
+++ b/assets/components/cards/render/TextOnlyCard.tsx
@@ -25,10 +25,10 @@ const getTextOnlyPanel = (item: IArticle, openItem: any, cardId: string, listCon
 );
 
 const TextOnlyCard: ComponentType<ICardProps> = (props: ICardProps) => {
-    const {items, title, id, openItem, isActive, cardId, listConfig} = props;
+    const {items, title, id, openItem, isActive, cardId, listConfig, kind} = props;
 
     return (
-        <CardRow title={title} id={id} isActive={isActive} onMoreNewsClicked={props.onMoreNewsClicked}>
+        <CardRow title={title} id={id} isActive={isActive} kind={kind} onMoreNewsClicked={props.onMoreNewsClicked}>
             {items.map((item: any) => getTextOnlyPanel(item, openItem, cardId, listConfig))}
         </CardRow>
     );

--- a/assets/components/cards/render/TopNewsOneByOneCard.tsx
+++ b/assets/components/cards/render/TopNewsOneByOneCard.tsx
@@ -33,10 +33,10 @@ const getTopNewsPanel = (item: IArticle, picture: IArticle | null, openItem: any
 };
 
 const TopNewsOneByOneCard: React.ComponentType<ICardProps> = (props: ICardProps) => {
-    const {items, title, id, openItem, isActive, cardId, listConfig} = props;
+    const {items, title, id, openItem, isActive, cardId, listConfig, kind} = props;
 
     return (
-        <CardRow title={title} id={id} isActive={isActive} onMoreNewsClicked={props.onMoreNewsClicked}>
+        <CardRow title={title} id={id} isActive={isActive} kind={kind} onMoreNewsClicked={props.onMoreNewsClicked}>
             {items.map((item: any) => getTopNewsPanel(item, getPicture(item), openItem, cardId, listConfig))}
         </CardRow>
     );

--- a/assets/components/cards/render/WireListCard.tsx
+++ b/assets/components/cards/render/WireListCard.tsx
@@ -116,7 +116,7 @@ interface IWireListCardProps extends ICardProps {
 
 const WireListCardComponent: React.ComponentType<IWireListCardProps> = (props: IWireListCardProps) => {
     return (
-        <CardRow title={props.title} id={props.id} isActive={props.isActive} onMoreNewsClicked={props.onMoreNewsClicked}>
+        <CardRow title={props.title} id={props.id} isActive={props.isActive} kind={props.kind} onMoreNewsClicked={props.onMoreNewsClicked}>
             {props.items.map((item: IArticle) => (
                 <WireListPanel
                     key={item._id}


### PR DESCRIPTION
### Purpose
When clicking on the `MORE NEWS` button Home dashboard was incorrectly using `product` instead of `topic` when used in the personal dashboard, leading to incorrect items shown in the next page.

### What has changed
* Pass on the `kind` param from the parent component down to the `CardRow` component
* 
### Steps to test
1. Navigate to the Wire section
2. Create a search, and save it as a topic
4. Navigate to the home page
6. Configure the Personal Dashboard with the above topic
7. Click on the `MORE NEWS` button

After clicking the `MORE NEWS` button, the list of items shown should be the same as in step 2.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: [CPCN-1103](https://sofab.atlassian.net/browse/CPCN-1103)


[CPCN-1103]: https://sofab.atlassian.net/browse/CPCN-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ