### PR TITLE
[CPCN-1133][CPCN-1134] fix state and translation publish issues

### DIFF
--- a/newsroom/agenda/agenda_service.py
+++ b/newsroom/agenda/agenda_service.py
@@ -94,6 +94,10 @@ class AgendaItemService(AsyncResourceService[AgendaItem]):
         if event.get("pubstatus") == "cancelled":
             agenda["state"] = AgendaWorkflowState.CANCELLED
 
+        if agenda["state"] not in list(AgendaWorkflowState):
+            # Fix an issue where Superdesk is not sending us a valid state
+            agenda["state"] = AgendaWorkflowState.SCHEDULED
+
         if event.get("planning_items"):
             agenda["planning_items"] = event["planning_items"]
         if event.get("coverages"):
@@ -150,6 +154,10 @@ class AgendaItemService(AsyncResourceService[AgendaItem]):
             if planning_item.get("pubstatus") == "cancelled":
                 agenda["state"] = AgendaWorkflowState.CANCELLED
 
+            if agenda["state"] not in list(AgendaWorkflowState):
+                # Fix an issue where Superdesk is not sending us a valid state
+                agenda["state"] = AgendaWorkflowState.SCHEDULED
+
         if planning_item.get("event_id"):
             agenda["event_id"] = planning_item["event_id"]
         elif planning_item.get("event_item") and force_adhoc:
@@ -194,6 +202,10 @@ class AgendaItemService(AsyncResourceService[AgendaItem]):
         plan[TO_BE_CONFIRMED_FIELD] = planning_item.get(TO_BE_CONFIRMED_FIELD)
         plan["language"] = planning_item.get("language")
         plan["source"] = planning_item.get("source")
+
+        if plan["state"] not in list(AgendaWorkflowState):
+            # Fix an issue where Superdesk is not sending us a valid state
+            plan["state"] = AgendaWorkflowState.SCHEDULED
 
         if new_plan:
             agenda["planning_items"].append(plan)

--- a/newsroom/push/publishing.py
+++ b/newsroom/push/publishing.py
@@ -25,7 +25,7 @@ from newsroom.agenda.notifications import notify_agenda_update
 
 from .tasks import notify_new_agenda_item
 from .agenda_manager import AgendaManager
-from .utils import fix_hrefs, fix_updates, set_dates, validate_event_push
+from .utils import fix_hrefs, fix_updates, set_dates, validate_event_push, fix_translation_value
 
 
 logger = logging.getLogger(__name__)
@@ -105,6 +105,10 @@ class Publisher:
                 for subject in doc["subject"]
                 if subject.get("scheme") in get_app_config("WIRE_SUBJECT_SCHEME_WHITELIST")
             ]
+
+        for field in {"subject", "service"}:
+            if doc.get(field):
+                doc[field] = fix_translation_value(doc[field])
 
         await signals.publish_item.send(doc, original is None)
 

--- a/newsroom/push/utils.py
+++ b/newsroom/push/utils.py
@@ -56,11 +56,11 @@ def fix_translation_value(items: list[dict]) -> list[dict]:
         if not isinstance(item.get("translations"), dict):
             # Remove any ``translations`` that aren't a dict
             item.pop("translations", None)
-
-        for key in list(item["translations"].keys()):
-            if not isinstance(item["translations"][key], dict):
-                # Remove any ``translations` entries that aren't a dict
-                item["translations"].pop(key, None)
+        else:
+            for key in list(item["translations"].keys()):
+                if not isinstance(item["translations"][key], dict):
+                    # Remove any ``translations` entries that aren't a dict
+                    item["translations"].pop(key, None)
 
     return items
 

--- a/newsroom/push/utils.py
+++ b/newsroom/push/utils.py
@@ -54,7 +54,13 @@ def fix_translation_value(items: list[dict]) -> list[dict]:
 
     for item in items:
         if not isinstance(item.get("translations"), dict):
+            # Remove any ``translations`` that aren't a dict
             item.pop("translations", None)
+
+        for key in list(item["translations"].keys()):
+            if not isinstance(item["translations"][key], dict):
+                # Remove any ``translations` entries that aren't a dict
+                item["translations"].pop(key, None)
 
     return items
 

--- a/tests/core/test_push_events.py
+++ b/tests/core/test_push_events.py
@@ -1494,3 +1494,53 @@ async def test_push_set_photo_coverage_href_async(client, app):
         assert response.status_code == 200
         parsed = await find_one_by_id("agenda", planning["guid"])
         assert "/async/photo/Vivid Photos" == parsed["coverages"][0]["deliveries"][0]["delivery_href"]
+
+
+async def test_push_malformed_cv_translations(client, app):
+    async def _test_cv_translations(resource, test_item, field):
+        test_item[field] = [
+            {
+                "code": "n",
+                "qcode": "n",
+                "name": "Weather",
+                "translations": {
+                    "name": {"fr-CA": "Météo"},
+                    "0": "[",
+                    "1": "o",
+                    "2": "b",
+                    "3": "j",
+                    "4": "e",
+                    "5": "c",
+                    "6": "t",
+                    "7": " ",
+                    "8": "O",
+                    "9": "b",
+                    "10": "j",
+                    "11": "e",
+                    "12": "c",
+                    "13": "t",
+                    "14": "]",
+                },
+            },
+        ]
+        response = await client.post("/push", json=test_item)
+        assert response.status_code == 200
+        parsed = await find_one_by_id(resource, test_item["guid"])
+        assert parsed["service"][0]["name"] == "Weather"
+        assert parsed["service"][0]["translations"] == {"name": {"fr-CA": "Météo"}}
+
+    await _test_cv_translations("agenda", deepcopy(test_event), "anpa_category")
+    await _test_cv_translations("agenda", deepcopy(test_planning), "anpa_category")
+    await _test_cv_translations("items", deepcopy(text_item), "service")
+
+
+async def test_push_item_with_invalid_state(client, app):
+    async def _test_item_state(test_item):
+        test_item["state"] = "draft"
+        response = await client.post("/push", json=test_item)
+        assert response.status_code == 200
+        parsed = await find_one_by_id("agenda", test_item["guid"])
+        assert parsed["state"] == "scheduled"
+
+    await _test_item_state(deepcopy(test_event))
+    await _test_item_state(deepcopy(test_planning))


### PR DESCRIPTION
### Purpose
There were 2 bugs found when publishing to Agenda (caused by bugs in Superdesk, but need to be handled here as well).

### What has changed
* If the Agenda item state is not a supported state, set it to scheduled
* If a CV item's translation has a dict[str, str], then remove those invalid keys

Resolves: [CPCN-1133](https://sofab.atlassian.net/browse/CPCN-1133)
Resolves: [CPCN-1134](https://sofab.atlassian.net/browse/CPCN-1134)


[CPCN-1133]: https://sofab.atlassian.net/browse/CPCN-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPCN-1134]: https://sofab.atlassian.net/browse/CPCN-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ