### PR TITLE
SDAN-747 Restrict the formatters available on the News API

### DIFF
--- a/newsroom/news_api/news/item/item.py
+++ b/newsroom/news_api/news/item/item.py
@@ -8,7 +8,7 @@ from superdesk.core.web import EndpointGroup
 from superdesk.utc import utcnow
 
 from newsroom.types import WireItem, SectionEnum
-from newsroom.wire.embeds import apply_company_permissions_to_embeds
+from newsroom.wire.embeds import apply_company_permissions_to_embeds, update_embed_urls, set_association_links
 from newsroom.formatters import get_formatter_by_classname
 from newsroom.settings import get_setting
 from newsroom.news_api.utils import post_api_audit
@@ -30,6 +30,8 @@ class RouteParams(BaseModel):
 async def get_item(args: RouteArguments, params: RouteParams, request: Request) -> Response:
     app = get_current_app()
     formatter = get_formatter_by_classname(params.format)
+    if not formatter or SectionEnum.NEWS_API not in formatter.sections:
+        return await request.abort(400)
 
     item = await WireItem.get_service().find_by_id(args.item_id)
     time_limit = int(get_setting("news_api_time_limit_days") or 0)
@@ -41,6 +43,8 @@ async def get_item(args: RouteArguments, params: RouteParams, request: Request) 
 
     item_dict = item.to_dict()
     await apply_company_permissions_to_embeds([item_dict], SectionEnum.NEWS_API)
+    await update_embed_urls(item_dict, None)
+    set_association_links(item_dict)
     formatted_item = await formatter.format_item(item_dict)
 
     response = app.response_class(response=formatted_item, status=200, mimetype=formatter.MIMETYPE)

--- a/newsroom/wire/formatters/newsmlg2.py
+++ b/newsroom/wire/formatters/newsmlg2.py
@@ -31,7 +31,7 @@ class NewsroomFormatter(SuperdeskFormatter):
 class NewsMLG2Formatter(BaseFormatter):
     format_id = "newsmlg2"
     name = lazy_gettext("NewsMLG2")
-    sections = [SectionEnum.WIRE]
+    sections = [SectionEnum.WIRE, SectionEnum.NEWS_API]
     assets = [FormatterAssetType.TEXT]
 
     MIMETYPE = "application/vnd.iptc.g2.newsitem+xml"

--- a/newsroom/wire/formatters/ninjs.py
+++ b/newsroom/wire/formatters/ninjs.py
@@ -12,7 +12,7 @@ from .base_wire_formatter import BaseWireFormatter
 class NINJSFormatter(BaseWireFormatter):
     format_id = "ninjs"
     name = lazy_gettext("Ninjs")
-    sections = [SectionEnum.WIRE]
+    sections = [SectionEnum.WIRE, SectionEnum.NEWS_API]
 
     MIMETYPE = "application/json"
     FILE_EXTENSION = "json"

--- a/newsroom/wire/formatters/ninjs2.py
+++ b/newsroom/wire/formatters/ninjs2.py
@@ -1,7 +1,8 @@
 from quart_babel import lazy_gettext
 
-from newsroom.wire.embeds import update_embed_urls, set_association_links, remove_internal_renditions
+from newsroom.wire.embeds import remove_internal_renditions
 from .ninjs import NINJSFormatter
+from newsroom.types import SectionEnum
 
 
 class NINJSFormatter2(NINJSFormatter):
@@ -11,11 +12,9 @@ class NINJSFormatter2(NINJSFormatter):
 
     format_id = "ninjs2"
     name = lazy_gettext("Ninjs v2")
-    # No sections this is an API only format
-    sections = []
+    # Sections set this is an API only format
+    sections = [SectionEnum.NEWS_API]
     direct_copy_properties: set[str] = NINJSFormatter.direct_copy_properties.union(["associations"])
 
     async def _transform_to_ninjs(self, item):
-        await update_embed_urls(item)
-        set_association_links(item)
         return remove_internal_renditions(await super()._transform_to_ninjs(item))

--- a/newsroom/wire/formatters/nitf.py
+++ b/newsroom/wire/formatters/nitf.py
@@ -47,7 +47,7 @@ class NewsroomNITFFormatter(SuperdeskNITFFormatter):
 class NITFFormatter(BaseFormatter):
     format_id = "nitf"
     name = lazy_gettext("NITF")
-    sections = [SectionEnum.WIRE]
+    sections = [SectionEnum.WIRE, SectionEnum.NEWS_API]
     assets = [FormatterAssetType.TEXT]
 
     MIMETYPE = "application/xml"

--- a/newsroom/wire/formatters/text.py
+++ b/newsroom/wire/formatters/text.py
@@ -11,7 +11,7 @@ from newsroom.formatters import BaseFormatter, FormatterAssetType
 class TextFormatter(BaseFormatter):
     format_id = "text"
     name = lazy_gettext("Plain Text")
-    sections = [SectionEnum.WIRE, SectionEnum.AGENDA]
+    sections = [SectionEnum.WIRE, SectionEnum.AGENDA, SectionEnum.NEWS_API]
     assets = [FormatterAssetType.TEXT]
 
     FILE_EXTENSION = "txt"


### PR DESCRIPTION
### Purpose
Only a limited set of the Formatters should be available to the News API

### What has changed
Ensures that each Formatter called by the News API item endpoint belongs to the NEWS API section. Also the embedded links needed to be updated in the NINJS formatter.

### Steps to test
Try to retrieve an item using a Wire only format such as some thing like 

http://localhost:5400/api/v1/news/item/urn:newsml:localhost:2025-10-16T12:22:09.434432:269eea59-4135-4c49-9823-db11ad383c49?format=NINJSPackageFormatter

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-747]


[SDAN-747]: https://sofab.atlassian.net/browse/SDAN-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ