### PR TITLE
[CPCN-1112] fix: Show PersonalDashboard card even if no items

### DIFF
--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -199,13 +199,10 @@ async def get_personal_dashboards_data(
     async def _get_topic_data(topic_id: ObjectId):
         for topic in topics:
             if topic.id == topic_id:
-                topic_items = await get_topic_items(topic)
-                if topic_items:
-                    return {
-                        "_id": topic.id,
-                        "items": topic_items,
-                    }
-                break
+                return {
+                    "_id": topic.id,
+                    "items": await get_topic_items(topic) or [],
+                }
         return None
 
     async def _get_dashboard_data(dashboard: DashboardModel, dashboard_index: int):


### PR DESCRIPTION
### Purpose
Previously when a personal dashboard card contained no items, the card was not included in the front-end. This meant it did not show in the personal dashboard nor in the config for the personal dashboards.

### What has changed
* Return all personal dashboard cards, regardless if they have items or not (this also replicates the functionality for the standard dashboard cards, bringing them on par with funcationality).

Resolves: [CPCN-1112](https://sofab.atlassian.net/browse/CPCN-1112)


[CPCN-1112]: https://sofab.atlassian.net/browse/CPCN-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ