### PR TITLE
Fix: sharing from monitoring throwing exception

### DIFF
--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -344,7 +344,7 @@ async def share(request: Request) -> Response:
             "item_name": "Monitoring Report",
         }
         formatter = get_formatter("monitoring_pdf")
-        monitoring_profile["format_type"] = "monitoring_pdf"
+        monitoring_profile.format_type = "monitoring_pdf"
         monitoring_file = await get_monitoring_file(monitoring_profile, items)
         attachment = base64.b64encode(monitoring_file.read())
 


### PR DESCRIPTION
### Purpose
Sharing an item in the Monitoring section was failing, throwing an exception

### What has changed
Correct the assignment of the required formatter_type to the Monitoring profile

### Steps to test
Share an item from the monitoring section as below
<img width="1907" height="466" alt="image" src="https://github.com/user-attachments/assets/969b453f-3915-4844-9348-2f870d4084f6" />

The recipient should receive an email with an attached PDF
<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] This pull request is not adding new forms that use redux
- [x ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
