### PR TITLE
Imediate email alerts from monitoring.

### DIFF
--- a/assets/monitoring/components/EditMonitoringProfile.tsx
+++ b/assets/monitoring/components/EditMonitoringProfile.tsx
@@ -145,6 +145,15 @@ class EditMonitoringProfile extends React.Component<any, any> {
                                         onChange={onChange}
                                         error={getError('company')} />
 
+                                    <TextInput
+                                        name='email'
+                                        label={gettext('Email Address')}
+                                        value={item.email || ''}
+                                        onChange={onChange}
+                                        error={getError('email')}
+                                        description={gettext('Optional comma seperated list of email addresses')}
+                                    />
+
                                     <TextAreaInput
                                         name='query'
                                         label={gettext('Query')}
@@ -181,7 +190,8 @@ class EditMonitoringProfile extends React.Component<any, any> {
                                         value={item.format_type || 'monitoring_pdf'}
                                         options={[
                                             {value: 'monitoring_pdf', text: 'PDF'},
-                                            {value: 'monitoring_rtf', text: 'RTF'}
+                                            {value: 'monitoring_rtf', text: 'RTF'},
+                                            {value: 'monitoring_email', text: 'Email'}
                                         ]}
                                         onChange={onChange}
                                         error={getError('format_type')} />

--- a/newsroom/email.py
+++ b/newsroom/email.py
@@ -101,7 +101,9 @@ def _send_email(to, subject, text_body, html_body=None, sender=None, sender_name
     for a in attachments_info:
         try:
             content = base64.b64decode(a["file"])
-            decoded_attachments.append(Attachment(a["file_name"], a["content_type"], data=content))
+            decoded_attachments.append(
+                Attachment(a["file_name"], a["content_type"], headers=a.get("headers"), data=content)
+            )
         except Exception as e:
             logger.error("Error attaching {} file to mail. Receipient(s): {}. Error: {}".format(a["file_desc"], to, e))
 
@@ -242,6 +244,7 @@ class EmailAttachment(TypedDict):
     file_name: str
     content_type: str
     file_desc: str
+    headers: Dict[str, str]
 
 
 class EmailKwargs(TypedDict, total=False):
@@ -263,7 +266,7 @@ async def send_user_email(
     """Send an email to Newsroom user, respecting user's email preferences."""
     user_dict: User = user.to_dict() if isinstance(user, ResourceModel) else user
 
-    if not user_dict.get("receive_email") and not ignore_preferences:
+    if (not user_dict.get("receive_email") and not ignore_preferences) or (not user_dict.get("is_enabled")):
         # If this is a user in the system, and has emails disabled
         # then skip this recipient
         return

--- a/newsroom/email_templates.py
+++ b/newsroom/email_templates.py
@@ -58,6 +58,7 @@ DEFAULT_SUBJECTS = {
     "{% endif %}",
     "monitoring_error": "Error sending alerts for monitoring: {{ profile.name | safe }}",
     "monitoring_email_no_updates": "{{ (profile.subject or profile.name) | safe }}",
+    "monitoring_export": "{{ (monitoring_profile.subject or monitoring_profile.name) | safe }}",
     "share_items": "From {{ app_name }}: {{ subject_name | safe }}",
     "share_topic": "From {{ app_name }}: {{ topic.label | safe }}",
     "share_wire": "From {{ app_name }}: {{ subject_name | safe }}",

--- a/newsroom/history_async.py
+++ b/newsroom/history_async.py
@@ -33,6 +33,7 @@ class HistoryService(NewshubAsyncResourceService[HistoryResourceModel]):
         user_id: ObjectId | None,
         company_id: ObjectId | None,
         section: str = "wire",
+        monitoring_id: ObjectId | None = None,
     ):
         now = utcnow()
 
@@ -45,6 +46,7 @@ class HistoryService(NewshubAsyncResourceService[HistoryResourceModel]):
                 "item": str(item["_id"]),
                 "version": str(item.get("version", item.get("_current_version"))),
                 "section": section,
+                "monitoring": monitoring_id,
             }
 
         transformed_docs = [transform(doc) for doc in docs]

--- a/newsroom/monitoring/__init__.py
+++ b/newsroom/monitoring/__init__.py
@@ -1,4 +1,5 @@
 from .service import MonitoringProfileService
+from os import path
 
 __all__ = ["MonitoringProfileService"]
 
@@ -27,7 +28,6 @@ def init_app(app):
     )
 
     app.add_template_global(get_keywords_in_text, "get_keywords_in_text")
-
-    # TODO-ASYNC: Removed in `develop` branch, investigate
-    # theme_folder = getattr(app, "theme_folder", None) or path.join(app.config["SERVER_PATH"], "theme")
-    # app.add_template_global(theme_folder, "monitoring_image_path")
+    # Add the theme path in order to be able to reference logo images in templates
+    theme_folder = getattr(app, "theme_folder", None) or path.join(app.config["SERVER_PATH"], "theme")
+    app.add_template_global(theme_folder, "monitoring_image_path")

--- a/newsroom/monitoring/email_alerts.py
+++ b/newsroom/monitoring/email_alerts.py
@@ -9,10 +9,12 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import base64
+import os
 from datetime import datetime, timedelta
 import logging
 from urllib.parse import urlparse
 from dataclasses import dataclass
+from typing import Dict, Any, List
 
 from superdesk.core import get_app_config, get_current_app, get_current_async_app
 from superdesk.core.resources.cursor import ResourceCursorAsync
@@ -20,17 +22,18 @@ from superdesk.utc import utcnow, utc_to_local, local_to_utc
 from superdesk.celery_task_utils import get_lock_id
 from superdesk.lock import lock, unlock
 
-from newsroom.types import MonitoringProfileResourceModel
+from newsroom.types import MonitoringProfileResourceModel, UserResourceModel
 from newsroom.formatters import get_formatter
 from newsroom.celery_app import celery
-from newsroom.email import send_user_email
+from newsroom.email import send_user_email, send_template_email, EmailAttachment, EmailKwargs
 from newsroom.settings import get_settings_collection, GENERAL_SETTINGS_LOOKUP
 from newsroom.utils import parse_date_str
 from newsroom.search.types import NewshubSearchRequest
+from newsroom.history_async import HistoryService
 
 from .service import MonitoringProfileService
 from .search import MonitoringSearchService, MonitoringSearchRequestArgs
-from .utils import get_monitoring_file, truncate_article_body
+from .utils import get_monitoring_file, truncate_article_body, get_date_items_dict
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +44,56 @@ class AlertMonitoringDataEntry:
     w_lists: list[MonitoringProfileResourceModel]
     created_from: str
     created_from_time: str
+
+
+async def send_email_alert(
+    items: list[Dict[str, Any]],
+    monitoring_profile: MonitoringProfileResourceModel,
+    users: List[UserResourceModel],
+    general_settings: Dict[str, Any],
+) -> None:
+    """
+    Send an email immediate alert with the details in the body of the email. If a logo image is set in the
+    monitoring_report_logo_path settings it will be attached to the email and can be referenced in the
+    monitoring_export.html template as <img src="CID:logo" />
+    :param items:
+    :param monitoring_profile:
+    :param users: List of users to receive the email alert
+    :param general_settings: Dictionary of setting passed to avoid having to read them again
+    :return:
+    """
+
+    # If there is only one story to send and the headline is to be used as the subject
+    if monitoring_profile.headline_subject and len(items) == 1:
+        monitoring_profile.subject = items[0].get("headline", monitoring_profile.subject or monitoring_profile.name)
+
+    data = {
+        "date_items_dict": get_date_items_dict(items),
+        "monitoring_profile": monitoring_profile,
+        "current_date": utc_to_local(get_app_config("DEFAULT_TIMEZONE"), utcnow()).strftime("%d/%m/%Y"),
+        "monitoring_report_name": get_app_config("MONITORING_REPORT_NAME", "Newsroom"),
+    }
+
+    # Attach logo to email if defined
+    kwargs: EmailKwargs = {}
+    if general_settings and general_settings["values"].get("monitoring_report_logo_path"):
+        image_filename = general_settings["values"].get("monitoring_report_logo_path")
+        if os.path.exists(image_filename):
+            with open(image_filename, "rb") as img:
+                bts = base64.b64encode(img.read())
+                logo: EmailAttachment = {
+                    "file": bts,
+                    "file_name": "logo{}".format(os.path.splitext(image_filename)[1]),
+                    "file_desc": "Logo",
+                    "content_type": "image/{}".format(os.path.splitext(image_filename)[1].replace(".", "")),
+                    "headers": {"Content-ID": "logo"},
+                }
+                kwargs["attachments_info"] = [logo]
+    if monitoring_profile.email:
+        to_list = [t.strip() for t in monitoring_profile.email.split(",")]
+        await send_template_email(to=to_list, template="monitoring_export", template_kwargs=data, cc=None, **kwargs)
+    for user in users:
+        await send_user_email(user, template="monitoring_export", template_kwargs=data, **kwargs)
 
 
 class MonitoringEmailAlerts:
@@ -249,6 +302,29 @@ class MonitoringEmailAlerts:
                 alert_monitoring["four"].w_lists.append(profile)
                 return
 
+    async def already_sent(self, item: Dict[str, Any], profile: MonitoringProfileResourceModel) -> bool:
+        #     """
+        #     Checks the history for this item/version being sent by the profile already
+        #     :param item:
+        #     :param profile:
+        #     :return: True if any matching found
+        #     """
+        version_to_query = item.get("version") or item.get("_current_version", "")
+        lookup = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"action": "email"}},
+                        {"term": {"item": item.get("_id")}},
+                        {"term": {"version": version_to_query}},
+                        {"term": {"monitoring": profile.id}},
+                        {"term": {"company": profile.company}},
+                    ]
+                }
+            }
+        }
+        return (await HistoryService().count(lookup=lookup)) > 0
+
     async def send_alerts(
         self,
         monitoring_list: list[MonitoringProfileResourceModel],
@@ -279,13 +355,21 @@ class MonitoringEmailAlerts:
                 # then we default it to ``monitoring_pdf``
                 monitoring_data.format_type = "monitoring_pdf"
 
-            if monitoring_data.users and len(monitoring_data.users):
-                users = await users_service.find_items_by_ids(monitoring_data.users)
+            if (monitoring_data.users and len(monitoring_data.users)) or monitoring_data.email:
+                users: List[UserResourceModel] = []
+                if monitoring_data.users and len(monitoring_data.users):
+                    users = await users_service.find_items_by_ids(monitoring_data.users)
                 company = (
                     await companies_service.find_by_id(monitoring_data.company) if monitoring_data.company else None
                 )
                 if company is None:
                     logger.exception(f"Company {monitoring_data.company} not found!")
+                    continue
+
+                if not company.is_enabled:
+                    logger.warning(
+                        f'Company "{monitoring_data.company}" for profile "{monitoring_data.name}" is disabled!'
+                    )
                     continue
 
                 search_request = NewshubSearchRequest(
@@ -299,7 +383,8 @@ class MonitoringEmailAlerts:
                 )
                 cursor = await MonitoringSearchService().search(search_request)
                 items = await cursor.to_list_raw()
-
+                # remove any items that have already been sent
+                items[:] = [item for item in items if not await self.already_sent(item, monitoring_data)]
                 template_kwargs = {"profile": monitoring_data.to_dict()}
 
                 if items:
@@ -311,26 +396,47 @@ class MonitoringEmailAlerts:
                             }
                         )
                         truncate_article_body(items, monitoring_data)
-                        monitoring_file = await get_monitoring_file(monitoring_data, items)
-                        attachment = base64.b64encode(monitoring_file.read())
-                        formatter = get_formatter(monitoring_data.format_type)
-
-                        for user in users:
-                            await send_user_email(
-                                user,
-                                template="monitoring_email",
-                                template_kwargs=template_kwargs,
-                                attachments_info=[
-                                    {
-                                        "file": attachment,
-                                        "file_name": formatter.format_filename(None),
-                                        "content_type": "application/{}".format(formatter.FILE_EXTENSION),
-                                        "file_desc": "Monitoring Report for Celery monitoring alerts for profile: {}".format(
-                                            monitoring_data.name
-                                        ),
-                                    }
-                                ],
-                            )
+                        if monitoring_data.format_type == "monitoring_email":
+                            await send_email_alert(items, monitoring_data, users, general_settings)
+                        else:
+                            kwargs: EmailKwargs = {}
+                            monitoring_file = await get_monitoring_file(monitoring_data, items)
+                            attachment = base64.b64encode(monitoring_file.read())
+                            formatter = get_formatter(monitoring_data.format_type)
+                            attachments_info: EmailAttachment = {
+                                "file": attachment,
+                                "file_name": formatter.format_filename(None),
+                                "content_type": "application/{}".format(formatter.FILE_EXTENSION),
+                                "file_desc": "Monitoring Report for Celery monitoring alerts for profile: {}".format(
+                                    monitoring_data.name
+                                ),
+                                "headers": {},
+                            }
+                            kwargs["attachments_info"] = [attachments_info]
+                            if monitoring_data.email:
+                                to_list = [t.strip() for t in monitoring_data.email.split(",")]
+                                await send_template_email(
+                                    to=to_list,
+                                    template="monitoring_email",
+                                    template_kwargs=template_kwargs,
+                                    cc=None,
+                                    **kwargs,
+                                )
+                            for user in users:
+                                await send_user_email(
+                                    user,
+                                    template="monitoring_email",
+                                    template_kwargs=template_kwargs,
+                                    **kwargs,
+                                )
+                        await HistoryService().create_history_record(
+                            items,
+                            action="email",
+                            user_id=None,
+                            company_id=monitoring_data.company,
+                            section="monitoring",
+                            monitoring_id=monitoring_data.id,
+                        )
                     except Exception:
                         logger.exception(
                             f"{self.log_msg} Error processing monitoring profile {monitoring_data.name} for company {company.name}."

--- a/newsroom/monitoring/forms.py
+++ b/newsroom/monitoring/forms.py
@@ -8,7 +8,11 @@ alert_types = [
     ("full_text", gettext("Full text")),
     ("linked_text", gettext("Linked extract(s)")),
 ]
-format_types = [("monitoring_pdf", gettext("PDF")), ("monitoring_rtf", gettext("RTF"))]
+format_types = [
+    ("monitoring_pdf", gettext("PDF")),
+    ("monitoring_rtf", gettext("RTF")),
+    ("monitoring_email", gettext("Email")),
+]
 
 
 class MonitoringForm(QuartForm):
@@ -22,6 +26,7 @@ class MonitoringForm(QuartForm):
     alert_type = SelectField(gettext("Alert Type"), choices=alert_types, default="full_text")
     format_type = SelectField(gettext("Format Type"), choices=format_types, default="monitoring_pdf")
     company = StringField(gettext("Company"), validators=[DataRequired()])
+    email = StringField("Email Address", validators=[])
     is_enabled = BooleanField(gettext("Enabled"), default=True, validators=[])
     always_send = BooleanField(gettext("Always Send"), default=False, validators=[])
     headline_subject = BooleanField(

--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -74,6 +74,11 @@ def process_form_request(updates, request_updates, form):
     if "keywords" in request_updates:
         updates["keywords"] = request_updates["keywords"]
 
+    if "email" in request_updates:
+        updates["email"] = request_updates.get("email").replace(" ", "")
+        if updates["email"] == "":
+            updates["email"] = None
+
 
 async def get_monitoring_for_company(user: UserResourceModel | None):
     company = user.company if user else None
@@ -90,10 +95,16 @@ class MonitoringIdUrlArg(BaseModel):
 )
 async def update_users(args: MonitoringIdUrlArg, params: None, request: Request) -> Response:
     updates = await request.get_json()
-    if "users" not in updates:
-        return Response({"error": gettext("Users data not provided")}, 403)
+    profile = await MonitoringProfileService().find_by_id(args.profile_id)
+    if not profile:
+        return Response({"error": gettext("Profile not found")}, status=404)
 
-    updates["users"] = [user_id for user_id in updates["users"]]
+    if "users" not in updates:
+        return Response({"error": gettext("Users data not provided")}, status=403)
+
+    updates["users"] = [
+        u.id for u in (await UsersService().find_by_ids(updates["users"])) if u.company == profile.company
+    ]
     await MonitoringProfileService().update(args.profile_id, updates)
     return Response({"success": True})
 
@@ -329,6 +340,7 @@ async def share(request: Request) -> Response:
                     "file_name": formatter.format_filename(None),
                     "content_type": "application/{}".format(formatter.FILE_EXTENSION),
                     "file_desc": "Monitoring Report",
+                    "headers": {},
                 }
             ],
         )

--- a/newsroom/templates/monitoring_export.txt
+++ b/newsroom/templates/monitoring_export.txt
@@ -1,0 +1,17 @@
+{{ monitoring_report_name }} Monitoring: {{ monitoring_profile.name }} {% if current_date %}({{ current_date }}){% endif %}
+    {% for d in date_items_dict.keys() %}
+        {{ d.strftime('%d/%m/%Y') }}
+        {% for item in date_items_dict[d]  %}
+            Headline: {{ item.get('headline', '') }}
+            Source: {{ item.get('source', '') }}
+            Keywords: {{ get_keywords_in_text(item.get('body_str', ''), monitoring_profile.keywords)|join(',') }}
+            {% if item.byline %}
+                By {{ item.get('byline', '') }}
+            {% endif %}
+                {{ item.get('body_str', '') | safe }}
+            {% if monitoring_profile.alert_type == 'linked_text' and not print%}
+                {{ url_for('monitoring.index', item=item._id, _external=True) }}
+            {% endif %}
+
+        {% endfor %}
+    {% endfor %}

--- a/newsroom/types/history.py
+++ b/newsroom/types/history.py
@@ -15,4 +15,5 @@ class HistoryResourceModel(NewshubResourceModel):
     item: Keyword
     version: str
     section: Keyword
+    monitoring: Annotated[ObjectIdField | None, keyword_mapping(), validate_data_relation_async("monitoring")] = None
     extra_data: dict[str, Any] | None = None

--- a/newsroom/types/monitoring.py
+++ b/newsroom/types/monitoring.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from enum import Enum, unique
+from typing import Annotated, Optional
 
 from superdesk.core.resources import Dataclass
 from superdesk.core.resources.fields import ObjectId
 from newsroom.core.resources import NewshubResourceModel
+from superdesk.core.resources.validators import validate_email
 
 
 @unique
@@ -27,6 +29,7 @@ class MonitoringProfileResourceModel(NewshubResourceModel):
     subject: str | None = None
     description: str | None = None
     company: ObjectId | None = None
+    email: Annotated[Optional[str], validate_email(multi=True)] = None
     query: str | None = None
     alert_type: str | None = None
     is_enabled: bool = True

--- a/tests/core/test_emails.py
+++ b/tests/core/test_emails.py
@@ -23,7 +23,7 @@ from tests.core.utils import create_entries_for
 
 
 async def test_item_notification_template(client, app, mocker):
-    user = {"email": "foo@example.com", "receive_email": True}
+    user = {"email": "foo@example.com", "receive_email": True, "is_enabled": True}
     item = {
         "_id": "tag:localhost:2018:bcc9fd45",
         "guid": "tag:localhost:2018:bcc9fd45",
@@ -227,6 +227,7 @@ async def test_send_user_email(app):
         notification_schedule={"timezone": "Europe/Helsinki"},
         user_type="user",
         receive_email=True,
+        is_enabled=True,
     )
     date = datetime(2024, 4, 9, 11, 0, 0)
     template_kwargs = dict(date=date, topic_match_table={"wire": [], "agenda": []}, entries={})
@@ -291,6 +292,7 @@ async def test_send_user_email_on_locale_changed():
         notification_schedule={"timezone": "Asia/Calcutta"},
         user_type="user",
         receive_email=True,
+        is_enabled=True,
     )
 
     event_item["coverages"][0]["coverage_status"] = "coverage intended"

--- a/tests/core/test_monitoring.py
+++ b/tests/core/test_monitoring.py
@@ -23,7 +23,7 @@ def mock_utcnow():
 
 
 def get_fixture_path(fixture):
-    return os.path.join(os.path.dirname(__file__), "fixtures", fixture)
+    return os.path.join(os.path.dirname(__file__), "../fixtures", fixture)
 
 
 @fixture(autouse=True)
@@ -52,6 +52,7 @@ async def init(app):
                 "last_name": "Doe",
                 "is_enabled": True,
                 "receive_email": True,
+                "company": ObjectId(company_id),
             },
             {
                 "_id": ObjectId("5c4684645f627debec1dc3db"),
@@ -266,10 +267,10 @@ async def test_send_immediate_alerts(client, app):
 
 
 def assert_recipients(outbox, recipients: List[str]):
-    assert len(outbox) == len(recipients)
     outbox_recipients = []
     for o in outbox:
         outbox_recipients.extend(o.recipients)
+    assert len(outbox_recipients) == len(recipients)
     for recipient in recipients:
         assert recipient in outbox_recipients
 
@@ -1148,3 +1149,255 @@ async def test_send_immediate_headline_subject_alerts(client, app):
         assert outbox[0].sender == "newsroom@localhost"
         assert outbox[0].subject == "Article headline about product"
         assert "Newsroom Monitoring: W1" in outbox[0].body
+
+
+@mock.patch("newsroom.monitoring.email_alerts.utcnow", mock_utcnow)
+@mock.patch("newsroom.email.send_email", mock_send_email)
+async def test_send_immediate_email_alerts(client, app):
+    await post_json(
+        client,
+        "/settings/general_settings",
+        {"monitoring_report_logo_path": get_fixture_path("thumbnail.jpg")},
+    )
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "foo",
+                "version": "1",
+                "headline": "product immediate",
+                "products": [{"code": "12345"}],
+                "versioncreated": utcnow(),
+                "byline": "Testy McTestface",
+                "body_html": "<p>line 1 of the article text\nline 2 of the story\nand a bit more.</p>"
+                '<!-- EMBED START Audio {id: "editor_2"} -->'
+                "<figure>"
+                '    <audio controls src="/assets.mp3"></audio>'
+                "    <figcaption>Assistant Treasurer</figcaption>"
+                "</figure>"
+                '<!-- EMBED END Audio {id: "editor_2"} -->'
+                "<p>Something after the embed",
+                "source": "AAAA",
+            }
+        ],
+    )
+    await login_public(client)
+    w = await find_one_by_id("monitoring", "5db11ec55f627d8aa0b545fb")
+    assert w is not None
+    await update_entries_for(
+        "monitoring",
+        ObjectId("5db11ec55f627d8aa0b545fb"),
+        {"format_type": "monitoring_email", "alert_type": "full_text", "keywords": ["text"]},
+        w,
+    )
+    with app.mail.record_messages() as outbox:
+        await MonitoringEmailAlerts().run(immediate=True)
+        assert_recipients(
+            outbox,
+            [
+                "foo_user2@bar.com",
+                "foo_user@bar.com",
+            ],
+        )
+        assert outbox[0].sender == "newsroom@localhost"
+        assert outbox[0].subject == "Monitoring Subject"
+        assert "Something after the embed" in outbox[0].body
+        ## TODO When code to remove the embeds from email is ported
+        # assert 'Assistant Treasurer' not in outbox[0].body
+        assert "Newsroom Monitoring: W1" in outbox[0].body
+
+
+@mock.patch("newsroom.monitoring.email_alerts.utcnow", mock_utcnow)
+@mock.patch("newsroom.email.send_email", mock_send_email)
+async def test_dont_send_immediate_email_alerts_twice(client, app):
+    await post_json(
+        client,
+        "/settings/general_settings",
+        {"monitoring_report_logo_path": get_fixture_path("thumbnail.jpg")},
+    )
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "foo",
+                "headline": "product immediate",
+                "products": [{"code": "12345"}],
+                "versioncreated": utcnow(),
+                "byline": "Testy McTestface",
+                "body_html": "<p>line 1 of the article text\nline 2 of the story\nand a bit more.</p>",
+                "source": "AAAA",
+                "version": "1",
+            }
+        ],
+    )
+    await create_entries_for(
+        "history",
+        [
+            {
+                "action": "email",
+                "company": ObjectId("5c3eb6975f627db90c84093c"),
+                "section": "monitoring",
+                "monitoring": ObjectId("5db11ec55f627d8aa0b545fb"),
+                "versioncreated": utcnow(),
+                "version": "1",
+                "item": "foo",
+            }
+        ],
+    )
+    await login_public(client)
+    with app.mail.record_messages() as outbox:
+        await MonitoringEmailAlerts().run(immediate=True)
+        assert len(outbox) == 0
+
+
+@mock.patch("newsroom.monitoring.email_alerts.utcnow", mock_utcnow)
+@mock.patch("newsroom.email.send_email", mock_send_email)
+async def test_dont_send_email_to_disabled_users(client, app):
+    await create_entries_for(
+        "users",
+        [
+            {
+                "_id": ObjectId("5d4ccb7265af3eaa4a8395bc"),
+                "email": "boo_user@bar.com",
+                "first_name": "Boo_First_name",
+                "last_name": "Boo_Last_name",
+                "is_enabled": False,
+                "receive_email": True,
+                "company": ObjectId(company_id),
+            },
+            {
+                "_id": ObjectId("617f257c04bfdad4366b6997"),
+                "email": "ringin@bar.com",
+                "first_name": "Ring_In_First_name",
+                "last_name": "Ring_In_Last_name",
+                "is_enabled": True,
+                "receive_email": True,
+                "company": ObjectId(company_id),
+            },
+        ],
+    )
+    w = await find_one_by_id("monitoring", "5db11ec55f627d8aa0b545fb")
+    assert w is not None
+    users = [ObjectId("5d4ccb7265af3eaa4a8395bc"), ObjectId("617f257c04bfdad4366b6997")]
+    await update_entries_for("monitoring", ObjectId("5db11ec55f627d8aa0b545fb"), {"users": users}, w)
+
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "foo",
+                "headline": "product immediate",
+                "products": [{"code": "12345"}],
+                "versioncreated": utcnow(),
+                "byline": "Testy McTestface",
+                "body_html": "<p>line 1 of the article text\nline 2 of the story\nand a bit more.</p>",
+                "source": "AAAA",
+            }
+        ],
+    )
+    with app.mail.record_messages() as outbox:
+        await MonitoringEmailAlerts().run(immediate=True)
+        assert len(outbox) == 1
+        assert len(outbox[0].recipients) == 1
+        assert_recipients(
+            outbox,
+            ["ringin@bar.com"],
+        )
+
+
+@mock.patch("newsroom.monitoring.email_alerts.utcnow", mock_utcnow)
+@mock.patch("newsroom.email.send_email", mock_send_email)
+async def test_dont_send_email_to_disabled_companies(client, app):
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "foo",
+                "headline": "product immediate",
+                "products": [{"code": "12345"}],
+                "versioncreated": utcnow(),
+                "byline": "Testy McTestface",
+                "body_html": "<p>line 1 of the article text\nline 2 of the story\nand a bit more.</p>",
+                "source": "AAAA",
+            }
+        ],
+    )
+    c = await find_one_by_id("companies", company_id)
+    assert c is not None
+    await update_entries_for("companies", ObjectId(company_id), {"is_enabled": False}, c)
+    with app.mail.record_messages() as outbox:
+        await MonitoringEmailAlerts().run(immediate=True)
+        assert len(outbox) == 0
+
+
+async def test_save_only_users_belonging_to_company(client, app):
+    w = await find_one_by_id("users", "5c53afa45f627d8333220f15")
+    await update_entries_for(
+        "users", ObjectId("5c53afa45f627d8333220f15"), {"company": ObjectId("5c3eb6975f627db90c84093c")}, w
+    )
+    await post_json(
+        client,
+        "/monitoring/5db11ec55f627d8aa0b545fb/users",
+        {"users": ["5c53afa45f627d8333220f15", "111111111111111111111111"]},
+    )
+    m = await find_one_by_id("monitoring", "5db11ec55f627d8aa0b545fb")
+    assert m["users"] == [ObjectId("5c53afa45f627d8333220f15")]
+
+
+@mock.patch("newsroom.monitoring.email_alerts.utcnow", mock_utcnow)
+@mock.patch("newsroom.email.send_email", mock_send_email)
+async def test_send_profile_email(client, app):
+    await post_json(
+        client, "/settings/general_settings", {"monitoring_report_logo_path": get_fixture_path("thumbnail.jpg")}
+    )
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "foo",
+                "headline": "product immediate",
+                "products": [{"code": "12345"}],
+                "versioncreated": utcnow(),
+                "byline": "Testy McTestface",
+                "body_html": "<p>line 1 of the article text\nline 2 of the story\nand a bit more.</p>",
+                "source": "AAAA",
+            }
+        ],
+    )
+    m = await find_one_by_id("monitoring", "5db11ec55f627d8aa0b545fb")
+    assert m is not None
+    await update_entries_for(
+        "monitoring",
+        ObjectId("5db11ec55f627d8aa0b545fb"),
+        {
+            "email": "atest@a.com,btest@b.com",
+            "format_type": "monitoring_email",
+            "is_enabled": "true",
+        },
+        m,
+    )
+    with app.mail.record_messages() as outbox:
+        await MonitoringEmailAlerts().run(immediate=True)
+        assert len(outbox) == 3
+        assert_recipients(
+            outbox,
+            ["atest@a.com", "btest@b.com", "foo_user2@bar.com", "foo_user@bar.com"],
+        )
+
+
+async def test_save_monitoring_email(client, app):
+    response = await client.post(
+        "/monitoring/5db11ec55f627d8aa0b545fb",
+        json={"email": "axb.com, a@b.com", "company": ObjectId(company_id), "name": "test"},
+    )
+    data = json.loads(await response.get_data())
+    assert data["email"] == "Invalid email address"
+    response = await client.post(
+        "/monitoring/5db11ec55f627d8aa0b545fb",
+        json={"email": "a@b.com , d@e.com", "company": ObjectId(company_id), "name": "test"},
+    )
+    data = json.loads(await response.get_data())
+    assert data["success"] is True
+    response = await client.get("/monitoring/5db11ec55f627d8aa0b545fb")
+    data = json.loads(await response.get_data())
+    assert data["email"] == "a@b.com,d@e.com"


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->
Adds immediate monitoring alerts that contain the entire article and the ability to nominate a list of email addresses that are not necessarily  Newshub users.

- [SDAN-710 Add option for a monitoring format to deliver alerts with the full text of matching articles in the email.](https://sofab.atlassian.net/browse/SDAN-710?atlOrigin=eyJpIjoiODE1NzlhYWJlODBlNGZlMGJlOGVmMDQxY2M1NTljMTkiLCJwIjoiaiJ9)
- [SDAN-711 Immediate monitoring profile sends duplicate email notifications a minute apart.](https://sofab.atlassian.net/browse/SDAN-711?atlOrigin=eyJpIjoiNmM1OWVhYjAwODIyNDA0ZjkzMmFjZjYyN2ZkNWJlZmUiLCJwIjoiaiJ9)
- [SDAN-712 Monitoring emails are sent to users that are disabled.](https://sofab.atlassian.net/browse/SDAN-712?atlOrigin=eyJpIjoiMDNmYmE0Y2YyODA2NDVhMGFmNWIxYThiYjdiZGUwY2MiLCJwIjoiaiJ9)
- [SDAN-713 Add the ability to add an email address to a Monitoring profile](https://sofab.atlassian.net/browse/SDAN-713?atlOrigin=eyJpIjoiMDExZGI0ZTJlOTQxNGRjZDgwNTNiNmVjNTYwNDg2MTMiLCJwIjoiaiJ9)

### What has changed
<!--- Explain what has changed and how -->
New field added to the Monitoring collection to hold a comma seperated list of email addresses.
New format for monitoring email that includes the entire article in the email.

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->
Create an immediate monitoring profile and set the format to email and alert type to full text. Set an email address in the Email Address text box.
Publish a story to the Newshub instance.
An email should be sent to the address with the full text of the article!

<!-- [For UI changes]
### Screenshots
-->
![image](https://github.com/user-attachments/assets/0b01a153-e129-43be-8010-b4954398f61f)


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]