### PR TITLE
[CPCN-1098] Fix match keyword(s) not highlighted in the results

### DIFF
--- a/newsroom/agenda/filters.py
+++ b/newsroom/agenda/filters.py
@@ -670,4 +670,5 @@ default_agenda_filters: list[SearchFilterFunction] = [
     prefill_args_from_topic,
     prefill_item_type_arg,
     apply_agenda_date_filters,
+    apply_highlights,
 ] + filters_without_dates


### PR DESCRIPTION
### Purpose
Fix the issue of matched keywords not being highlighted in the search results in Agenda section

### What has changed
- Added `apply_highlights` function to the  `default_agenda_filters`

Resolves: [CPCN-1098]

[CPCN-1098]: https://sofab.atlassian.net/browse/CPCN-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ