### PR TITLE
[SDAN-743] Extra Wire download formatters

### DIFF
--- a/newsroom/assets/utils.py
+++ b/newsroom/assets/utils.py
@@ -1,5 +1,7 @@
 import os
 import bson
+import logging
+from base64 import b64encode
 
 from werkzeug.utils import secure_filename
 from typing import Any
@@ -15,6 +17,9 @@ from .module import ASSETS_ENDPOINT_GROUP_NAME, ASSETS_RESOURCE
 CACHE_MAX_AGE = 3600 * 24 * 7  # 7 days
 
 
+logger = logging.getLogger(__name__)
+
+
 async def get_media_file(media_id: str, begin: int = 0, end: int | None = None) -> SuperdeskAsyncFile | None:
     """
     Asynchronously retrieves a media file from the database using its media ID.
@@ -28,6 +33,11 @@ async def get_media_file(media_id: str, begin: int = 0, end: int | None = None) 
         return result
     except bson.errors.InvalidId:
         return None
+
+
+async def get_media_file_as_base64(media_id: str) -> bytes | None:
+    file = await get_media_file(media_id)
+    return None if not file else b64encode(await file.read())
 
 
 def get_content_disposition(filename: str | None, content_type: str = "") -> str:

--- a/newsroom/news_api/formatters/rss.py
+++ b/newsroom/news_api/formatters/rss.py
@@ -71,7 +71,7 @@ class RSSFormatter:
 
     async def format_item(self, entry: SubElement, item: dict, token: str | None) -> None:
         await apply_company_permissions_to_embeds([item], SectionEnum.NEWS_API)
-        update_embed_urls(item, token)
+        await update_embed_urls(item, token)
         set_association_links(item)
 
         self.set_item_id(entry, item)

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -108,7 +108,7 @@ class NewsApiSearchServiceAsync(BaseNewshubSearchService[NewsApiSearchRequestArg
                     await apply_company_permissions_to_embeds([doc], SectionEnum.NEWS_API)
 
                     remove_internal_renditions(doc)
-                    update_embed_urls(doc, None)
+                    await update_embed_urls(doc, None)
                 else:
                     remove_all_embeds(doc)
 

--- a/newsroom/templates/download_embed.html
+++ b/newsroom/templates/download_embed.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+
+    <title>{{ config.SITE_NAME }} : {{ item.headline }}</title>
+
+    <style>
+            *, ::after, ::before {
+            box-sizing: border-box
+        }
+
+        html {
+            font-family: sans-serif;
+            line-height: 1.15;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+            -ms-overflow-style: scrollbar;
+            -webkit-tap-highlight-color: transparent
+        }
+
+        article, figcaption, figure, footer {
+            display: block
+        }
+
+        body {
+            margin: 0;
+            font-family: Roboto, "Helvetica Neue", Arial, sans-serif;
+            font-size: 1rem;
+            font-weight: 400;
+            line-height: 1.5;
+            color: #212529;
+            text-align: left;
+            background-color: #fff
+        }
+
+        h1 {
+            margin-top: 0;
+            margin-bottom: .5rem
+        }
+
+        p {
+            margin-top: 0;
+            margin-bottom: 1rem
+        }
+
+        b {
+            font-weight: bolder
+        }
+
+        small {
+            font-size: 80%
+        }
+
+        figure {
+            margin: 0 0 1rem
+        }
+
+        img {
+            vertical-align: middle;
+            border-style: none
+        }
+
+        ::-webkit-file-upload-button {
+            font: inherit;
+            -webkit-appearance: button
+        }
+
+        h1 {
+            margin-bottom: .5rem;
+            font-family: inherit;
+            font-weight: 500;
+            line-height: 1.2;
+            color: inherit
+        }
+
+        h1 {
+            font-size: 2.5rem
+        }
+
+        .lead {
+            font-size: 1.25rem;
+            font-weight: 300
+        }
+
+        small {
+            font-size: 80%;
+            font-weight: 400
+        }
+
+        .container {
+            width: 100%;
+            padding-right: 15px;
+            padding-left: 15px;
+            margin-right: auto;
+            margin-left: auto
+        }
+
+        @media (min-width: 321px) {
+            .container {
+                max-width: 300px
+            }
+        }
+
+        @media (min-width: 576px) {
+            .container {
+                max-width: 540px
+            }
+        }
+
+        @media (min-width: 768px) {
+            .container {
+                max-width: 720px
+            }
+        }
+
+        @media (min-width: 992px) {
+            .container {
+                max-width: 960px
+            }
+        }
+
+        @media (min-width: 1200px) {
+            .container {
+                max-width: 1140px
+            }
+        }
+
+        @media (min-width: 1440px) {
+            .container {
+                max-width: 1360px
+            }
+        }
+
+        .row {
+            display: flex;
+            flex-wrap: wrap;
+            margin-right: -15px;
+            margin-left: -15px
+        }
+
+        .col-9 {
+            position: relative;
+            width: 100%;
+            min-height: 1px;
+            padding-right: 15px;
+            padding-left: 15px
+        }
+
+        .col-9 {
+            flex: 0 0 75%;
+            max-width: 75%
+        }
+
+        @supports (transform-style:preserve-3d) {
+        }
+
+        @supports (transform-style:preserve-3d) {
+        }
+
+        @supports (transform-style:preserve-3d) {
+        }
+
+        @supports (transform-style:preserve-3d) {
+        }
+
+        @supports (position:sticky) {
+        }
+
+        @media print {
+            *, ::after, ::before {
+                text-shadow: none !important;
+                box-shadow: none !important
+            }
+
+            img {
+                page-break-inside: avoid
+            }
+
+            p {
+                orphans: 3;
+                widows: 3
+            }
+
+            @page {
+                size: a3
+            }
+
+            body {
+                min-width: 992px !important
+            }
+
+            .container {
+                min-width: 992px !important
+            }
+        }
+
+        html {
+            -webkit-tap-highlight-color: transparent;
+            height: 100%
+        }
+
+        body {
+            color: #444;
+            background-color: #f8f8f8;
+            overflow: hidden;
+            height: 100%
+        }
+
+        figcaption {
+            font-size: .8125rem;
+            color: #7c7c7c;
+            margin: 10px 20px
+        }
+
+        body.print {
+            color: #000;
+            background-color: #fff;
+            overflow: auto
+        }
+
+    </style>
+
+
+</head>
+<body class="print">
+
+<div class="container">
+    <div id="print-content">
+
+        {% if item.associations is defined and item.associations.featuremedia is defined %}
+            <br>
+            <img
+                id="feature-image"
+                style="height: auto; width: 100%; max-width: max-content;"
+                src="{{ item.associations.featuremedia.renditions['16-9'].href }}"
+                alt="{{ item.associations.featuremedia.headline }}"
+            >
+            <br>
+        {% endif %}
+
+        <article>
+            <pre>{{ item.slugline }}</pre>
+
+            <h1>{{ item.headline }}</h1>
+            <p>{{ _('By:') }} <b>{{ item.byline }}</b> {{ _('On:') }} {{ item.versioncreated|datetime_long }}</p>
+
+            <div class="row">
+                <div class="col-9">
+                    <div class="lead">
+                        {{ item.description_html | safe }}
+                    </div>
+
+                    {{ item.body_html | safe }}
+                </div>
+            </div>
+        </article>
+
+
+    </div>
+</div>
+
+<footer class="container">
+    <p class="text-right">
+        <small>All contents &copy; Copyright {{ get_date().year }} {{ config.COPYRIGHT_HOLDER }}. All rights reserved.
+        </small>
+    </p>
+</footer>
+
+</body>
+</html>

--- a/newsroom/templates/download_item.html
+++ b/newsroom/templates/download_item.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    {% block title %}<title>{{ item.headline }}</title>{% endblock %}
+</head>
+<body>
+{% block content %}
+    <p>{{ item.slugline }}</p>
+
+    <h1>{{ item.headline }}</h1>
+    <p>{{ _('By:') }} <b>{{ item.byline }}</b> {{ _('On:') }} {{ item.versioncreated|datetime_long }}</p>
+
+    {{ item.description_html | safe }}
+    {{ item.body_html | safe }}
+{% endblock %}
+</body>

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -1,4 +1,5 @@
-from typing import Generator, Callable
+from typing import Generator, Callable, TypeAlias, Awaitable
+from inspect import isawaitable
 import logging
 
 import re
@@ -61,20 +62,25 @@ async def apply_company_permissions_to_embeds(items: list[dict], section: Sectio
         _remove_or_disable_item_media(doc, company, sdesk_products)
 
 
-def update_embeds_in_body(
+EmbedUpdateCallback: TypeAlias = Callable[[dict, lxml_html.HtmlElement, str], bool]
+EmbedUpdateAsyncCallback: TypeAlias = Callable[[dict, lxml_html.HtmlElement, str], Awaitable[bool]]
+
+
+# TODO-PR: Support async callbacks
+async def update_embeds_in_body(
     item,
-    update_image: Callable[[dict, lxml_html.HtmlElement, str], bool] | None = None,
-    update_audio: Callable[[dict, lxml_html.HtmlElement, str], bool] | None = None,
-    update_video: Callable[[dict, lxml_html.HtmlElement, str], bool] | None = None,
+    update_image_cb: EmbedUpdateCallback | EmbedUpdateAsyncCallback | None = None,
+    update_audio_cb: EmbedUpdateCallback | EmbedUpdateAsyncCallback | None = None,
+    update_video_cb: EmbedUpdateCallback | EmbedUpdateAsyncCallback | None = None,
 ):
     """
     Scans the story body for editor3 embeds and calls the appropriate passed function for each embed type.
     The functions should expect the item, element and the number associated with the association
 
     :param item:
-    :param update_image:
-    :param update_audio:
-    :param update_video:
+    :param update_image_cb:
+    :param update_audio_cb:
+    :param update_video_cb:
     :return:
     """
 
@@ -88,28 +94,40 @@ def update_embeds_in_body(
             continue  # No figure element found after the comment
         figure_elem = figure_elem[0]
         if figure_elem is not None and figure_elem.tag == "figure":
-            if update_image is not None:
+            if update_image_cb is not None:
                 elem = figure_elem.find("./img")
                 if elem is not None:
-                    body_updated = update_image(embed_item, elem, editor_id) or body_updated
+                    image_updated = update_image_cb(embed_item, elem, editor_id)
+                    if isawaitable(image_updated):
+                        image_updated = await image_updated
+                    if image_updated:
+                        body_updated = True
                     continue
 
-            if update_audio is not None:
+            if update_audio_cb is not None:
                 elem = figure_elem.find("./audio")
                 if elem is not None:
-                    body_updated = update_audio(embed_item, elem, editor_id) or body_updated
+                    audio_updated = update_audio_cb(embed_item, elem, editor_id)
+                    if isawaitable(audio_updated):
+                        audio_updated = await audio_updated
+                    if audio_updated:
+                        body_updated = True
                     continue
 
-            if update_video is not None:
+            if update_video_cb is not None:
                 elem = figure_elem.find("./video")
                 if elem is not None:
-                    body_updated = update_video(embed_item, elem, editor_id) or body_updated
+                    video_updated = update_video_cb(embed_item, elem, editor_id)
+                    if isawaitable(video_updated):
+                        video_updated = await video_updated
+                    if video_updated:
+                        body_updated = True
 
     if body_updated:
         item["body_html"] = to_string(root_elem, method="html")
 
 
-def update_embed_urls(item: dict, token: str | None = None):
+async def update_embed_urls(item: dict, token: str | None = None):
     """
     Update the urls in the embeds to the endpoint that allows logging of the item that the embed belongs to
 
@@ -148,7 +166,7 @@ def update_embed_urls(item: dict, token: str | None = None):
             return True  # Return True if assignment happened
         return False  # Return False if src or elem was None
 
-    update_embeds_in_body(item, update_embed, update_embed, update_embed)
+    await update_embeds_in_body(item, update_embed, update_embed, update_embed)
 
 
 def remove_all_embeds(item: dict, remove_by_class: bool = True, remove_media_embeds: bool = True) -> bool:

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -41,7 +41,9 @@ def iterate_embeds(
         yield comment, f"editor_{m.group(1)}"
 
 
-async def apply_company_permissions_to_embeds(items: list[dict], section: SectionEnum) -> None:
+async def apply_company_permissions_to_embeds(
+    items: list[dict], section: SectionEnum, use_download_as_view_permission: bool = False
+) -> None:
     if not len(items) or not get_app_config("WIRE_EMBED_PERMISSIONS", True):
         return
 
@@ -59,7 +61,7 @@ async def apply_company_permissions_to_embeds(items: list[dict], section: Sectio
     }
 
     for doc in items:
-        _remove_or_disable_item_media(doc, company, sdesk_products)
+        _remove_or_disable_item_media(doc, company, sdesk_products, use_download_as_view_permission)
 
 
 EmbedUpdateCallback: TypeAlias = Callable[[dict, lxml_html.HtmlElement, str], bool]
@@ -270,7 +272,9 @@ def _embed_item_has_product_code(embed_item: dict, products: set[str]) -> bool:
 
 
 def _get_associations_to_remove_or_disable(
-    item: dict, company: CompanyResource, permitted_products: set[str]
+    item: dict,
+    company: CompanyResource,
+    permitted_products: set[str],
 ) -> tuple[set[str], set[str]]:
     disable_display: set[str] = set()
     disable_download: set[str] = set()
@@ -300,8 +304,12 @@ def _get_associations_to_remove_or_disable(
     return disable_display, disable_download
 
 
-def _remove_or_disable_item_media(item: dict, company: CompanyResource, permitted_products: set[str]) -> None:
+def _remove_or_disable_item_media(
+    item: dict, company: CompanyResource, permitted_products: set[str], use_download_as_view_permission: bool = False
+) -> None:
     disable_display, disable_download = _get_associations_to_remove_or_disable(item, company, permitted_products)
+    if use_download_as_view_permission:
+        disable_display |= disable_download
     disable_embed_codes = not company.is_permissioned_for_embed("embed_code", EmbedPermissionUserAction.DISPLAY)
 
     if not disable_download and not disable_display and not disable_embed_codes:

--- a/newsroom/wire/formatters/__init__.py
+++ b/newsroom/wire/formatters/__init__.py
@@ -6,6 +6,12 @@ from .ninjs import NINJSFormatter
 from .picture import PictureFormatter
 from .ninjs2 import NINJSFormatter2
 
+from .html import HTMLFormatter
+from .html_b64_package import HTMLMediaFormatter
+from .html_package import HTMLPackageFormatter
+from .ninjs_no_embeds import NINJSWithoutEmbedsFormatter
+from .ninjs_package import NINJSPackageFormatter
+
 
 __all__ = [
     "TextFormatter",
@@ -15,4 +21,9 @@ __all__ = [
     "NINJSFormatter",
     "PictureFormatter",
     "NINJSFormatter2",
+    "HTMLFormatter",
+    "HTMLMediaFormatter",
+    "HTMLPackageFormatter",
+    "NINJSWithoutEmbedsFormatter",
+    "NINJSPackageFormatter",
 ]

--- a/newsroom/wire/formatters/base_wire_formatter.py
+++ b/newsroom/wire/formatters/base_wire_formatter.py
@@ -1,0 +1,100 @@
+from lxml.html import HtmlElement
+
+from superdesk.logging import logger
+
+from newsroom.types import SectionEnum
+from newsroom.formatters import BaseFormatter, FormatterAssetType
+from newsroom.wire.embeds import (
+    remove_internal_renditions,
+    apply_company_permissions_to_embeds,
+    update_embeds_in_body,
+)
+
+
+class BaseWireFormatter(BaseFormatter):
+    assets = [FormatterAssetType.TEXT]
+
+    def get_widest_rendition(self, association: dict) -> dict | None:
+        widest: int = -1
+        src_rendition: dict | None = None
+        renditions: dict = association.get("renditions", {})
+        for rendition in renditions.values():
+            width = rendition.get("width", -2)
+
+            if width > widest:
+                widest = width
+                src_rendition = rendition
+
+        if src_rendition and widest > 0:
+            return src_rendition
+
+        logger.warning("href not found for the original in HTMLPackage formatter")
+        return None
+
+    def get_html_srcset_value_for_renditions(self, association: dict) -> str:
+        """
+        For the given marker (association) return the set of available hrefs and the widths
+        :param association:
+        :return:
+        """
+
+        srcset = []
+        renditions: dict = association.get("renditions", {})
+        for rendition in renditions.values():
+            ref = rendition.get("href", "").lstrip("/")
+            width = rendition.get("width", "")
+            srcset.append(f"{ref} {width}w")
+
+        return ",".join(srcset)
+
+    async def update_image_element_attributes(self, embed_item: dict, elem: HtmlElement, embed_id: str) -> bool:
+        elem.attrib["id"] = embed_id
+        widest_rendition = self.get_widest_rendition(embed_item)
+        if widest_rendition:
+            elem.attrib["src"] = widest_rendition.get("href", "").lstrip("/")
+        srcset = self.get_html_srcset_value_for_renditions(embed_item)
+        if srcset:
+            elem.attrib["srcset"] = srcset
+            elem.attrib["sizes"] = "80vw"
+        return True
+
+    async def update_av_element_attributes(self, embed_item: dict, elem: HtmlElement, embed_id: str) -> bool:
+        elem.attrib["id"] = embed_id
+
+        try:
+            elem.attrib["src"] = embed_item["renditions"]["original"]["href"].lstrip("/")
+        except (KeyError, TypeError):
+            logger.warning("audio/video href not found for the original in HTMLPackage formatter")
+
+        elem.attrib.pop("alt", None)
+        elem.attrib.pop("width", None)
+        elem.attrib.pop("height", None)
+        return True
+
+    async def rewire_embdeded_images(self, item: dict) -> None:
+        await update_embeds_in_body(
+            item,
+            self.update_image_element_attributes,
+            self.update_av_element_attributes,
+            self.update_av_element_attributes,
+        )
+
+    async def rewire_featuremedia(self, item: dict) -> None:
+        """
+        Set the references in the feature media strip the leading / to make it a legitimate relative path
+        :param item:
+        :return:
+        """
+        renditions = item.get("associations", {}).get("featuremedia", {}).get("renditions", {})
+        for _rendition_key, rendition_data in renditions.items():
+            rendition_data["href"] = rendition_data.get("href", "").lstrip("/")
+
+    async def update_embeds(self, item: dict):
+        await apply_company_permissions_to_embeds([item], SectionEnum.WIRE)
+
+        # Remove the renditions we should not be showing the world
+        remove_internal_renditions(item, remove_media=False)
+
+        # set the references embedded in the html body of the story
+        await self.rewire_embdeded_images(item)
+        await self.rewire_featuremedia(item)

--- a/newsroom/wire/formatters/base_wire_formatter.py
+++ b/newsroom/wire/formatters/base_wire_formatter.py
@@ -90,7 +90,7 @@ class BaseWireFormatter(BaseFormatter):
             rendition_data["href"] = rendition_data.get("href", "").lstrip("/")
 
     async def update_embeds(self, item: dict):
-        await apply_company_permissions_to_embeds([item], SectionEnum.WIRE)
+        await apply_company_permissions_to_embeds([item], SectionEnum.WIRE, use_download_as_view_permission=True)
 
         # Remove the renditions we should not be showing the world
         remove_internal_renditions(item, remove_media=False)

--- a/newsroom/wire/formatters/html.py
+++ b/newsroom/wire/formatters/html.py
@@ -1,0 +1,32 @@
+from quart_babel import lazy_gettext
+
+from superdesk.flask import render_template
+
+from newsroom.types import SectionEnum
+from newsroom.formatters import BaseFormatter, FormatterAssetType
+from newsroom.wire.embeds import remove_all_embeds
+
+
+class HTMLFormatter(BaseFormatter):
+    """
+    Formatter that allows the download of "plain" html
+    with any embeds in the html body stripped
+    """
+
+    format_id = "html"
+    name = lazy_gettext("Plain HTML")
+    sections = [
+        SectionEnum.WIRE,
+        SectionEnum.FACTCHECK,
+        SectionEnum.MONITORING,
+        SectionEnum.MARKET_PLACE,
+        SectionEnum.MEDIA_RELEASES,
+    ]
+    assets = [FormatterAssetType.TEXT]
+
+    FILE_EXTENSION = "html"
+    MIMETYPE = "text/html"
+
+    async def format_item(self, item: dict, item_type: str | None = "items") -> bytes:
+        remove_all_embeds(item)
+        return str.encode(await render_template("download_item.html", item=item), "utf-8")

--- a/newsroom/wire/formatters/html_b64_package.py
+++ b/newsroom/wire/formatters/html_b64_package.py
@@ -1,0 +1,90 @@
+from lxml.html import HtmlElement
+from quart_babel import lazy_gettext
+
+from superdesk.flask import render_template
+from superdesk.logging import logger
+
+from newsroom.types import SectionEnum
+from newsroom.assets.utils import get_media_file_as_base64
+from newsroom.wire.formatters.base_wire_formatter import BaseWireFormatter
+from newsroom.wire.formatters.utils import log_media_downloads
+
+
+class HTMLMediaFormatter(BaseWireFormatter):
+    """
+    This formatter will render an HTML file with the media embedded as base64 encoded strings
+    """
+
+    FILE_EXTENSION = "html"
+    MIMETYPE = "text/html"
+    format_id = "html_media"
+    name = lazy_gettext("HTML with embedded media")
+    sections = [
+        SectionEnum.WIRE,
+        SectionEnum.FACTCHECK,
+        SectionEnum.MONITORING,
+        SectionEnum.MARKET_PLACE,
+        SectionEnum.MEDIA_RELEASES,
+    ]
+
+    async def get_base64_file_data(self, embed_item: dict, use_widest_rendition: bool = False) -> str | None:
+        if use_widest_rendition:
+            rendition = self.get_widest_rendition(embed_item)
+        else:
+            rendition = embed_item.get("renditions", {}).get("original", {})
+
+        if not rendition:
+            return None
+
+        src = rendition.get("media", "")
+        mimetype = rendition.get("mimetype", "")
+
+        file_data = await get_media_file_as_base64(src)
+        if not file_data:
+            logger.warning(f"Failed to retrieve media file for embed item: {embed_item}")
+            return None
+
+        return f"data:{mimetype};base64,{file_data.decode()}"
+
+    async def update_image_element_attributes(self, embed_item: dict, elem: HtmlElement, embed_id: str) -> bool:
+        elem.attrib["id"] = embed_id
+        src = await self.get_base64_file_data(embed_item, use_widest_rendition=True)
+        if src:
+            elem.attrib["src"] = src
+        return True
+
+    async def update_av_element_attributes(self, embed_item: dict, elem: HtmlElement, embed_id: str) -> bool:
+        elem.attrib["id"] = embed_id
+        src = await self.get_base64_file_data(embed_item, use_widest_rendition=False)
+        if src:
+            elem.attrib["src"] = src
+        elem.attrib.pop("alt", None)
+        elem.attrib.pop("width", None)
+        elem.attrib.pop("height", None)
+        return True
+
+    async def rewire_featuremedia(self, item: dict) -> None:
+        """
+        Set the references in the feature media to base64 encoded versions
+        :param item:
+        :return:
+        """
+
+        try:
+            renditions = item["associations"]["featuremedia"]["renditions"]
+        except (KeyError, TypeError):
+            return
+
+        for rendition in renditions.values():
+            src: str = rendition.get("media", "")
+            mimetype: str = rendition.get("mimetype", "")
+            file_data = await get_media_file_as_base64(src)
+            if file_data and mimetype:
+                rendition["href"] = f"data:{mimetype};base64,{file_data.decode()}"
+
+    async def format_item(self, item: dict, item_type: str | None = "items") -> bytes:
+        await self.update_embeds(item)
+        resp = str.encode(await render_template("download_embed.html", item=item), "utf-8")
+        # log media as the last step in case something fails!
+        await log_media_downloads(item)
+        return resp

--- a/newsroom/wire/formatters/html_package.py
+++ b/newsroom/wire/formatters/html_package.py
@@ -24,7 +24,7 @@ class HTMLPackageFormatter(BaseWireFormatter):
 
     async def format_item(self, item: dict, item_type: str | None = "items") -> bytes:
         await self.update_embeds(item)
-        await log_media_downloads(item)
         resp = str.encode(await render_template("download_embed.html", item=item), "utf-8")
         # log media as the last step in case something fails!
+        await log_media_downloads(item)
         return resp

--- a/newsroom/wire/formatters/html_package.py
+++ b/newsroom/wire/formatters/html_package.py
@@ -1,0 +1,30 @@
+from quart_babel import lazy_gettext
+
+from superdesk.flask import render_template
+
+from newsroom.types import SectionEnum
+
+from .base_wire_formatter import BaseWireFormatter
+from .utils import log_media_downloads
+
+
+class HTMLPackageFormatter(BaseWireFormatter):
+    FILE_EXTENSION = "html"
+    MIMETYPE = "application/zip"
+    format_id = "html_package"
+    name = lazy_gettext("HTML package")
+    sections = [
+        SectionEnum.WIRE,
+        SectionEnum.FACTCHECK,
+        SectionEnum.MONITORING,
+        SectionEnum.MARKET_PLACE,
+        SectionEnum.MEDIA_RELEASES,
+    ]
+    MULTI_ZIP = True
+
+    async def format_item(self, item: dict, item_type: str | None = "items") -> bytes:
+        await self.update_embeds(item)
+        await log_media_downloads(item)
+        resp = str.encode(await render_template("download_embed.html", item=item), "utf-8")
+        # log media as the last step in case something fails!
+        return resp

--- a/newsroom/wire/formatters/ninjs.py
+++ b/newsroom/wire/formatters/ninjs.py
@@ -5,19 +5,19 @@ from quart_babel import lazy_gettext
 from superdesk.utils import json_serialize_datetime_objectId
 
 from newsroom.types import SectionEnum
-from newsroom.formatters import BaseFormatter, FormatterAssetType
+
+from .base_wire_formatter import BaseWireFormatter
 
 
-class NINJSFormatter(BaseFormatter):
+class NINJSFormatter(BaseWireFormatter):
     format_id = "ninjs"
     name = lazy_gettext("Ninjs")
     sections = [SectionEnum.WIRE]
-    assets = [FormatterAssetType.TEXT]
 
     MIMETYPE = "application/json"
     FILE_EXTENSION = "json"
 
-    direct_copy_properties = (
+    direct_copy_properties: set[str] = {
         "versioncreated",
         "usageterms",
         "language",
@@ -49,7 +49,7 @@ class NINJSFormatter(BaseFormatter):
         "evolvedfrom",
         "original_id",
         "decsription_text",
-    )
+    }
 
     async def format_item(self, item: dict[str, Any], item_type: str | None = "items") -> bytes:
         item = item.copy()

--- a/newsroom/wire/formatters/ninjs2.py
+++ b/newsroom/wire/formatters/ninjs2.py
@@ -13,9 +13,7 @@ class NINJSFormatter2(NINJSFormatter):
     name = lazy_gettext("Ninjs v2")
     # No sections this is an API only format
     sections = []
-
-    def __init__(self):
-        self.direct_copy_properties += ("associations",)
+    direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties.union(["associations"])
 
     async def _transform_to_ninjs(self, item):
         await update_embed_urls(item)

--- a/newsroom/wire/formatters/ninjs2.py
+++ b/newsroom/wire/formatters/ninjs2.py
@@ -18,6 +18,6 @@ class NINJSFormatter2(NINJSFormatter):
         self.direct_copy_properties += ("associations",)
 
     async def _transform_to_ninjs(self, item):
-        update_embed_urls(item)
+        await update_embed_urls(item)
         set_association_links(item)
         return remove_internal_renditions(await super()._transform_to_ninjs(item))

--- a/newsroom/wire/formatters/ninjs_no_embeds.py
+++ b/newsroom/wire/formatters/ninjs_no_embeds.py
@@ -1,0 +1,18 @@
+from quart_babel import lazy_gettext
+from newsroom.wire.embeds import remove_all_embeds
+
+from .ninjs2 import NINJSFormatter2
+
+
+class NINJSWithoutEmbedsFormatter(NINJSFormatter2):
+    """
+    Format with no Embeds, some API subscribers are unable to handle them!
+    """
+
+    format_id = "ninjs_exclude_embeds"
+    name = lazy_gettext("Ninjs with no embeds")
+
+    async def _transform_to_ninjs(self, item):
+        remove_all_embeds(item)
+        ninjs = await super()._transform_to_ninjs(item)
+        return ninjs

--- a/newsroom/wire/formatters/ninjs_package.py
+++ b/newsroom/wire/formatters/ninjs_package.py
@@ -30,5 +30,6 @@ class NINJSPackageFormatter(NINJSFormatter):
     async def _transform_to_ninjs(self, item: dict[str, Any]):
         await self.update_embeds(item)
         resp = await super()._transform_to_ninjs(item)
+        # log media as the last step in case something fails!
         await log_media_downloads(item)
         return resp

--- a/newsroom/wire/formatters/ninjs_package.py
+++ b/newsroom/wire/formatters/ninjs_package.py
@@ -25,9 +25,7 @@ class NINJSPackageFormatter(NINJSFormatter):
         SectionEnum.MEDIA_RELEASES,
     ]
     MULTI_ZIP = True
-    direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties | set(
-        "associations",
-    )
+    direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties.union(["associations"])
 
     async def _transform_to_ninjs(self, item: dict[str, Any]):
         await self.update_embeds(item)

--- a/newsroom/wire/formatters/ninjs_package.py
+++ b/newsroom/wire/formatters/ninjs_package.py
@@ -25,7 +25,9 @@ class NINJSPackageFormatter(NINJSFormatter):
         SectionEnum.MEDIA_RELEASES,
     ]
     MULTI_ZIP = True
-    direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties | set("associations",)
+    direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties | set(
+        "associations",
+    )
 
     async def _transform_to_ninjs(self, item: dict[str, Any]):
         await self.update_embeds(item)

--- a/newsroom/wire/formatters/ninjs_package.py
+++ b/newsroom/wire/formatters/ninjs_package.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from quart_babel import lazy_gettext
+
+from newsroom.types import SectionEnum
+
+from .ninjs import NINJSFormatter
+from .utils import log_media_downloads
+
+
+class NINJSPackageFormatter(NINJSFormatter):
+    """
+    Overload the NINJSFormatter and add the associations as a field to copy
+    """
+
+    FILE_EXTENSION = "json"
+    MIMETYPE = "application/zip"
+    format_id = "ninjspackage"
+    name = lazy_gettext("NINJS package")
+    sections = [
+        SectionEnum.WIRE,
+        SectionEnum.FACTCHECK,
+        SectionEnum.MONITORING,
+        SectionEnum.MARKET_PLACE,
+        SectionEnum.MEDIA_RELEASES,
+    ]
+    MULTI_ZIP = True
+    direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties | set("associations",)
+
+    async def _transform_to_ninjs(self, item: dict[str, Any]):
+        await self.update_embeds(item)
+        resp = await super()._transform_to_ninjs(item)
+        await log_media_downloads(item)
+        return resp

--- a/newsroom/wire/formatters/utils.py
+++ b/newsroom/wire/formatters/utils.py
@@ -4,7 +4,7 @@ import logging
 from superdesk.flask import flask
 
 from newsroom.auth.utils import get_user_from_request
-from newsroom.assets import ASSETS_RESOURCE
+from newsroom.assets.utils import get_media_file
 from newsroom.history_async import HistoryService
 
 
@@ -27,13 +27,13 @@ async def add_media(zf, item: dict[str, Any]):
             name = associated_item.get("renditions").get(rendition).get("href").lstrip("/")
             if name in added_files:
                 continue
-            file = flask.current_app.media.get(
-                associated_item.get("renditions").get(rendition).get("media"), ASSETS_RESOURCE
-            )
+
+            file = await get_media_file(associated_item.get("renditions").get(rendition).get("media"))
             if not file:
                 logger.warning("failed to get file for media {}".format(associated_item))
                 continue
-            zf.writestr(name, file.read())
+
+            zf.writestr(name, await file.read())
             added_files.append(name)
 
 

--- a/newsroom/wire/module.py
+++ b/newsroom/wire/module.py
@@ -15,6 +15,11 @@ from .formatters import (
     PictureFormatter,
     NINJSFormatter,
     NINJSFormatter2,
+    HTMLFormatter,
+    HTMLMediaFormatter,
+    HTMLPackageFormatter,
+    NINJSWithoutEmbedsFormatter,
+    NINJSPackageFormatter,
 )
 
 wire_endpoints = EndpointGroup("wire", __name__)
@@ -59,6 +64,11 @@ def init_module(app: SuperdeskAsyncApp) -> None:
     register_formatter(JsonFormatter)
     register_formatter(NINJSFormatter)
     register_formatter(NINJSFormatter2)
+    register_formatter(HTMLFormatter)
+    register_formatter(HTMLMediaFormatter)
+    register_formatter(HTMLPackageFormatter)
+    register_formatter(NINJSWithoutEmbedsFormatter)
+    register_formatter(NINJSPackageFormatter)
 
     if app.wsgi.config.get("ALLOW_PICTURE_DOWNLOAD", True):
         register_formatter(PictureFormatter)

--- a/tests/core/test_wire_downloads.py
+++ b/tests/core/test_wire_downloads.py
@@ -1,0 +1,429 @@
+from typing import Any
+import bson
+from datetime import timedelta
+from copy import deepcopy
+
+from zipfile import ZipFile
+import lxml.html as lxml_html
+
+from superdesk.core import json
+from superdesk.utc import utcnow
+
+from newsroom.tests import test_utils
+from newsroom.tests.fixtures import (  # noqa
+    user,
+    auth_users,
+    items,
+    init_items,
+    init_auth,
+    ADMIN_USER_ID,
+)
+from .test_push import upload_binary, get_fixture_path
+
+items_ids = [item["_id"] for item in items[:2]]
+item = deepcopy(items[0])
+
+media_id = str(bson.ObjectId())
+associations: dict[str, Any] = {
+    "featuremedia": {
+        "mimetype": "image/jpeg",
+        "type": "picture",
+        "products": [{"code": "123", "name": "Product A"}],
+        "renditions": {
+            "16-9": {
+                "mimetype": "image/jpeg",
+                "href": "http://a.b.c/xxx.jpg",
+                "media": media_id,
+                "width": 1280,
+                "height": 720,
+            },
+            "4-3": {
+                "href": "/assets/633d11b9fb5122dcf06a6f02",
+                "width": 800,
+                "height": 600,
+                "media": media_id,
+                "mimetype": "image/jpeg",
+            },
+        },
+    },
+    "editor_1": {
+        "type": "video",
+        "renditions": {
+            "original": {
+                "mimetype": "video/mp4",
+                "href": "/assets/640ff0bdfb5122dcf06a6fc3",
+                "media": media_id,
+            }
+        },
+        "mimetype": "video/mp4",
+        "products": [
+            {"code": "123", "name": "Product A"},
+            {"code": "321", "name": "Product B"},
+        ],
+    },
+    "editor_0": {
+        "type": "audio",
+        "renditions": {
+            "original": {
+                "mimetype": "audio/mp3",
+                "href": "/assets/640feb9bfb5122dcf06a6f7c",
+                "media": "640feb9bfb5122dcf06a6f7c",
+            }
+        },
+        "mimetype": "audio/mp3",
+        "products": [{"code": "999", "name": "NSW News"}],
+    },
+    "editor_2": {
+        "type": "picture",
+        "renditions": {
+            "4-3": {
+                "href": "/assets/633d11b9fb5122dcf06a6f03",
+                "width": 800,
+                "height": 600,
+                "mimetype": "image/jpeg",
+                "media": "633d11b9fb5122dcf06a6f03",
+            },
+            "16-9": {
+                "href": "/assets/633d0f59fb5122dcf06a6ee8",
+                "width": 1280,
+                "height": 720,
+                "mimetype": "image/jpeg",
+                "media": "633d0f59fb5122dcf06a6ee8",
+                "poi": {},
+            },
+        },
+        "products": [{"code": "888"}],
+    },
+    "editor_3": None,
+}
+
+
+async def _setup_embeds(client):
+    await upload_binary("picture.jpg", client, media_id=media_id)
+
+    await test_utils.update_entries_for(
+        "items",
+        item["_id"],
+        {
+            "associations": deepcopy(associations),
+            "body_html": '<p>Par 1</p><!-- EMBED START Audio {id: "editor_0"} --><figure>'
+            '<audio controls src="/assets/640feb9bfb5122dcf06a6f7c" alt="minns" '
+            'width="100%" height="100%"></audio>'
+            "<figcaption>minns</figcaption>"
+            "</figure>"
+            '<!-- EMBED END Audio {id: "editor_0"} -->'
+            "<p><br></p>"
+            "<p>Par 2</p>"
+            '<!-- EMBED START Video {id: "editor_1"} -->'
+            "<figure>"
+            '<video controls src="/assets/640ff0bdfb5122dcf06a6fc3" '
+            'alt="Scomo text" width="100%" height="100%">'
+            "</video>"
+            "<figcaption>Scomo whinging</figcaption>"
+            "</figure>"
+            '<!-- EMBED END Video {id: "editor_1"} -->'
+            "<p><br></p>Par 3<p></p>"
+            '<!-- EMBED START Image {id: "editor_2"} -->'
+            "<figure>"
+            '<img src="/assets/6189e8a48b37621081610714_newsroom_custom" '
+            'alt="SCOTT MORRISON MELBOURNE VISIT"'
+            ' id="editor_2">'
+            "<figcaption>Prime Minister Scott Morrison and Liberal member for "
+            "Higgins Katie Allen</figcaption>"
+            "</figure>"
+            '<!-- EMBED END Image {id: "editor_2"} -->'
+            "<p>Par 4</p>",
+        },
+        item,
+    )
+
+
+async def _setup_company_user_products(client, app) -> bson.ObjectId:
+    await _setup_embeds(client)
+    app.config["WIRE_EMBED_PERMISSIONS"] = True
+    company_id = bson.ObjectId()
+    await test_utils.create_entries_for(
+        "companies",
+        [
+            {
+                "_id": company_id,
+                "name": "Another Press co.",
+                "is_enabled": True,
+                "embed_permissions": {
+                    "video": ["display", "download"],
+                    "audio": ["display", "download"],
+                    "sd_product": ["display", "download"],
+                },
+            }
+        ],
+    )
+    admin_user = await test_utils.find_one_for("users", req=None, first_name="admin")
+    assert admin_user
+    await test_utils.update_entries_for(
+        "users",
+        admin_user["_id"],
+        {"company": company_id, "user_type": "public"},
+        admin_user,
+    )
+    await test_utils.create_entries_for(
+        "products",
+        [
+            {
+                "name": "product test",
+                "sd_product_id": "123",
+                "companies": [company_id],
+                "is_enabled": True,
+                "product_type": "wire",
+            }
+        ],
+    )
+    app.general_setting("news_api_allowed_renditions", "Foo", default="16-9,4-3")
+    return company_id
+
+
+def _assert_ninjs_content(content: str, item: dict, media_included: list[str]) -> dict:
+    data = json.loads(content)
+    assert item["slugline"] == data["slugline"]
+    assert item["headline"] == data["headline"]
+
+    for media_id in ("editor_0", "editor_1", "editor_2"):
+        if media_id in media_included:
+            assert data.get("associations").get(media_id)
+        else:
+            assert not data.get("associations").get(media_id)
+
+    return data
+
+
+def _assert_html_content(content: str, item: dict, use_base64: bool = False) -> None:
+    root = lxml_html.fromstring(content)
+
+    if use_base64:
+        with open(get_fixture_path("picture.jpg"), "rb") as original_fixture:
+            from base64 import b64encode
+
+            fixture_data = b64encode(original_fixture.read()).decode("utf-8")
+            featuremedia_src = "data:image/jpeg;base64," + fixture_data
+            video_src = "data:video/mp4;base64," + fixture_data
+    else:
+        featuremedia_src = _get_rendition_href("featuremedia", "16-9")
+        video_src = _get_rendition_href("editor_1", "original")
+
+    if root.tag == "html":
+        assert root.find("head/title").text == f"Newshub : {item['headline']}"
+        assert root.find("body//article/pre").text == item["slugline"]
+        assert root.find("body//article/h1").text == item["headline"]
+        footer_text = root.find("body/footer").text_content()
+        assert "All contents © Copyright 2025 Sourcefabric. All rights reserved." in footer_text
+
+        featuremedia_element = root.xpath("//img[@id='feature-image']")[0]
+        assert featuremedia_element.attrib["src"] == featuremedia_src
+
+    assert "editor_0" not in content
+    assert "editor_2" not in content
+    video_element = root.xpath("//video[@id='editor_1']")[0]
+    assert video_element.attrib["src"] == video_src
+
+
+def _assert_html_content_without_embeds(content: str, item: dict) -> None:
+    root = lxml_html.fromstring(content)
+
+    if root.tag == "html":
+        assert root.tag == "html"
+        assert root.find("head/title").text == item["headline"]
+        assert root.find("body//p").text == item["slugline"]
+        assert root.find("body//h1").text == item["headline"]
+
+    assert len(root.xpath("//img")) == 0
+    assert len(root.xpath("//video")) == 0
+    assert len(root.xpath("//audio")) == 0
+
+
+def _get_rendition_href(association: str, rendition: str) -> str:
+    href = associations[association]["renditions"][rendition]["href"]
+    return href[1:] if href.startswith("/") else href
+
+
+def _assert_zip_file_contents(zf: ZipFile, expected_files: dict[str, bytes | None]) -> None:
+    assert sorted(zf.namelist()) == sorted(expected_files.keys())
+    for filename, expected_data in expected_files.items():
+        if expected_data is None:
+            continue
+        assert zf.open(filename).read() == expected_data
+
+
+async def _assert_download_history_entries(
+    company_id: bson.ObjectId, expected_item_actions: dict[str, list[str]]
+) -> None:
+    history_items = await test_utils.get_all("history")
+    assert len(history_items) == sum(len(actions) for actions in expected_item_actions.values())
+
+    item_actions: dict[str, list[str]] = {}
+    for history_item in history_items:
+        item_actions.setdefault(history_item["item"], []).append(history_item["action"])
+
+    assert sorted(item_actions.keys()) == sorted(expected_item_actions.keys())
+    for item_id, expected_actions in expected_item_actions.items():
+        assert sorted(item_actions[item_id]) == sorted(expected_actions)
+
+    for history_entry in history_items:
+        assert history_entry.get("item") in items_ids
+        assert history_entry.get("user") == bson.ObjectId(ADMIN_USER_ID)
+        assert history_entry.get("versioncreated") + timedelta(seconds=2) >= utcnow()
+        assert history_entry.get("version")
+        assert history_entry.get("company") == company_id
+        assert history_entry.get("section") == "wire"
+
+
+async def _download_file(client, item_id: str, download_format: str):
+    response = await client.post("/download", json={"items": [item_id], "type": "wire", "format": download_format})
+    assert response.status_code == 200, await response.get_data(as_text=True)
+    return await response.get_data()
+
+
+async def test_html_download(client, app):
+    """Tests HTMLFormatter"""
+    company_id = await _setup_company_user_products(client, app)
+    html_file = await _download_file(client, items_ids[0], "html")
+    _assert_html_content_without_embeds(html_file, items[0])
+    await _assert_download_history_entries(company_id, {items[0]["_id"]: ["download"]})
+
+
+async def test_html_media_formatter_download(client, app):
+    """Tests HTMLMediaFormatter"""
+
+    company_id = await _setup_company_user_products(client, app)
+    html_file = await _download_file(client, items_ids[0], "html_media")
+    _assert_html_content(html_file.decode("utf-8"), item, use_base64=True)
+    await _assert_download_history_entries(
+        company_id, {items[0]["_id"]: ["download", "download video", "download picture"]}
+    )
+
+
+async def test_html_package_formatter_download(client, app):
+    """Test HTMLPackageFormatter"""
+
+    company_id = await _setup_company_user_products(client, app)
+    _file = await test_utils.download_zip_file(client, [items[0]["_id"]], "html_package", "wire")
+
+    with ZipFile(_file) as zf, open(get_fixture_path("picture.jpg"), "rb") as original_fixture:
+        original_fixture_data = original_fixture.read()
+        content_filename = test_utils.get_download_filename("amazon-bookstore-opening.html", item)
+
+        _assert_zip_file_contents(
+            zf,
+            {
+                content_filename: None,
+                _get_rendition_href("featuremedia", "16-9"): original_fixture_data,
+                _get_rendition_href("featuremedia", "4-3"): original_fixture_data,
+                _get_rendition_href("editor_1", "original"): original_fixture_data,
+            },
+        )
+        content = zf.open(content_filename).read()
+
+    _assert_html_content(content.decode("utf-8"), item)
+    await _assert_download_history_entries(
+        company_id,
+        {
+            items[0]["_id"]: ["download", "download video", "download picture"],
+        },
+    )
+
+
+async def test_ninjs_without_embeds_formatter_download(client, app):
+    """Test NINJSWithoutEmbedsFormatter"""
+
+    company_id = await _setup_company_user_products(client, app)
+    content = await _download_file(client, items_ids[0], "ninjs_exclude_embeds")
+    data = _assert_ninjs_content(content.decode("utf-8"), items[0], [])
+    _assert_html_content_without_embeds(data.get("body_html"), item)
+    await _assert_download_history_entries(company_id, {items[0]["_id"]: ["download"]})
+
+
+async def test_ninjs_package_formatter_download(client, app):
+    """Test NINJSPackageFormatter"""
+
+    company_id = await _setup_company_user_products(client, app)
+    _file = await test_utils.download_zip_file(client, [items[0]["_id"]], "ninjspackage", "wire")
+
+    with ZipFile(_file) as zf:
+        content_filename = test_utils.get_download_filename("amazon-bookstore-opening.json", item)
+        assert sorted(zf.namelist()) == sorted(
+            [
+                content_filename,
+                _get_rendition_href("featuremedia", "16-9"),
+                _get_rendition_href("featuremedia", "4-3"),
+                _get_rendition_href("editor_1", "original"),
+            ]
+        )
+        content = zf.open(content_filename).read()
+
+    data = _assert_ninjs_content(content.decode("utf-8"), items[0], ["editor_1"])
+    _assert_html_content(data.get("body_html"), item)
+    await _assert_download_history_entries(
+        company_id,
+        {
+            items[0]["_id"]: ["download", "download video", "download picture"],
+        },
+    )
+
+
+async def test_ninjs_package_formatter_download_multiple(client, app):
+    """Test NINJSPackageFormatter"""
+
+    company_id = await _setup_company_user_products(client, app)
+    _file = await test_utils.download_zip_file(client, items_ids, "ninjspackage", "wire")
+
+    with ZipFile(_file) as zf:
+        content_filename = test_utils.get_download_filename("amazon-bookstore-opening.json", item)
+        assert sorted(zf.namelist()) == sorted(
+            [
+                test_utils.get_download_filename("weather.json", items[1]),
+                content_filename,
+                _get_rendition_href("featuremedia", "16-9"),
+                _get_rendition_href("featuremedia", "4-3"),
+                _get_rendition_href("editor_1", "original"),
+            ]
+        )
+        content = zf.open(content_filename).read()
+
+    data = _assert_ninjs_content(content.decode("utf-8"), items[0], ["editor_1"])
+    _assert_html_content(data.get("body_html"), item)
+    await _assert_download_history_entries(
+        company_id,
+        {
+            items[0]["_id"]: ["download", "download video", "download picture"],
+            items[1]["_id"]: ["download"],
+        },
+    )
+
+
+async def test_html_package_formatter_download_multiple(client, app):
+    """Test HTMLPackageFormatter"""
+    company_id = await _setup_company_user_products(client, app)
+    _file = await test_utils.download_zip_file(client, items_ids, "html_package", "wire")
+
+    with ZipFile(_file) as zf, open(get_fixture_path("picture.jpg"), "rb") as original_fixture:
+        original_fixture_data = original_fixture.read()
+        content_filename = test_utils.get_download_filename("amazon-bookstore-opening.html", item)
+
+        _assert_zip_file_contents(
+            zf,
+            {
+                test_utils.get_download_filename("weather.html", items[1]): None,
+                content_filename: None,
+                _get_rendition_href("featuremedia", "16-9"): original_fixture_data,
+                _get_rendition_href("featuremedia", "4-3"): original_fixture_data,
+                _get_rendition_href("editor_1", "original"): original_fixture_data,
+            },
+        )
+        content = zf.open(content_filename).read()
+
+    _assert_html_content(content.decode("utf-8"), item)
+    await _assert_download_history_entries(
+        company_id,
+        {
+            items[0]["_id"]: ["download", "download video", "download picture"],
+            items[1]["_id"]: ["download"],
+        },
+    )

--- a/tests/core/test_wire_downloads.py
+++ b/tests/core/test_wire_downloads.py
@@ -67,7 +67,7 @@ associations: dict[str, Any] = {
             "original": {
                 "mimetype": "audio/mp3",
                 "href": "/assets/640feb9bfb5122dcf06a6f7c",
-                "media": "640feb9bfb5122dcf06a6f7c",
+                "media": media_id,
             }
         },
         "mimetype": "audio/mp3",
@@ -81,14 +81,14 @@ associations: dict[str, Any] = {
                 "width": 800,
                 "height": 600,
                 "mimetype": "image/jpeg",
-                "media": "633d11b9fb5122dcf06a6f03",
+                "media": media_id,
             },
             "16-9": {
                 "href": "/assets/633d0f59fb5122dcf06a6ee8",
                 "width": 1280,
                 "height": 720,
                 "mimetype": "image/jpeg",
-                "media": "633d0f59fb5122dcf06a6ee8",
+                "media": media_id,
                 "poi": {},
             },
         },
@@ -150,9 +150,10 @@ async def _setup_company_user_products(client, app) -> bson.ObjectId:
                 "name": "Another Press co.",
                 "is_enabled": True,
                 "embed_permissions": {
+                    "picture": ["display"],
                     "video": ["display", "download"],
                     "audio": ["display", "download"],
-                    "sd_product": ["display", "download"],
+                    "sd_product": ["display"],
                 },
             }
         ],
@@ -427,3 +428,36 @@ async def test_html_package_formatter_download_multiple(client, app):
             items[1]["_id"]: ["download"],
         },
     )
+
+
+async def test_package_download_permissions(client, app):
+    company_id = await _setup_company_user_products(client, app)
+
+    # Remove sdesk product checking, use content type directly and remove download permission for video
+    await test_utils.update_entries_for(
+        "companies",
+        company_id,
+        {
+            "embed_permissions": {
+                "featuremedia": [],
+                "picture": [],
+                "video": ["display"],
+                "audio": ["display", "download"],
+            }
+        },
+    )
+
+    with open(get_fixture_path("picture.jpg"), "rb") as original_fixture:
+        original_fixture_data = original_fixture.read()
+
+    _file = await test_utils.download_zip_file(client, items_ids, "html_package", "wire")
+    with ZipFile(_file) as zf:
+        # pictures and video will not be included, only audio will be
+        _assert_zip_file_contents(
+            zf,
+            {
+                test_utils.get_download_filename("weather.html", items[1]): None,
+                test_utils.get_download_filename("amazon-bookstore-opening.html", item): None,
+                _get_rendition_href("editor_0", "original"): original_fixture_data,
+            },
+        )


### PR DESCRIPTION
### Purpose
Add new formatters that support packaging the wire item and any associated media.

### What has changed
The following formatters have been added:
* Plain HTML
* HTML with embedded media
* HTML package
* Ninjs with no embeds
* NINJS package


Resolves: [SDAN-743](https://sofab.atlassian.net/browse/SDAN-743)


[SDAN-743]: https://sofab.atlassian.net/browse/SDAN-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ