### PR TITLE
[SDAN-730] fix: Issue parsing html if starts with embed comment

### DIFF
--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -64,11 +64,25 @@ async def apply_company_permissions_to_embeds(
         _remove_or_disable_item_media(doc, company, sdesk_products, use_download_as_view_permission)
 
 
+def _get_html_from_string(html_string: bytes | str | None) -> HtmlElement:
+    # Fix a parsing issue when the HTML string starts with an embed comment
+    # otherwise ``xpath("//comment()")[0].getparent()`` returns None
+    # instead of the root element
+
+    if not html_string:
+        html_string = "<p></p>"
+    elif isinstance(html_string, bytes) and html_string.startswith(b"<!-- EMBED START"):
+        html_string = b"<p></p>" + html_string
+    elif isinstance(html_string, str) and html_string.startswith("<!-- EMBED START"):
+        html_string = "<p></p>" + html_string
+
+    return lxml_html.fromstring(html_string)
+
+
 EmbedUpdateCallback: TypeAlias = Callable[[dict, lxml_html.HtmlElement, str], bool]
 EmbedUpdateAsyncCallback: TypeAlias = Callable[[dict, lxml_html.HtmlElement, str], Awaitable[bool]]
 
 
-# TODO-PR: Support async callbacks
 async def update_embeds_in_body(
     item,
     update_image_cb: EmbedUpdateCallback | EmbedUpdateAsyncCallback | None = None,
@@ -87,7 +101,7 @@ async def update_embeds_in_body(
     """
 
     body_updated = False
-    root_elem = lxml_html.fromstring(item.get("body_html") or "<p></p>")
+    root_elem = _get_html_from_string(item.get("body_html"))
     for comment, editor_id in iterate_embeds(root_elem, ["Image", "Video", "Audio"]):
         # Assumes the sibling of the Embed Image comment is the figure tag containing the image
         embed_item = (item.get("associations") or {}).get(editor_id) or {}
@@ -184,7 +198,7 @@ def remove_all_embeds(item: dict, remove_by_class: bool = True, remove_media_emb
     if not original_body_html:
         return False  # No body to process, so no changes made
 
-    root_elem = lxml_html.fromstring(original_body_html)
+    root_elem = _get_html_from_string(original_body_html)
 
     if remove_by_class:
         embed_blocks = root_elem.xpath('//div[contains(concat(" ", @class, " "), " embed-block ")]')
@@ -328,10 +342,10 @@ def _remove_or_disable_item_media(
     highlighted: bool = False
     root_elem: HtmlElement
     if item.get("es_highlight", {}).get("body_html", ""):
-        root_elem = lxml_html.fromstring(item.get("es_highlight", {}).get("body_html", "")[0])
+        root_elem = _get_html_from_string(item.get("es_highlight", {}).get("body_html", "")[0])
         highlighted = True
     else:
-        root_elem = lxml_html.fromstring(item.get("body_html", ""))
+        root_elem = _get_html_from_string(item.get("body_html"))
 
     for comment, editor_id in iterate_embeds(root_elem):
         if editor_id in disable_display:

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -71,9 +71,9 @@ def _get_html_from_string(html_string: bytes | str | None) -> HtmlElement:
 
     if not html_string:
         html_string = "<p></p>"
-    elif isinstance(html_string, bytes) and html_string.startswith(b"<!-- EMBED START"):
+    elif isinstance(html_string, bytes) and html_string.startswith(b"<!--"):
         html_string = b"<p></p>" + html_string
-    elif isinstance(html_string, str) and html_string.startswith("<!-- EMBED START"):
+    elif isinstance(html_string, str) and html_string.startswith("<!--"):
         html_string = "<p></p>" + html_string
 
     return lxml_html.fromstring(html_string)

--- a/tests/core/test_wire_embed_permissions.py
+++ b/tests/core/test_wire_embed_permissions.py
@@ -149,3 +149,75 @@ async def test_embed_mark_disable_download(client, app):
             "editor_1": ["display"],
         },
     )
+
+
+async def test_html_starts_with_embed_comment(client, app):
+    app.config["WIRE_EMBED_PERMISSIONS"] = True
+    await login(client, {"email": PUBLIC_USER_EMAIL})
+    await test_utils.update_entries_for(
+        "companies",
+        COMPANY_1_ID,
+        {
+            "embed_permissions": {"video": ["display"], "audio": ["display"], "sd_product": ["display"]},
+        },
+    )
+    await test_utils.add_company_products(
+        app,
+        COMPANY_1_ID,
+        [
+            {
+                "name": "Service A",
+                "is_enabled": True,
+                "query": "service.code: a",
+                "product_type": "wire",
+            },
+            {
+                "name": "product test",
+                "is_enabled": True,
+                "sd_product_id": "123",
+                "product_type": "wire",
+            },
+        ],
+    )
+    await setup_embeds()
+
+    # Update the body_html so it starts with an embed comment
+    item = items[:2][0]
+    await test_utils.update_entries_for(
+        "items",
+        item["_id"],
+        {
+            "body_html": (
+                '<!-- EMBED START Audio {id: "editor_0"} --><figure>'
+                '<audio controls src="/assets/640feb9bfb5122dcf06a6f7c" alt="minns" '
+                'width="100%" height="100%"></audio>'
+                "<figcaption>minns</figcaption>"
+                "</figure>"
+                '<!-- EMBED END Audio {id: "editor_0"} -->'
+                "<p><br></p>"
+                "<p>Par 2</p>"
+                '<!-- EMBED START Video {id: "editor_1"} -->'
+                "<figure>"
+                '<video controls src="/assets/640ff0bdfb5122dcf06a6fc3" '
+                'alt="Scomo text" width="100%" height="100%">'
+                "</video>"
+                "<figcaption>Scomo whinging</figcaption>"
+                "</figure>"
+                '<!-- EMBED END Video {id: "editor_1"} -->'
+                "<p><br></p>Par 3<p></p>"
+                "<p>Par 4</p>"
+            ),
+        },
+        item,
+    )
+    resp = await client.get("/wire/search?type=wire")
+
+    data = await resp.get_json()
+    assert data is not None
+    test_utils.test_embed_permissions(
+        data["_items"][0],
+        {
+            "editor_0": [],
+            "editor_1": ["display"],
+        },
+    )


### PR DESCRIPTION
### Purpose
Processing body_html for embeds fails if the value starts with an embed comment, `<!-- EMBED START`, with the following failure:
```python
root_elem = lxml_html.fromstring(body_html_string)
parent = root_elem.xpath("//comment()")[0].getparent()
assert parent is not None
```
Here `parent` should be the same as `root_elem` but it is None. Otherwise when we run `parent.remove`, it fails.


### What has changed
If the html string starts with an embed comment, prefix it with an empty paragraph (which seems to fix the issue)

Resolves: [SDAN-730](https://sofab.atlassian.net/browse/SDAN-738)


[SDAN-730]: https://sofab.atlassian.net/browse/SDAN-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ