### PR TITLE
fix(videojs): Tell webpack not to compile videojs

### DIFF
--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -1,6 +1,6 @@
 import {isEmpty} from 'lodash';
 import classNames from 'classnames';
-import videojs from 'video.js';
+import videojs from '!video.js';
 
 type VjsPlayer = ReturnType<typeof videojs>;
 const isNotEmpty = (x: any) => !isEmpty(x);


### PR DESCRIPTION
### Purpose
VideoJS was being transpiled by webpack, which broke it's usage.

### What has changed
Tell Webpack not to compile videojs (see https://videojs.com/guides/webpack/)

As you can see from this screenshot, there is no download option (right click doesn't work either), so this indicates videojs is being used.
<img width="403" height="703" alt="image" src="https://github.com/user-attachments/assets/6f1279c9-cd5a-473b-ae8a-f63e8c53721c" />
