### PR TITLE
[CPCN-1114] fix: Various bugs around downloading items

### DIFF
--- a/assets/wire/actions.ts
+++ b/assets/wire/actions.ts
@@ -450,7 +450,7 @@ export function submitDownloadItems(items: any, params: any) {
                 const response = await server.post(url, payload, undefined, {parseJson: false});
                 const blob = await response.blob();
                 initiateDownload(blob);
-            } catch (error) {
+            } catch (error: any) {
                 errorHandler(error);
             }
         }

--- a/assets/wire/actions.ts
+++ b/assets/wire/actions.ts
@@ -451,7 +451,7 @@ export function submitDownloadItems(items: any, params: any) {
                 const blob = await response.blob();
                 initiateDownload(blob);
             } catch (error) {
-                console.error('Error downloading file:', error);
+                errorHandler(error);
             }
         }
         dispatch(setDownloadItems(items));

--- a/newsroom/agenda/formatters/csv_formatter.py
+++ b/newsroom/agenda/formatters/csv_formatter.py
@@ -25,6 +25,7 @@ class CSVFormatter(BaseFormatter):
     PRODID = "Newshub"
     FILE_EXTENSION = "csv"
     MIMETYPE = "text/csv"
+    BULK_MIMETYPE = "text/csv"
     MULTI = True
 
     async def format_item(self, item: dict[str, Any], item_type: str | None = None) -> bytes:

--- a/newsroom/agenda/formatters/ical_formatter.py
+++ b/newsroom/agenda/formatters/ical_formatter.py
@@ -102,7 +102,7 @@ class iCalFormatter(BaseFormatter):
                     event.add("location", loc["name"])
                 try:
                     event.add("geo", (loc["location"]["lat"], loc["location"]["lon"]))
-                except KeyError:
+                except (KeyError, TypeError):
                     pass
 
         # links

--- a/newsroom/formatters.py
+++ b/newsroom/formatters.py
@@ -25,6 +25,7 @@ class BaseFormatter:
     assets: list[FormatterAssetType] | None = None
 
     MIMETYPE = None
+    BULK_MIMETYPE = "application/zip"
     FILE_EXTENSION = None
     MEDIATYPE = "text"
     MULTI = False
@@ -38,8 +39,8 @@ class BaseFormatter:
         items_file = BytesIO()
         with zipfile.ZipFile(items_file, mode="w") as zf:
             for item in items:
-                formatted_data = await self.format_item(item, item_type=item_type)
                 parse_dates(item)  # fix for old items
+                formatted_data = await self.format_item(item, item_type=item_type)
                 zf.writestr(
                     secure_filename(self.format_filename(item)),
                     formatted_data,

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -374,7 +374,7 @@ async def download(args: None, params: ItemActionUrlParams, request: Request):
         else:
             _file.write(file_data)
             _file.seek(0)
-        mimetype = "application/zip"
+        mimetype = formatter.BULK_MIMETYPE
         if filename is not None:
             attachment_filename = filename
 


### PR DESCRIPTION
### Purpose
Users are unable to download one or more items when using the 'NewsMLG2', 'ICalendar' or 'CSV' formatters.

### What has changed
* Show message to the end user if downloading fails (previously the error was only logged to the console)
* Allow formatters to define what mimetype to use when bulk downloading
* Fix issue in iCal formatter when populating Event location information
* Convert date fields from string to datetime instances **before** formatting bulk items

Resolves: [CPCN-1114](https://sofab.atlassian.net/browse/CPCN-1114)


[CPCN-1114]: https://sofab.atlassian.net/browse/CPCN-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ