### PR TITLE
fix - the asset item end point should log downloads

### DIFF
--- a/newsroom/news_api/news/assets/views.py
+++ b/newsroom/news_api/news/assets/views.py
@@ -13,6 +13,7 @@ assets_endpoints = EndpointGroup("assets", __name__)
 
 class RouteParams(BaseModel):
     token: str | None = None
+    item_id: str | None = None
 
 
 class RouteArguments(BaseModel):
@@ -41,8 +42,10 @@ async def get_item(args: RouteArguments, params: RouteParams, request: Request):
     @param request:
     @return:
     """
-
-    return await return_item(args, None, request)
+    response = await return_item(args, None, request=request)
+    if params.item_id is not None:
+        await HistoryService().log_api_media_download(params.item_id, args.asset_id)
+    return response
 
 
 async def return_item(args: RouteArguments, _p: None, request: Request):


### PR DESCRIPTION
### Purpose
The News API asset endpoint should log the download of an asset is the item_id associated with it is passed.
Reflection the old functionality [here](https://github.com/superdesk/newsroom/blob/fa2a2b8afe849fce56d5d828a21690e9b651a4d7/newsroom/news_api/news/assets/assets.py#L32)

### What has changed
If the item_id is found an entry is made in the History collection

### Steps to test

- Ensure Newshub is configured for embedded images and the News API in enabled.
- Publish an item to NewsHub that has an embedded image
- Use the API to retrieve the item using the NINJSFormatter2 format
- Extract the URL for the embedded image, it should have the item_id as a argument.
- Retrieve the image 
- Got to the "Subscriber Activity" report and the image download should have been logged.

<img width="1812" height="137" alt="image" src="https://github.com/user-attachments/assets/0b8aabd1-3404-4040-848d-59a7ef1b8d59" />


<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
