### PR TITLE
[SDAN-737-Fix] - Videojs fix + implementation on featured video/audio items

### DIFF
--- a/assets/ui/components/ArticleMedia.tsx
+++ b/assets/ui/components/ArticleMedia.tsx
@@ -11,7 +11,8 @@ export default function ArticleMedia({isKilled, media, download}: any) {
     const disableDownload = media.disable_download;
 
     useEffect(() => {
-        const cleanupMediaPlayers = containerRef.current && setupMediaPlayers(containerRef.current);
+        if (!containerRef.current) return;
+        const cleanupMediaPlayers = setupMediaPlayers(containerRef.current);
         return () => cleanupMediaPlayers?.();
     }, [media]);
 

--- a/assets/ui/components/ArticleMedia.tsx
+++ b/assets/ui/components/ArticleMedia.tsx
@@ -1,29 +1,37 @@
-import React from 'react';
+import React, {useRef, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {gettext} from 'utils';
 import {getOriginalRendition} from 'wire/utils';
+import {setupMediaPlayers} from '../utils';
 
 export default function ArticleMedia({isKilled, media, download}: any) {
     const rendition = getOriginalRendition(media);
     const filename = media.slugline || rendition.media;
+    const containerRef = useRef<HTMLDivElement>(null);
+    const disableDownload = media.disable_download;
+
+    useEffect(() => {
+        const cleanupMediaPlayers = containerRef.current && setupMediaPlayers(containerRef.current);
+        return () => cleanupMediaPlayers?.();
+    }, [media]);
 
     return (
         (rendition && !isKilled) && (
-            <div className='wire-column__preview__video' key={rendition.href}>
+            <div ref={containerRef} className='wire-column__preview__video' key={rendition.href}>
                 <span className='wire-column__preview__video-headline'>{media.headline || media.description_text}</span>
                 {media.type === 'video' && (
-                    <video controls preload="metadata">
+                    <video controls preload="metadata" {...(disableDownload && {'data-disable-download':'true'})}>
                         <source src={rendition.href} type={rendition.mimetype} />
                         {gettext('Your browser does not support playing video')}
                     </video>
                 )}
                 {media.type === 'audio' && (
-                    <audio controls>
+                    <audio controls {...(disableDownload && {'data-disable-download':'true'})}>
                         <source src={rendition.href} type={rendition.mimetype} />
                         {gettext('Your browser does not support playing audio')}
                     </audio>
                 )}
-                {rendition.media && (
+                {rendition.media && !disableDownload && (
                     <button className="nh-button nh-button--secondary nh-button--small mt-3 mb-4"
                         onClick={() => download(rendition.media, filename)}>
                         <i className="icon--download"></i>{gettext('Download')}

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -44,17 +44,12 @@ function initPlayer(
 
         if (typeof videojs === 'function') {
             try {
-                const options = {
+                const player = videojs(el, {
                     controls: true,
                     preload: 'auto',
                     fluid: true,
-                };
-
-                if (isAudio) {
-                    options.audioOnlyMode = true;
-                }
-
-                const player = videojs(el, options);
+                    audioOnlyMode: isAudio,
+                });
                 el.setAttribute('data-vjs-initialized', 'true');
                 onReady(player);
                 return;

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -28,50 +28,63 @@ export function bem(block: any, element: any, modifier: any) {
     return classes.join(' ');
 }
 
+function tryInitPlayer(el: HTMLElement, retries = 3, delay = 100): VjsPlayer | null {
+    if (!document.body.contains(el)) return null;
+
+    if (typeof videojs !== 'function') {
+        if (retries > 0) {
+            setTimeout(() => tryInitPlayer(el, retries - 1, delay), delay);
+        } else {
+            console.warn('video.js not ready after retries for', el);
+        }
+        return null;
+    }
+
+    try {
+        const player = videojs(el, {
+            controls: true,
+            preload: 'auto',
+            fluid: true,
+        });
+        // Mark element initialized only after success
+        el.setAttribute('data-vjs-initialized', 'true');
+        return player;
+    } catch (err) {
+        console.warn('video.js init failed, retrying...', err);
+        if (retries > 0) {
+            setTimeout(() => tryInitPlayer(el, retries - 1, delay), delay);
+        }
+        return null;
+    }
+}
+
 export function setupMediaPlayers(root: HTMLElement) {
     const players: Array<VjsPlayer> = [];
 
     root.querySelectorAll('video, audio').forEach((element) => {
         if (element.getAttribute('data-vjs-initialized')) return;
 
-        try {
-            const disable = element.getAttribute('data-disable-download') === 'true';
+        const disable = element.getAttribute('data-disable-download') === 'true';
 
-            if (disable) {
-                // Remove native controls everywhere on all major browsers
-                element.removeAttribute('controls');
-                // Additional override for browsers that support controlsList
-                element.setAttribute('controlsList', 'nodownload');
-                // Disable right-click context menu on all browsers
-                element.addEventListener('contextmenu', (e) => e.preventDefault());
+        if (disable) {
+            // Remove native controls everywhere on all major browsers
+            element.removeAttribute('controls');
+            // Additional override for browsers that support controlsList
+            element.setAttribute('controlsList', 'nodownload');
+            // Disable right-click context menu on all browsers
+            element.addEventListener('contextmenu', (e) => e.preventDefault());
 
-                if (element instanceof HTMLVideoElement) {
-                    element.classList.add('video-js', 'vjs-big-play-centered');
-                } else if (element instanceof HTMLAudioElement) {
-                    element.classList.add('video-js');
-                }
-
-                // Guard to return early if import is not resolved
-                if (typeof videojs !== 'function') {
-                    console.warn('videojs not ready yet'); 
-                    return;
-                }
-
-                const player = videojs(element, {
-                    controls: true,
-                    preload: 'auto',
-                    fluid: true,
-                });
-                players.push(player);
-
-                // Mark element as initialized only after successful initialization to allow for retrys
-                element.setAttribute('data-vjs-initialized', 'true');
-            } else {
-                // Enable all native controls
-                element.setAttribute('controls', '');
+            if (element instanceof HTMLVideoElement) {
+                element.classList.add('video-js', 'vjs-big-play-centered');
+            } else if (element instanceof HTMLAudioElement) {
+                element.classList.add('video-js');
             }
-        } catch (err) {
-            console.error('Video.js init failed', err);
+
+            const player = tryInitPlayer(element);
+            if (player) players.push(player);
+        } else {
+            // Enable all native controls
+            element.setAttribute('controls', '');
         }
     });
 

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -40,14 +40,21 @@ function initPlayer(
     function attempt(remainingTries: number): void {
         if (cancelled) return;
         if (!document.body.contains(el)) { onReady(null); return; }
+        const isAudio = el instanceof HTMLAudioElement;
 
         if (typeof videojs === 'function') {
             try {
-                const player = videojs(el, {
+                const options = {
                     controls: true,
                     preload: 'auto',
                     fluid: true,
-                });
+                };
+
+                if (isAudio) {
+                    options.audioOnlyMode = true;
+                }
+
+                const player = videojs(el, options);
                 el.setAttribute('data-vjs-initialized', 'true');
                 onReady(player);
                 return;

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -34,32 +34,44 @@ export function setupMediaPlayers(root: HTMLElement) {
     root.querySelectorAll('video, audio').forEach((element) => {
         if (element.getAttribute('data-vjs-initialized')) return;
 
-        const disable = element.getAttribute('data-disable-download') === 'true';
-        element.setAttribute('data-vjs-initialized', 'true');
+        try {
+            const disable = element.getAttribute('data-disable-download') === 'true';
 
-        if (disable) {
-            // Remove native controls everywhere on all major browsers
-            element.removeAttribute('controls');
-            // Additional override for browsers that support controlsList
-            element.setAttribute('controlsList', 'nodownload');
-            // Disable right-click context menu on all browsers
-            element.addEventListener('contextmenu', (e) => e.preventDefault());
+            if (disable) {
+                // Remove native controls everywhere on all major browsers
+                element.removeAttribute('controls');
+                // Additional override for browsers that support controlsList
+                element.setAttribute('controlsList', 'nodownload');
+                // Disable right-click context menu on all browsers
+                element.addEventListener('contextmenu', (e) => e.preventDefault());
 
-            if (element instanceof HTMLVideoElement) {
-                element.classList.add('video-js', 'vjs-big-play-centered');
-            } else if (element instanceof HTMLAudioElement) {
-                element.classList.add('video-js');
+                if (element instanceof HTMLVideoElement) {
+                    element.classList.add('video-js', 'vjs-big-play-centered');
+                } else if (element instanceof HTMLAudioElement) {
+                    element.classList.add('video-js');
+                }
+
+                // Guard to return early if import is not resolved
+                if (typeof videojs !== 'function') {
+                    console.warn('videojs not ready yet'); 
+                    return;
+                }
+
+                const player = videojs(element, {
+                    controls: true,
+                    preload: 'auto',
+                    fluid: true,
+                });
+                players.push(player);
+
+                // Mark element as initialized only after successful initialization to allow for retrys
+                element.setAttribute('data-vjs-initialized', 'true');
+            } else {
+                // Enable all native controls
+                element.setAttribute('controls', '');
             }
-
-            const player = videojs(element, {
-                controls: true,
-                preload: 'auto',
-                fluid: true,
-            });
-            players.push(player);
-        } else {
-            // Enable all native controls
-            element.setAttribute('controls', '');
+        } catch (err) {
+            console.error('Video.js init failed', err);
         }
     });
 

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -60,8 +60,9 @@ function tryInitPlayer(el: HTMLElement, retries = 3, delay = 100): VjsPlayer | n
 
 export function setupMediaPlayers(root: HTMLElement) {
     const players: Array<VjsPlayer> = [];
+    const elements = root.querySelectorAll<HTMLVideoElement | HTMLAudioElement>('video, audio');
 
-    root.querySelectorAll('video, audio').forEach((element) => {
+    elements.forEach((element) => {
         if (element.getAttribute('data-vjs-initialized')) return;
 
         const disable = element.getAttribute('data-disable-download') === 'true';

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -28,38 +28,54 @@ export function bem(block: any, element: any, modifier: any) {
     return classes.join(' ');
 }
 
-function tryInitPlayer(el: HTMLElement, retries = 3, delay = 100): VjsPlayer | null {
-    if (!document.body.contains(el)) return null;
+function initPlayer(
+    el: HTMLElement,
+    retries = 3,
+    delay = 100,
+    onReady: (player: VjsPlayer | null) => void
+): () => void {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-    if (typeof videojs !== 'function') {
-        if (retries > 0) {
-            setTimeout(() => tryInitPlayer(el, retries - 1, delay), delay);
+    function attempt(remainingTries: number): void {
+        if (cancelled) return;
+        if (!document.body.contains(el)) { onReady(null); return; }
+
+        if (typeof videojs === 'function') {
+            try {
+                const player = videojs(el, {
+                    controls: true,
+                    preload: 'auto',
+                    fluid: true,
+                });
+                el.setAttribute('data-vjs-initialized', 'true');
+                onReady(player);
+                return;
+            } catch (err) {
+                console.warn('video.js init failed, retrying...', err);
+            }
+        }
+
+        if (remainingTries > 0) {
+            timeoutId = setTimeout(() => attempt(remainingTries - 1), delay);
         } else {
             console.warn('video.js not ready after retries for', el);
+            onReady(null);
         }
-        return null;
     }
 
-    try {
-        const player = videojs(el, {
-            controls: true,
-            preload: 'auto',
-            fluid: true,
-        });
-        // Mark element initialized only after success
-        el.setAttribute('data-vjs-initialized', 'true');
-        return player;
-    } catch (err) {
-        console.warn('video.js init failed, retrying...', err);
-        if (retries > 0) {
-            setTimeout(() => tryInitPlayer(el, retries - 1, delay), delay);
-        }
-        return null;
-    }
+    attempt(retries);
+
+    // Return cancel function for any pending timeouts in cases of unmounts and such
+    return () => {
+        cancelled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+    };
 }
 
 export function setupMediaPlayers(root: HTMLElement) {
     const players: Array<VjsPlayer> = [];
+    const timeoutCancels: Array<() => void> = [];
     const elements = root.querySelectorAll<HTMLVideoElement | HTMLAudioElement>('video, audio');
 
     elements.forEach((element) => {
@@ -81,8 +97,10 @@ export function setupMediaPlayers(root: HTMLElement) {
                 element.classList.add('video-js');
             }
 
-            const player = tryInitPlayer(element);
-            if (player) players.push(player);
+            const cancel = initPlayer(element, 3, 100, (player: VjsPlayer | null) => {
+                if (player) players.push(player);
+            });
+            timeoutCancels.push(cancel);
         } else {
             // Enable all native controls
             element.setAttribute('controls', '');
@@ -90,10 +108,7 @@ export function setupMediaPlayers(root: HTMLElement) {
     });
 
     return () => {
-        players.forEach((player) => {
-            if (player && typeof player.dispose === 'function') {
-                player.dispose();
-            }
-        });
+        timeoutCancels.forEach((c) => c());
+        players.forEach((p) => p?.dispose?.());
     };
 }

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -878,7 +878,7 @@ CALENDAR_LOCATIONS_FILTER_OPTIONS = {
 #:
 #: .. versionadded: 3.1
 #:
-WIRE_EMBED_PERMISSIONS = True
+WIRE_EMBED_PERMISSIONS = False
 
 #: Enable/Disable using Wire Embed permissions in the Dashboard
 #:

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -878,7 +878,7 @@ CALENDAR_LOCATIONS_FILTER_OPTIONS = {
 #:
 #: .. versionadded: 3.1
 #:
-WIRE_EMBED_PERMISSIONS = False
+WIRE_EMBED_PERMISSIONS = True
 
 #: Enable/Disable using Wire Embed permissions in the Dashboard
 #:

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -286,6 +286,10 @@ def _remove_or_disable_item_media(item: dict, company: CompanyResource, permitte
     disable_display, disable_download = _get_associations_to_remove_or_disable(item, company, permitted_products)
     disable_embed_codes = not company.is_permissioned_for_embed("embed_code", EmbedPermissionUserAction.DISPLAY)
 
+    # Tag featuredMedia association if download is disabled too
+    if "featuremedia" in disable_download and item.get("associations", {}).get("featuremedia"):
+        item["associations"]["featuremedia"]["disable_download"] = True
+
     if not disable_download and not disable_display and not disable_embed_codes:
         return
 

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -278,6 +278,7 @@ def _get_associations_to_remove_or_disable(
             embed_type, EmbedPermissionUserAction.DOWNLOAD
         ):
             disable_download.add(key)
+            item["associations"][key]["disable_download"] = True
 
     return disable_display, disable_download
 
@@ -285,10 +286,6 @@ def _get_associations_to_remove_or_disable(
 def _remove_or_disable_item_media(item: dict, company: CompanyResource, permitted_products: set[str]) -> None:
     disable_display, disable_download = _get_associations_to_remove_or_disable(item, company, permitted_products)
     disable_embed_codes = not company.is_permissioned_for_embed("embed_code", EmbedPermissionUserAction.DISPLAY)
-
-    # Tag featuredMedia association if download is disabled too
-    if "featuremedia" in disable_download and item.get("associations", {}).get("featuremedia"):
-        item["associations"]["featuremedia"]["disable_download"] = True
 
     if not disable_download and not disable_display and not disable_embed_codes:
         return


### PR DESCRIPTION
### Purpose
This PR adds a try/catch block for `setupMediaPlayers` function. It also sets the `data-vjs-initialized` as true only when successful to allow for retries. This PR also adds videojs to featured media audio/video to enable/disable downloads. It also hides the download button if it is not allowed.


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-737](https://sofab.atlassian.net/browse/SDAN-737)


[SDAN-737]: https://sofab.atlassian.net/browse/SDAN-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ