### PR TITLE
fix: Loading of Event related Plannings failed to update store

### DIFF
--- a/assets/agenda/actions.ts
+++ b/assets/agenda/actions.ts
@@ -177,6 +177,11 @@ export function recieveItem(data: any) {
     return {type: RECIEVE_ITEM, data};
 }
 
+export const STORE_ITEMS = 'STORE_ITEMS';
+export function storeItems(items: Array<IAgendaItem>) {
+    return {type: STORE_ITEMS, data: items};
+}
+
 export const INIT_DATA = 'INIT_DATA';
 export function initData(agendaData: any, readData: any, activeDate: any, featuredOnly: any) {
     return {type: INIT_DATA, agendaData, readData, activeDate, featuredOnly};
@@ -406,7 +411,7 @@ export function fetchItemsById(ids: Array<string>): Promise<IRestApiResponse<IAg
 export function fetchItemsByIdToRedux(ids: Array<string>): (dispatch: any) => Promise<void> {
     return (dispatch: any) => {
         return fetchItemsById(ids).then((response) => {
-            dispatch(recieveItem(response));
+            dispatch(storeItems(response._items));
         });
     };
 }

--- a/assets/agenda/actions.ts
+++ b/assets/agenda/actions.ts
@@ -172,9 +172,9 @@ export function toggleHiddenGroupItems(dateString: string) {
     return {type: TOGGLE_HIDDEN_GROUP_ITEMS, data: dateString};
 }
 
-export const RECIEVE_ITEM = 'RECIEVE_ITEM';
+export const RECEIVE_ITEM = 'RECEIVE_ITEM';
 export function recieveItem(data: any) {
-    return {type: RECIEVE_ITEM, data};
+    return {type: RECEIVE_ITEM, data};
 }
 
 export const STORE_ITEMS = 'STORE_ITEMS';

--- a/assets/agenda/reducers.ts
+++ b/assets/agenda/reducers.ts
@@ -105,7 +105,7 @@ function receiveItemsFromSearch(state: IAgendaState, data: IRestApiResponse<IAge
 }
 
 function receiveItems(state: IAgendaState, items: Array<IAgendaItem>): IAgendaState {
-    const itemsById = Object.assign({}, state.itemsById);
+    const itemsById = {...state.itemsById};
     const itemIds = items.map((item) => {
         itemsById[item._id] = item;
         return item._id;

--- a/assets/agenda/reducers.ts
+++ b/assets/agenda/reducers.ts
@@ -8,6 +8,7 @@ import {
 } from 'interfaces';
 import {
     RECIEVE_ITEMS,
+    STORE_ITEMS,
     SET_LIST_GROUPS_AND_ITEMS,
     ADD_ITEMS_TO_LIST_GROUPS,
     TOGGLE_HIDDEN_GROUP_ITEMS,
@@ -84,18 +85,12 @@ const initialState: IAgendaState = {
     savedItemsCount: 0,
 };
 
-function recieveItems(state: IAgendaState, data: IRestApiResponse<IAgendaItem>): IAgendaState {
-    const itemsById = Object.assign({}, state.itemsById);
-    const items = data._items.map((item) => {
-        itemsById[item._id] = item;
-        return item._id;
-    });
+function receiveItemsFromSearch(state: IAgendaState, data: IRestApiResponse<IAgendaItem>): IAgendaState {
+    const newState = receiveItems(state, data._items);
 
     return {
-        ...state,
-        items,
-        fetchFrom: items.length,
-        itemsById,
+        ...newState,
+        fetchFrom: newState.items.length,
         listItems: {
             ...state.listItems,
             groups: [],
@@ -106,6 +101,20 @@ function recieveItems(state: IAgendaState, data: IRestApiResponse<IAgendaItem>):
         newItems: [],
         searchInitiated: false,
         loadingAggregations: false,
+    };
+}
+
+function receiveItems(state: IAgendaState, items: Array<IAgendaItem>): IAgendaState {
+    const itemsById = Object.assign({}, state.itemsById);
+    const itemIds = items.map((item) => {
+        itemsById[item._id] = item;
+        return item._id;
+    });
+
+    return {
+        ...state,
+        items: itemIds,
+        itemsById,
     };
 }
 
@@ -161,7 +170,10 @@ export default function agendaReducer(state: IAgendaState = initialState, action
     switch (action.type) {
 
     case RECIEVE_ITEMS:
-        return recieveItems(state, action.data);
+        return receiveItemsFromSearch(state, action.data);
+
+    case STORE_ITEMS:
+        return receiveItems(state, action.data);
 
     case SET_LIST_GROUPS_AND_ITEMS:
         return {

--- a/assets/reducers.ts
+++ b/assets/reducers.ts
@@ -13,7 +13,7 @@ import {
     PREVIEW_ITEM,
     PRINT_ITEMS,
     QUERY_ITEMS,
-    RECIEVE_ITEM,
+    RECEIVE_ITEM,
     RECIEVE_NEXT_ITEMS,
     REMOVE_BOOKMARK,
     SELECT_ALL,
@@ -191,7 +191,7 @@ export function defaultReducer(state: any = {}, action: any) {
         };
     }
 
-    case RECIEVE_ITEM: {
+    case RECEIVE_ITEM: {
         const itemsById = Object.assign({}, state.itemsById);
         itemsById[action.data._id] = action.data;
         return  {...state, itemsById};

--- a/assets/wire/actions.ts
+++ b/assets/wire/actions.ts
@@ -111,9 +111,9 @@ function recieveAggs(data: any) {
     return {type: RECIEVE_AGGS, data};
 }
 
-export const RECIEVE_ITEM = 'RECIEVE_ITEM';
+export const RECEIVE_ITEM = 'RECEIVE_ITEM';
 export function recieveItem(data: any) {
-    return {type: RECIEVE_ITEM, data};
+    return {type: RECEIVE_ITEM, data};
 }
 
 export const INIT_DATA = 'INIT_DATA';

--- a/newsroom/agenda/filters.py
+++ b/newsroom/agenda/filters.py
@@ -171,6 +171,9 @@ def apply_item_type_filter(request: NewshubSearchRequest[AgendaSearchRequestArgs
                 }
             }
         )
+    elif request.args.ids:
+        # This request is for Items by ID, don't apply item type filter
+        return
     elif get_app_config("AGENDA_DEFAULT_FILTER_HIDE_PLANNING"):
         request.search.query.filter.append(
             {


### PR DESCRIPTION
### Purpose
There were 2 bugs with regards to loading an Event's related Planning items (mainly used when opening an Event in preview mode).
* The back-end was applying item_type filter when getting Agenda items by ID (which would exclude the desired Planning items)
* The front-end was failing to add the item to the Redux store (using incorrect Redux action/reducer)

### What has changed
* back-end: When getting Agenda by IDs, and no item_type filter applied, then don't apply default item_type filter
* front-end: Add new Redux action/reducer to store Agenda items (without updating search metadata, such as page, search result count etc)

Related to: [STT-1428](https://sofab.atlassian.net/browse/STT-1428) (discovered while testing Coverage schedule config)


[STT-1428]: https://sofab.atlassian.net/browse/STT-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ