### PR TITLE
[CPCN-1118] Fix missing highlighted keywords in the real time email alerts

### DIFF
--- a/newsroom/agenda/agenda_search.py
+++ b/newsroom/agenda/agenda_search.py
@@ -34,6 +34,7 @@ from .filters import (
     apply_agenda_query_string,
     apply_agenda_filters,
     apply_agenda_date_filters,
+    apply_highlights,
 )
 from .agenda_service import AgendaItemService
 from .utils import remove_restricted_coverage_info
@@ -70,6 +71,7 @@ class AgendaSearchServiceAsync(BaseWebSearchService[AgendaSearchRequestArgs, Age
         apply_agenda_filters,
         apply_advanced_search,
         apply_agenda_date_filters,
+        apply_highlights,
     ]
     get_topic_items_query_user_filters = [
         apply_section_filter,

--- a/newsroom/push/views.py
+++ b/newsroom/push/views.py
@@ -47,7 +47,7 @@ async def handle_publish_planning(item):
     plan_id = await publisher.publish_planning_item(item, orig.to_dict() if orig else {})
     event_id = await publisher.publish_planning_into_event(item)
 
-    # Prefer parent Event when sending notificaitons
+    # Prefer parent Event when sending notifications
     _id = event_id or plan_id
     await notify_new_agenda_item.delay(_id, check_topics=True, is_new=orig is None)
 
@@ -77,7 +77,7 @@ async def handle_publish_planning_featured(item):
 
 
 def get_publish_handler(
-    item_type: Literal["event", "planning", "text", "planning_featured"]
+    item_type: Literal["event", "planning", "text", "planning_featured"],
 ) -> PublishHandlerFunc | None:
     handlers = {
         "event": handle_publish_event,


### PR DESCRIPTION
### Purpose
Includes the `apply_highlights` filter in `AgendaSearchServiceAsync` to show the highlighted keywords on the real-time email alerts

### What has changed
- Add `apply_highlights` to agenda search filters

### Screenshots
<img width="1301" height="665" alt="image" src="https://github.com/user-attachments/assets/63467d31-75d3-4612-879a-f7ab23db4838" />

Keywords are being highlighted in the emails now

<img width="1449" height="746" alt="image" src="https://github.com/user-attachments/assets/6818f09f-e858-4a0d-a21e-f8a5c84614f8" />

Resolves: [CPCN-1118]



[CPCN-1118]: https://sofab.atlassian.net/browse/CPCN-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ