### PR TITLE
SDAN-748 Missing immediate monitoring stories

### DIFF
--- a/newsroom/monitoring/email_alerts.py
+++ b/newsroom/monitoring/email_alerts.py
@@ -34,7 +34,7 @@ from newsroom.history_async import HistoryService
 from .service import MonitoringProfileService
 from .search import MonitoringSearchService, MonitoringSearchRequestArgs
 from .utils import get_monitoring_file, truncate_article_body, get_date_items_dict
-
+from ..wire.embeds import remove_all_embeds
 
 logger = logging.getLogger(__name__)
 
@@ -345,6 +345,7 @@ class MonitoringEmailAlerts:
         companies_service = CompanyServiceAsync()
 
         for monitoring_data in monitoring_list:
+            last_run_time = local_to_utc(get_app_config("DEFAULT_TIMEZONE"), now)
             if monitoring_data.schedule is None:
                 # This should not happen, as we're filtering specifically for monitoring profiles with a schedule
                 # but the schedule is optional, and the type dictates it could be `None`, so trap that scenario here
@@ -372,12 +373,20 @@ class MonitoringEmailAlerts:
                     )
                     continue
 
+                # if immediate set the created from to the time of the last item set in the profile, if available
+                if monitoring_data.schedule.interval == "immediate" and monitoring_data.last_run_time:
+                    start_date = monitoring_data.last_run_time.strftime("%Y-%m-%d")
+                    start_time = monitoring_data.last_run_time.strftime("%H:%M:%S")
+                else:
+                    start_date = created_from
+                    start_time = created_from_time
+
                 search_request = NewshubSearchRequest(
                     args=MonitoringSearchRequestArgs(
                         navigation_ids=[monitoring_data.id],
                         skip_user_validation=True,
-                        start_date=created_from,
-                        start_time=created_from_time,
+                        start_date=start_date,
+                        start_time=start_time,
                     ),
                     company=company,
                 )
@@ -386,7 +395,8 @@ class MonitoringEmailAlerts:
                 # remove any items that have already been sent
                 items[:] = [item for item in items if not await self.already_sent(item, monitoring_data)]
                 template_kwargs = {"profile": monitoring_data.to_dict()}
-
+                for item in items:
+                    remove_all_embeds(item)
                 if items:
                     try:
                         template_kwargs.update(
@@ -462,9 +472,20 @@ class MonitoringEmailAlerts:
                             template_kwargs=template_kwargs,
                         )
 
-            await MonitoringProfileService().update(
-                monitoring_data.id, {"last_run_time": local_to_utc(get_app_config("DEFAULT_TIMEZONE"), now)}
-            )
+                # for immediate schedules we set the last_run_time to the versioncreated of the last item.
+                # with an additional grace period in case an item is late getting to Newshub or previouse run
+                # exceeds the soft time out or dies with the lock!
+                if monitoring_data.schedule.interval == "immediate":
+                    if len(items):
+                        last_article_created = max(parse_date_str(item.get("versioncreated")) for item in items)
+                        if last_article_created:
+                            last_run_time = last_article_created - timedelta(minutes=11)
+                    elif monitoring_data.last_run_time is None:
+                        last_run_time = last_run_time - timedelta(minutes=11)
+                    else:  # don't override the last_run_time if no items were found
+                        last_run_time = None
+            if last_run_time:
+                await MonitoringProfileService().update(monitoring_data.id, {"last_run_time": last_run_time})
 
 
 @celery.task(soft_time_limit=600)

--- a/tests/core/test_monitoring.py
+++ b/tests/core/test_monitoring.py
@@ -800,7 +800,7 @@ async def test_last_run_time_always_updated_with_matching_content_immediate(clie
         w = await find_one_by_id("monitoring", "5db11ec55f627d8aa0b545fb")
         assert w is not None
         assert w.get("last_run_time") is not None
-        assert w["last_run_time"] > (mock_utcnow() - timedelta(minutes=5))
+        assert w["last_run_time"] > (mock_utcnow() - timedelta(minutes=15))
 
 
 @mock.patch("newsroom.email.send_email", mock_send_email)
@@ -856,7 +856,7 @@ async def test_last_run_time_always_updated_with_matching_content_scheduled(clie
 
 
 @mock.patch("newsroom.email.send_email", mock_send_email)
-async def test_last_run_time_always_updated_with_no_matching_content_immediate(client, app):
+async def test_last_run_time_does_not_update_with_no_matching_content_immediate(client, app):
     await create_entries_for(
         "items",
         [
@@ -1214,8 +1214,7 @@ async def test_send_immediate_email_alerts(client, app):
         assert outbox[0].sender == "newsroom@localhost"
         assert outbox[0].subject == "Monitoring Subject"
         assert "Something after the embed" in outbox[0].body
-        ## TODO When code to remove the embeds from email is ported
-        # assert 'Assistant Treasurer' not in outbox[0].body
+        assert "Assistant Treasurer" not in outbox[0].body
         assert "Newsroom Monitoring: W1" in outbox[0].body
 
 


### PR DESCRIPTION
### Purpose
The aim is to resolve an issue where articles matching immediate monitoring profiles are sporadically missed and fail to generate email alerts.

### What has changed

The immediate monitoring profile's 'last_run_time' is set with an 11-minute offset before the most recent item's creation time. This offset serves as a grace period, chosen specifically because it safely exceeds the Celery task's soft time limit and the job lock's timeout duration.

This design accounts for two potential issues:

Items delayed in the Superdesk queue for more than a minute may be missed by the immediate monitoring alert.

Rarely, the alert job runs for more than a minute (evidenced by the log message: "Monitoring email alerts task already running").

### Steps to test
Create an immediate monitoring profile that will send an email to a know email address.
Create an publish a story from Superdesk that will match the profile,
Publish the story to  Newshub finding some way to delay the transmission of an item in the Superdesk queue to Newshub for more than a minute and less than 11 minutes.
Ensure that once the item is received by Newshub an email from the profile is sent.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #SDAN-748
