### PR TITLE
[CPCN-1122] fix: Make sure user create/update sets default locale

### DIFF
--- a/newsroom/types/users.py
+++ b/newsroom/types/users.py
@@ -119,14 +119,10 @@ class UserResourceModel(NewshubResourceModel):
 
     @field_validator("locale", mode="before")
     @classmethod
-    def validate_locale(cls, value: str | None) -> str | None:
-        if value == "":
-            # If any empty value is supplied, change it to ``None`` instead
-            value = None
-
+    def validate_locale(cls, value: str | None) -> str:
         if value is not None and value not in get_app_config("LANGUAGES", []):
             raise SuperdeskApiError.badRequestError("Locale is not in configured list of locales.")
-        return value
+        return value or get_app_config("DEFAULT_LANGUAGE", "en")
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
### Purpose
`locale` was not being sent with user create/update signals if the locale was not changed from the default from the front-end.

### What has changed
When constructing an instance of the User model, make sure the locale defaults to the system configured default.

Note: I left the locale optional for those users that do not have locale currently set, and for existing tests etc (to keep this change small).

### Steps to test
1. Open chrome DevTools -> Network
2. Navigate to Settings -> User Management
3. Click `NEW USER` button
4. Enter in the required fields (but do not change the `Language` field)
5. Click the `SAVE` button

Notice in the network tab, the request to reload users includes the new user, and the locale is set to the default `en`.

Resolves: [CPCN-1122](https://sofab.atlassian.net/browse/CPCN-1122)


[CPCN-1122]: https://sofab.atlassian.net/browse/CPCN-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ