### PR TITLE
set default MAX_CONTENT_LENGTH to 1GB

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -874,3 +874,9 @@ CALENDAR_LOCATIONS_FILTER_OPTIONS = {
     "country": True,
     "place": True,
 }
+
+#: Maximum allowed content length for file uploads (in bytes)
+#:
+#: .. versionadded: 3.0
+#:
+MAX_CONTENT_LENGTH = int(os.environ.get("MAX_CONTENT_LENGTH", 1024 * 1024 * 1000))  # 1GB

--- a/tests/core/test_push.py
+++ b/tests/core/test_push.py
@@ -98,7 +98,7 @@ async def test_push_binary(client):
     resp = await client.post(
         "/push_binary",
         form=dict(media_id=media_id),
-        files={"media": FileStorage(io.BytesIO(b"binary"), filename=media_id)},
+        files={"media": FileStorage(io.BytesIO(1024 * 1024 * 20 * b"b"), filename=media_id)},
     )
     assert 201 == resp.status_code
 


### PR DESCRIPTION
it was 16MB by default

CPCN-1149

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
