### PR TITLE
Implement permissioning flag for AV media

### DIFF
--- a/newsroom/wire/service.py
+++ b/newsroom/wire/service.py
@@ -1,6 +1,9 @@
-from typing import Any, cast, List
+from typing import Any, cast, List, Set, Optional
 from datetime import datetime, timedelta
 import logging
+import re
+from lxml.html import HtmlElement
+from lxml import html as lxml_html
 
 from bson import ObjectId
 
@@ -9,12 +12,13 @@ from superdesk.core.types import Request, Response, SearchRequest, ESQuery
 from superdesk.core import get_app_config
 from superdesk.core.resources import AsyncResourceService
 from superdesk.core.resources.cursor import ElasticsearchResourceCursorAsync
+from superdesk.etree import to_string
 
 from newsroom.types import SectionEnum, ProductResourceModel, UserResourceModel, CompanyResource, WireItem, Navigation
-from newsroom.auth.utils import get_user_or_none_from_request
+from newsroom.auth.utils import get_user_or_none_from_request, get_company_from_request
 from newsroom.search.types import NewshubSearchRequest, SearchFilterFunction
 from newsroom.search.base_web_service import BaseWebSearchService
-from newsroom.products import get_products_by_navigation_async
+from newsroom.products import get_products_by_navigation_async, get_products_by_company_async
 from newsroom.search.utils import query_string
 from newsroom.search.filters import (
     apply_query_string,
@@ -167,6 +171,9 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
         matched_ids: list[str] = request.storage.request.get("matched_ids", [])
         if matched_ids:
             response.setdefault("_links", {})["matched_ids"] = matched_ids
+
+        if get_app_config("EMBED_PRODUCT_FILTERING", False):
+            await self.permission_media_embeds_in_response(response)
 
         return Response(response, 200, [("X-Total-Count", count)])
 
@@ -493,3 +500,71 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
                 exc,
                 exc_info=True,
             )
+
+    async def permission_media_embeds_in_response(self, response: dict[str, Any]):
+        """
+        Mark any embedded audio/visual media with an attribute in the response to block download if required
+        Only called if EMBED_PRODUCT_FILTERING is enabled
+        @param response:
+        @return:
+        """
+        items: List[Any] = response.get("_items", [])
+        if len(items) == 0:
+            return
+        company: Optional[CompanyResource] = get_company_from_request(None)
+        permitted_products: Set[str | None] = {
+            p.sd_product_id
+            for p in await get_products_by_company_async(company=company, product_type=SectionEnum.WIRE)
+            if p.sd_product_id and p.is_enabled
+        }
+
+        for doc in items:
+            self.permission_media(doc, permitted_products)
+
+    def permission_media(self, item: dict[str, Any], permitted_products: Set[str | None]):
+        """
+        Flags any Video or Audio embeds if they are not allowed to be downloaded
+        @param item:
+        @param permitted_products:
+        @return:
+        """
+        disable_download: List[str] = []
+        for key, embed_item in item.get("associations", {}).items():
+            if key and embed_item and key.startswith("editor_") and embed_item.get("type", "") in ["audio", "video"]:
+                # get the list of products that the embedded item matched in Superdesk
+                embed_products: Set[str | None] = {
+                    p.get("code") for p in ((item.get("associations") or {}).get(key) or {}).get("products", [])
+                }
+                if not (embed_products & permitted_products):
+                    disable_download.append(key)
+        if not disable_download:
+            return
+
+        highlighted: bool = False
+        root_elem: HtmlElement = None
+        if item.get("es_highlight", {}).get("body_html", ""):
+            root_elem = lxml_html.fromstring(item.get("es_highlight", {}).get("body_html", "")[0])
+            highlighted = True
+        else:
+            root_elem = lxml_html.fromstring(item.get("body_html", ""))
+        regex = re.compile(r" EMBED START (?:Video|Audio) {id: \"editor_([0-9]+)")
+        html_updated: bool = False
+        comments = root_elem.xpath("//comment()")
+        for comment in comments:
+            m = regex.search(comment.text)
+            # if we've found an Embed Start comment
+            if m and m.group(1):
+                figure = comment.getnext()
+                for elem in figure.iterchildren():
+                    if elem.tag in ["video", "audio"]:
+                        if "editor_" + m.group(1) in disable_download:
+                            elem.attrib["data-disable-download"] = "true"
+                    if elem.text and " EMBED END " in elem.text:
+                        break
+                html_updated = True
+
+        if html_updated:
+            if highlighted:
+                item["es_highlight"]["body_html"][0] = to_string(root_elem, method="html")
+            else:
+                item["body_html"] = to_string(root_elem, method="html")

--- a/tests/core/test_wire.py
+++ b/tests/core/test_wire.py
@@ -88,6 +88,65 @@ async def setup_products(app):
     )
 
 
+async def setup_embeds(client, app):
+    media_id = str(ObjectId())
+    item = items[:2][0]
+    associations = {
+        "editor_1": {
+            "type": "video",
+            "renditions": {
+                "original": {
+                    "mimetype": "video/mp4",
+                    "href": "/assets/640ff0bdfb5122dcf06a6fc3",
+                    "media": media_id,
+                }
+            },
+            "mimetype": "video/mp4",
+            "products": [{"code": "123", "name": "Product A"}, {"code": "321", "name": "Product B"}],
+        },
+        "editor_0": {
+            "type": "audio",
+            "renditions": {
+                "original": {
+                    "mimetype": "audio/mp3",
+                    "href": "/assets/640feb9bfb5122dcf06a6f7c",
+                    "media": "640feb9bfb5122dcf06a6f7c",
+                }
+            },
+            "mimetype": "audio/mp3",
+            "products": [{"code": "999", "name": "NSW News"}],
+        },
+        "editor_3": None,
+    }
+
+    await update_entries_for(
+        "items",
+        item["_id"],
+        {
+            "associations": associations,
+            "body_html": '<p>Par 1</p><!-- EMBED START Audio {id: "editor_0"} --><figure>'
+            '<audio controls src="/assets/640feb9bfb5122dcf06a6f7c" alt="minns" '
+            'width="100%" height="100%"></audio>'
+            "<figcaption>minns</figcaption>"
+            "</figure>"
+            '<!-- EMBED END Audio {id: "editor_0"} -->'
+            "<p><br></p>"
+            "<p>Par 2</p>"
+            '<!-- EMBED START Video {id: "editor_1"} -->'
+            "<figure>"
+            '<video controls src="/assets/640ff0bdfb5122dcf06a6fc3" '
+            'alt="Scomo text" width="100%" height="100%">'
+            "</video>"
+            "<figcaption>Scomo whinging</figcaption>"
+            "</figure>"
+            '<!-- EMBED END Video {id: "editor_1"} -->'
+            "<p><br></p>Par 3<p></p>"
+            "<p>Par 4</p>",
+        },
+        item,
+    )
+
+
 async def test_item_detail(client):
     resp = await client.get("/wire/tag:foo")
     assert resp.status_code == 200
@@ -1057,3 +1116,20 @@ async def test_sorting_wire_items(app, client):
     assert json_data[0]["_id"] == "item3"
     assert json_data[1]["_id"] == "item2"
     assert json_data[2]["_id"] == "item1"
+
+
+async def test_embed_mark_disable_download(client, app):
+    app.config["EMBED_PRODUCT_FILTERING"] = True
+    user_id = get_admin_user_id(app)
+    user = await find_one_by_id("users", user_id)
+    await update_entries_for("users", user_id, {"company": COMPANY_1_ID}, user)
+    await add_company_products(
+        app,
+        COMPANY_1_ID,
+        [{"name": "product test", "sd_product_id": "123", "is_enabled": True, "product_type": "wire"}],
+    )
+    await setup_embeds(client, app)
+    resp = await client.get("/wire/search?type=wire")
+    data = json.loads(await resp.get_data())
+    assert "data-disable-download" in data["_items"][0]["body_html"]
+    assert data["_items"][0]["body_html"].count("data-disable-download") == 1


### PR DESCRIPTION
### Purpose
Sets an attribute on the Video and Audio embeds that should have the download button removed/disabled on displaying the article containing them.

### What has changed
If the EMBED_PRODUCT_FILTERING setting is enabled (true), the system will perform the following check for any embedded video or audio media:

1. The media item's associated Superdesk products are compared against the products allowed for the company.
2. If no matching products are found, the HTML element for the video or audio will be given the attribute **data-disable-download="true"**.

It is then expected that the media player rendering the item will recognize this attribute and disable the download functionality.

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

**Prerequisites:**

A version of Newshub where the EMBED_PRODUCT_FILTERING setting is set to true.

A connected Superdesk instance.

A Newsroom Ninjs formatter that is configured to pass Superdesk product information to embedded media.

Step 1: Superdesk Content and Product Setup

- In Superdesk, create a new product and configure it to filter for Article Type = Video.
- Make a note of the Product ID of this new product.
- Upload a video to Superdesk.
- Embed the video into a new story and publish it to Newshub.
- Crucially, ensure this product is NOT yet assigned to your test company.
- Check the video's association in Superdesk and confirm that the product you created has been included.

Step 2: Initial Verification (Download Disabled)

- View the published story in Newshub (using a test account that does not have the product).
- Open your browser's developer tools (F12) and inspect the HTML element for the video.
- Verify that the data-disable-download="true" attribute is present.
<img width="1035" height="157" alt="image" src="https://github.com/user-attachments/assets/1d10ca7e-52b4-4aac-aadd-94ae5d30f9a4" />
Step 3: Newshub Product and Company Assignment

- In the Newshub administration interface, create a new product using the Product ID you noted in Step 1.
- Assign this newly created Newshub product to your test company.

Step 4: Final Verification (Download Enabled)

- Re-display the same article in Newshub (the page may need to be refreshed).
- Using the developer tools, inspect the video's HTML element again.
- Verify that the data-disable-download attribute is no longer present.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
