### PR TITLE
[NHUB-627] Add system health check endpoint module

### DIFF
--- a/newsroom/system/__init__.py
+++ b/newsroom/system/__init__.py
@@ -1,0 +1,5 @@
+from superdesk.core.module import Module
+
+from .health import health_endpoints
+
+module = Module(name="newsroom.system", endpoints=[health_endpoints])

--- a/newsroom/system/health.py
+++ b/newsroom/system/health.py
@@ -1,0 +1,23 @@
+import logging
+
+from superdesk.core import get_app_config
+from superdesk.core.types import Response
+from superdesk.core.web import EndpointGroup
+from superdesk.system.health import get_health_status
+
+
+logger = logging.getLogger(__name__)
+health_endpoints = EndpointGroup("health", __name__, auth=False)
+
+
+@health_endpoints.endpoint("/system/health", methods=["GET"])
+async def health():
+    """
+    Health check endpoint for the system.
+
+    Returns a JSON response containing the application name, the status of various health checks,
+    and an overall system status. Each health check is run and its result is included in the output.
+    """
+    app_name = get_app_config("SITE_NAME", "Newshub")
+
+    return Response(get_health_status(app_name))

--- a/newsroom/system/health.py
+++ b/newsroom/system/health.py
@@ -7,7 +7,7 @@ from superdesk.system.health import get_health_status
 
 
 logger = logging.getLogger(__name__)
-health_endpoints = EndpointGroup("health", __name__, auth=False)
+health_endpoints = EndpointGroup("system_health", __name__, auth=False)
 
 
 @health_endpoints.endpoint("/system/health", methods=["GET"])
@@ -16,7 +16,7 @@ async def health():
     Health check endpoint for the system.
 
     Returns a JSON response containing the application name, the status of various health checks,
-    and an overall system status. Each health check is run and its result is included in the output.
+    and an overall system status.
     """
     app_name = get_app_config("SITE_NAME", "Newshub")
 

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -177,6 +177,7 @@ MODULES = [
     "newsroom.monitoring.module",
     "newsroom.news_api.api_audit",
     "newsroom.mgmt_api.mgmt_api_docs",
+    "newsroom.system",
 ]
 
 ASYNC_POPULATE_HATEOAS = False


### PR DESCRIPTION
### Purpose
Introduces the `newsroom.system` module with a health check endpoint at `/system/health`. Updates default settings to include the new module for system health monitoring.

This PR depends on https://github.com/superdesk/superdesk-core/pull/3011

Resolves: [NHUB-627]


[NHUB-627]: https://sofab.atlassian.net/browse/NHUB-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ