### PR TITLE
[STT-1412] - Fix elastic reindex command (Agenda) and add tests

### DIFF
--- a/newsroom/commands/elastic_reindex.py
+++ b/newsroom/commands/elastic_reindex.py
@@ -1,12 +1,39 @@
 import click
 
-from superdesk.core import get_current_app
+from superdesk.core import get_current_async_app
+
 from .cli import newsroom_cli
+
+
+def elastic_reindex_handler(resource: str, requests_per_second: int = 1000):
+    """
+    Handler function for elastic reindex operation.
+
+    Args:
+        resource: The resource to reindex (must be one of: items, agenda, history)
+        requests_per_second: Number of requests per second for reindexing
+
+    Returns:
+        The result of the elastic reindex operation
+
+    Raises:
+        ValueError: If resource is not one of the allowed values
+    """
+    valid_resources = ("items", "agenda", "history")
+    if resource not in valid_resources:
+        raise ValueError(f"Invalid resource '{resource}'. Must be one of: {', '.join(valid_resources)}")
+
+    return get_current_async_app().elastic.reindex(resource, requests_per_second=requests_per_second)
 
 
 @newsroom_cli.command("elastic_reindex")
 @click.option("-r", "--resource", required=True, help="Resource to reindex")
 @click.option("-s", "--requests-per-second", default=1000, type=int, help="Number of requests per second")
 def elastic_reindex(resource, requests_per_second=1000):
-    assert resource in ("items", "agenda", "history")
-    return get_current_app().data.elastic.reindex(resource, requests_per_second=requests_per_second)
+    """
+    Reindex a specific resource in Elasticsearch.
+
+    This command rebuilds the Elasticsearch index for the specified resource
+    with the ability to control the reindexing speed.
+    """
+    return elastic_reindex_handler(resource, requests_per_second)

--- a/newsroom/tests/test_utils.py
+++ b/newsroom/tests/test_utils.py
@@ -42,11 +42,7 @@ async def get_all(resource: str) -> list[Any]:
     async_app = app.async_app
 
     try:
-        return [
-            # item.to_dict(context={"use_objectid": True})
-            item
-            async for item in async_app.resources.get_resource_service(resource).get_all_raw()
-        ]
+        return [item async for item in async_app.resources.get_resource_service(resource).get_all_raw()]
     except KeyError:
         return [item for item in app.data.find(resource, {})]
 

--- a/tests/commands/test_elastic_reindex.py
+++ b/tests/commands/test_elastic_reindex.py
@@ -1,0 +1,71 @@
+import pytest
+import asyncio
+
+from superdesk.utc import utcnow
+from newsroom.wire import WireItemService
+from newsroom.commands.elastic_reindex import elastic_reindex_handler
+
+from tests.core.utils import create_entries_for, delete_entries_for
+
+
+async def test_invalid_resource_raises_error():
+    """Test that handler raises ValueError for invalid resource"""
+
+    with pytest.raises(ValueError) as exc_info:
+        await elastic_reindex_handler("invalid_resource", 1000)
+
+    assert "Invalid resource 'invalid_resource'" in str(exc_info.value)
+    assert "Must be one of: items, agenda, history" in str(exc_info.value)
+
+
+async def test_empty_resource_raises_error():
+    """Test that handler raises ValueError for empty resource"""
+
+    with pytest.raises(ValueError) as exc_info:
+        await elastic_reindex_handler("", 1000)
+
+    assert "Invalid resource ''" in str(exc_info.value)
+
+
+async def test_reindex_items_preserves_data():
+    """Test that reindex successfully copies data from old ES index to new ES index"""
+
+    test_items = [
+        {
+            "_id": "reindex-item-1",
+            "headline": "Test Reindex Item 1",
+            "versioncreated": utcnow(),
+            "type": "text",
+        },
+        {
+            "_id": "reindex-item-2",
+            "headline": "Test Reindex Item 2",
+            "versioncreated": utcnow(),
+            "type": "text",
+        },
+        {
+            "_id": "reindex-item-3",
+            "headline": "Test Reindex Item 3",
+            "versioncreated": utcnow(),
+            "type": "text",
+        },
+    ]
+    await delete_entries_for("items")
+    await create_entries_for("items", test_items)
+
+    service = WireItemService()
+    cursor = await service.search({})
+    elastic_count = await cursor.count()
+    assert elastic_count == 3, f"ElasticSearch should have 3 items before reindex, found {elastic_count}"
+
+    elastic_reindex_handler("items")
+    await asyncio.sleep(2)  # Give ES time to complete the reindex operation
+
+    cursor = await service.search({})
+    elastic_count = await cursor.count()
+    assert elastic_count == 3, f"ElasticSearch should have 3 items after reindex, found {elastic_count}"
+
+    elastic_results = await cursor.to_list_raw()
+    found_ids = {item["_id"] for item in elastic_results}
+    expected_ids = {"reindex-item-1", "reindex-item-2", "reindex-item-3"}
+    assert found_ids == expected_ids, f"Expected {expected_ids}, got {found_ids}"


### PR DESCRIPTION
### Purpose
To fix the reindex command in newsroom given that it was not working for async services/resources.

### What has changed
- Fixed the `elastic_reindex` command to support async resources/services (agenda).
- Added unit tests for `elastic_reindex_handler` covering invalid resources and data preservation during reindexing.
- Minor cleanup in `test_utils.py` for readability.

### How to test
- Checkout this branch/PR
- Run `python manage.py elastic_reindex --resource agenda` (should also work for `items` and `history`)

Resolves: [STT-1412]


[STT-1412]: https://sofab.atlassian.net/browse/STT-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ