### PR TITLE
[NHUB-627] Add support to render Flourish embeds in article body

### DIFF
--- a/assets/ui/components/ArticleBodyHtml.tsx
+++ b/assets/ui/components/ArticleBodyHtml.tsx
@@ -48,14 +48,78 @@ class ArticleBodyHtmlComponent extends React.PureComponent<IProps, IState> {
 
     componentDidMount() {
         if (this.renderPreview()) {
+            this.loadIframely();
+            this.executeScripts();
             document.addEventListener('copy', this.copyClicked);
             document.addEventListener('click', this.clickClicked);
         }
     }
 
+    componentDidUpdate() {
+        this.loadIframely();
+        this.executeScripts();
+    }
+
     componentWillUnmount() {
         document.removeEventListener('copy', this.copyClicked);
         document.removeEventListener('click', this.clickClicked);
+    }
+
+    loadIframely() {
+        const html = this.props.item.body_html;
+
+        if (window.iframely && html && html.includes('iframely')) {
+            window.iframely.load();
+        }
+    }
+
+    executeScripts() {
+        const tree = this.bodyRef.current;
+        const loaded: Array<string> = [];
+
+        if (tree == null) {
+            return;
+        }
+
+        tree.querySelectorAll('script').forEach((s) => {
+            let url = s.getAttribute('src');
+
+            if (!url || loaded.includes(url)) {
+                return;
+            }
+
+            loaded.push(url);
+
+            if (url.includes('twitter.com/') && window.twttr != null) {
+                window.twttr.widgets.load();
+                return;
+            }
+
+            if (url.includes('instagram.com/') && window.instgrm != null) {
+                window.instgrm.Embeds.process();
+                return;
+            }
+
+            if (url.startsWith('http')) {
+                // change https?:// to // so it uses schema of the client
+                url = url.substring(url.indexOf(':') + 1);
+            }
+
+            const script = document.createElement('script');
+
+            script.src = url;
+            script.async = true;
+
+            script.onload = () => {
+                document.body.removeChild(script);
+            };
+
+            script.onerror = () => {
+                throw new URIError(`The script ${url} didn't load.`);
+            };
+
+            document.body.appendChild(script);
+        });
     }
 
     static getDerivedStateFromError(error: any): IState {

--- a/assets/ui/components/ArticleBodyHtml.tsx
+++ b/assets/ui/components/ArticleBodyHtml.tsx
@@ -89,7 +89,7 @@ class ArticleBodyHtmlComponent extends React.PureComponent<IProps, IState> {
         const bodyHtml = (item.es_highlight?.body_html ?? '').length > 0 ?
             item.es_highlight?.body_html[0] :
             item.body_html;
-        
+
         if (this.bodyRef.current == null) {
             return false;
         }
@@ -152,10 +152,6 @@ function _updateImageEmbedSources(html: string, item: IArticle): HTMLElement {
         return container.body;
     }
 
-    // Create a DOM node tree from the supplied html
-    // We can then efficiently find and update the image sources
-    let imageSourcesUpdated = false;
-
     container
         .querySelectorAll('img, video, audio')
         .forEach((mediaTag: any) => {
@@ -172,7 +168,6 @@ function _updateImageEmbedSources(html: string, item: IArticle): HTMLElement {
             if (originalMediaId) {
                 // We now have the Original Rendition's ID
                 // Use that to update the `src` attribute to use Newshub's Web API
-                imageSourcesUpdated = true;
                 mediaTag.src = `/assets/${originalMediaId}`;
             }
         });
@@ -182,9 +177,60 @@ function _updateImageEmbedSources(html: string, item: IArticle): HTMLElement {
 
 function _getBodyElement(bodyHtml: string, item: IArticle): HTMLElement {
     const output = _updateImageEmbedSources(formatHTML(bodyHtml), item);
+
+    // let's take care of embeds case by case
+    replaceFlourishEmbeds(output);
+
     const prepareWirePreview = extensions.prepareWirePreview ?? ((element) => element);
     return prepareWirePreview(
         output,
         item,
     );
+}
+
+const resizeScript = `
+    <script>
+        (function () {
+            function getHeight() {
+                const doc = document.documentElement;
+                return Math.max(doc?.scrollHeight || 0, document.body?.scrollHeight || 0);
+            }
+
+            function resize() {
+                if (window.frameElement) {
+                    window.frameElement.style.height = Math.max(100, getHeight()) + 'px';
+                }
+            }
+
+            window.addEventListener('load', resize);
+            if ('ResizeObserver' in window)
+                new ResizeObserver(resize).observe(document.body);
+        })();
+    </script>
+`;
+
+
+function replaceFlourishEmbeds(root: HTMLElement) {
+    root.querySelectorAll<HTMLElement>('.flourish-embed[data-src]').forEach((el) => {
+        const dataSrc = el.getAttribute('data-src');
+
+        if (!dataSrc || !/^(visualisation|story)\/\d+$/.test(dataSrc)) return;
+
+        const iframe = document.createElement('iframe');
+        iframe.style.width = '100%';
+        iframe.style.border = '0';
+
+        const embedHtml = el.outerHTML;
+        iframe.srcdoc = `
+            <!doctype html>
+            <html>
+            <body>
+                ${embedHtml}
+                ${resizeScript}
+            </body>
+            </html>
+        `;
+
+        el.replaceWith(iframe);
+    });
 }

--- a/assets/ui/components/ArticleBodyHtml.tsx
+++ b/assets/ui/components/ArticleBodyHtml.tsx
@@ -90,14 +90,24 @@ class ArticleBodyHtmlComponent extends React.PureComponent<IProps, IState> {
 
             loaded.push(url);
 
-            if (url.includes('twitter.com/') && window.twttr != null) {
-                window.twttr.widgets.load();
-                return;
-            }
-
-            if (url.includes('instagram.com/') && window.instgrm != null) {
-                window.instgrm.Embeds.process();
-                return;
+            try {
+                const parsedUrl = new URL(url, window.location.origin);
+                if (
+                    (parsedUrl.host === 'twitter.com' || parsedUrl.host === 'www.twitter.com') &&
+                    window.twttr != null
+                ) {
+                    window.twttr.widgets.load();
+                    return;
+                }
+                if (
+                    (parsedUrl.host === 'instagram.com' || parsedUrl.host === 'www.instagram.com') &&
+                    window.instgrm != null
+                ) {
+                    window.instgrm.Embeds.process();
+                    return;
+                }
+            } catch (e) {
+                throw new URIError(`Invalid script url: ${url}. ${e}`);
             }
 
             if (url.startsWith('http')) {


### PR DESCRIPTION
### Purpose
Introduces a `replaceFlourishEmbeds` function to detect and replace `.flourish-embed` elements with iframes using srcdoc, including a script to auto-resize the iframe based on content height. This improves rendering and integration of Flourish visualizations within article bodies. 

The implementation is structured to be extensible, allowing similar handling for other embed types (as required) that would be added in the future with minimal changes.

### Steps to test
- Create a text item in superdesk that would contain a flourish embed 
- Publish it and push it to newsroom
- Observe that the graphic renders properly

### Screenshots

<img width="900" alt="image" src="https://github.com/user-attachments/assets/bc848c80-d4ae-4c6a-be9b-d68dd1d768f7" />

<img width="900" alt="image" src="https://github.com/user-attachments/assets/82598195-4949-4b4d-bd5f-046cd53b3b60" />

<img width="833" height="829" alt="image" src="https://github.com/user-attachments/assets/353a8a4c-3452-4d23-ba8e-a461223fface" />


Resolves: [NHUB-627]




[NHUB-627]: https://sofab.atlassian.net/browse/NHUB-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ