### PR TITLE
[CPCN-1097] Fixes a bug where `0` was being rendered in the DOM

### DIFF
--- a/assets/wire/components/WireListItem.tsx
+++ b/assets/wire/components/WireListItem.tsx
@@ -306,7 +306,7 @@ class WireListItem extends React.Component<IProps, IState> {
                             </div>
                         )}
 
-                        {!!showItemVersions(item) && (
+                        {showItemVersions(item) && (
                             <div
                                 className="no-bindable wire-articles__item__versions-btn"
                             >

--- a/assets/wire/utils.ts
+++ b/assets/wire/utils.ts
@@ -255,12 +255,14 @@ export function isPreformatted(item: any) {
 /**
  * Test if other item versions should be visible
  *
- * @param {Object} item
- * @param {bool} next toggle if checking for next or previous versions
- * @return {Boolean}
+ * @param {IArticle} item - The article to check for versions
+ * @param {boolean} [next] - Toggle if checking for next or previous versions
+ * @return {boolean} - True if versions should be visible
  */
-export function showItemVersions(item: any, next?: any) {
-    return !isKilled(item) && (next || item.ancestors && item.ancestors.length);
+export function showItemVersions(item: IArticle, next?: boolean): boolean {
+    const hasNextOrAncestors = Boolean(next || (item.ancestors?.length ?? 0));
+
+    return !isKilled(item) && hasNextOrAncestors;
 }
 
 /**


### PR DESCRIPTION
### Purpose
Fix rendering issue where a numeric value (`0`) was being inserted into the DOM due to inconsistent return type from a utility function. `showItemVersions` was returning a truthy value that wasn't explicitly a boolean, which could cause React to mistakenly try rendering it. The function now returns a strict boolean to avoid React rendering unintended output.

### What has changed
- Updated `showItemVersions` to always return a strict boolean
- This prevents React from mistakenly rendering values like `0` as visible DOM nodes
- Removed unnecessary `!!` coercion in JSX now that the function is guaranteed to return a boolean

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Related PR: https://github.com/superdesk/newsroom-core/pull/1285

Resolves: [CPCN-1097]


[CPCN-1097]: https://sofab.atlassian.net/browse/CPCN-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ