### PR TITLE
[SDAN-745] All copy to clipboard events being logged are reported as …

### DIFF
--- a/assets/wire/actions.ts
+++ b/assets/wire/actions.ts
@@ -86,8 +86,8 @@ export function openItem(item: any) {
 }
 
 export function selectCopy(item: any) {
-    return () => {
-        recordAction(item, 'clipboard');
+    return (dispatch: any, getState: any) => {
+        recordAction(item, 'clipboard', getState().context, getState());
     };
 }
 


### PR DESCRIPTION
…coming from the wire

### Purpose
Irrespective of which section the item is “in” if part of the text is selected it is reported has being in the “wire” section.

### What has changed
The current section is passed to the recordAction function

### Steps to test
To replicate the issue :- 

- Preview an item in any section other than “The Wire”
- Select some of the text and copy it to clipboard
- Go to the “Subscriber Activity” report and note that the section logged against “Clipboard” event is “The Wire”

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-745]


[SDAN-745]: https://sofab.atlassian.net/browse/SDAN-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ