### PR TITLE
Fix intermittent external gallery display

### DIFF
--- a/newsroom/wire/items.py
+++ b/newsroom/wire/items.py
@@ -126,6 +126,6 @@ async def get_items_for_dashboard(
         elif card.dashboard_type == "4-photo-gallery":
             # Omit external media, let the client manually request these
             # using '/media_card_external' endpoint
-            items_by_card[card.label] = []
+            items_by_card.pop(card.label, None)
 
     return items_by_card


### PR DESCRIPTION
### Purpose
Fixes a bug where the 4-photo-gallery would only display intermitently

### What has changed
Rather than returning an empty array for the card response, don't return it at all!

### Steps to test
Set define a 4-photo-gallery (I suspect this is only used in the AAP instance, it requires a server token)

<img width="1639" height="492" alt="image" src="https://github.com/user-attachments/assets/f2fd55a2-3f5f-4875-95aa-09d57e5ced5a" />

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] This pull request is not adding new forms that use redux
- [x ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: N/A
