### PR TITLE
[SDAN-741] fix(newsapi): Only register required web endpoints

### DIFF
--- a/features/mgmt_api/mgmt_api.feature
+++ b/features/mgmt_api/mgmt_api.feature
@@ -31,11 +31,11 @@ Feature: Management API
                     },
                     {
                         "href": "companies/<regex('[a-f0-9]{24}'):company_id>/products",
-                        "title": "update_company_products"
+                        "title": "Update Company Products"
                     },
                     {
                         "href": "companies/<regex('[a-f0-9]{24}'):company_id>/products",
-                        "title": "get_company_products_endpoint"
+                        "title": "Get Company Products Endpoint"
                     }
                 ]
         }}

--- a/newsroom/companies/module.py
+++ b/newsroom/companies/module.py
@@ -3,10 +3,10 @@ from typing import Any
 from typing_extensions import TypedDict
 
 from superdesk.core.app import SuperdeskAsyncApp
-from superdesk.core.config import ConfigModel
 from superdesk.core.module import Module
 from superdesk.core.web import EndpointGroup
 
+from newsroom.core import NewshubModuleConfig
 from .companies_async import company_resource_config
 
 
@@ -20,7 +20,7 @@ class CompanyType(CompanyTypeBase, total=False):
     wire_must_not: dict[str, Any]
 
 
-class CompanyConfigs(ConfigModel):
+class CompanyConfigs(NewshubModuleConfig):
     company_types: list[CompanyType] = []
 
 
@@ -31,6 +31,9 @@ def init_module(app: SuperdeskAsyncApp):
             "WIRE_EMBED_PERMISSIONS", True
         )
 
+    if company_configs.register_endpoints:
+        app.wsgi.register_endpoint(company_endpoints)
+
 
 company_endpoints = EndpointGroup("companies", __name__)
 company_configs = CompanyConfigs()
@@ -38,6 +41,6 @@ module = Module(
     name="newsroom.companies",
     config=company_configs,
     resources=[company_resource_config],
-    endpoints=[company_endpoints],
+    endpoints=[],
     init=init_module,
 )

--- a/newsroom/core/__init__.py
+++ b/newsroom/core/__init__.py
@@ -1,8 +1,15 @@
 from typing import cast
+
 from superdesk.core import get_current_app
+from superdesk.core.config import ConfigModel
 
 
 def get_current_wsgi_app():
     from newsroom.web.factory import NewsroomWebApp
 
     return cast(NewsroomWebApp, get_current_app())
+
+
+class NewshubModuleConfig(ConfigModel):
+    register_endpoints: bool = True
+    register_settings: bool = True

--- a/newsroom/history_async.py
+++ b/newsroom/history_async.py
@@ -7,6 +7,7 @@ from quart_babel import gettext
 import logging
 
 from superdesk.core.types import Request, Response
+from superdesk.core.app import SuperdeskAsyncApp
 from superdesk.core.module import Module
 from superdesk.core.resources import (
     ResourceConfig,
@@ -20,6 +21,7 @@ from superdesk.utc import utcnow
 from superdesk.flask import abort
 
 from newsroom.types import HistoryResourceModel, UserResourceModel, SectionEnum, WireItem
+from newsroom.core import NewshubModuleConfig
 from newsroom.auth.utils import get_company_or_none_from_request
 from newsroom.core.resources.service import NewshubAsyncResourceService
 from newsroom import MONGO_PREFIX, ELASTIC_PREFIX
@@ -221,10 +223,18 @@ history_resource_config = ResourceConfig(
 history_endpoint = EndpointGroup("history", __name__)
 
 
+def init_module(app: SuperdeskAsyncApp):
+    if history_config.register_endpoints:
+        app.wsgi.register_endpoint(history_endpoint)
+
+
+history_config = NewshubModuleConfig()
 module = Module(
     name="newsroom.history_async",
+    config=history_config,
     resources=[history_resource_config],
-    endpoints=[history_endpoint],
+    endpoints=[],
+    init=init_module,
 )
 
 

--- a/newsroom/news_api/default_settings.py
+++ b/newsroom/news_api/default_settings.py
@@ -8,6 +8,7 @@ from newsroom.web.default_settings import (  # noqa
     CONTENTAPI_ELASTICSEARCH_SETTINGS,
     CLIENT_URL,
     AUTH_PROVIDERS,  # Required otherwise NewsAPI behave tests fail on ``company.validate_auth_provider``
+    LOG_CONFIG_FILE,
 )
 
 SITE_NAME = env("SITE_NAME", "NEWSHUB")
@@ -27,17 +28,16 @@ CORE_APPS = [
     "content_api.items_versions",
     "newsroom.news_api.section_filters",
     "newsroom.news_api.news",
-    "newsroom.history",
 ]
 
 MODULES = [
     "newsroom.assets.module",
-    "newsroom.companies",
-    "newsroom.history_async",
+    ("newsroom.companies", dict(register_endpoints=False)),
+    ("newsroom.history_async", dict(register_endpoints=False)),
     # Register ``settings`` module, so we can call ``get_setting`` in NewsAPI
     ("newsroom.settings", dict(register_endpoints=False, register_settings=False)),
-    "newsroom.wire.module",
-    "newsroom.section_filters",
+    ("newsroom.wire.module", dict(register_endpoints=False)),
+    ("newsroom.section_filters", dict(register_endpoints=False)),
     "newsroom.news_api.news.assets",
     "newsroom.news_api.news.atom",
     "newsroom.news_api.news.rss",
@@ -45,7 +45,7 @@ MODULES = [
     "newsroom.news_api.news.feed",
     "newsroom.news_api.api_audit",
     "newsroom.news_api.news.item.item",
-    "newsroom.products",
+    ("newsroom.products", dict(register_endpoints=False)),
     "newsroom.news_api.products",
 ]
 

--- a/newsroom/news_api/news/assets/views.py
+++ b/newsroom/news_api/news/assets/views.py
@@ -22,7 +22,12 @@ class RouteArguments(BaseModel):
     token: str | None = None
 
 
-@assets_endpoints.endpoint("assets/<path:asset_id>/<item_id>", methods=["GET"], auth=[support_auth_token_in_url])
+@assets_endpoints.endpoint(
+    "assets/<path:asset_id>/<item_id>",
+    title="Download Asset (with Wire ID)",
+    methods=["GET"],
+    auth=[support_auth_token_in_url],
+)
 async def download(args: RouteArguments, params: RouteParams, request: Request):
     """
     Called on download of a media item, keeps a record of the download
@@ -33,7 +38,12 @@ async def download(args: RouteArguments, params: RouteParams, request: Request):
     return response
 
 
-@assets_endpoints.endpoint("assets/<string:asset_id>", methods=["GET"], auth=[support_auth_token_in_url])
+@assets_endpoints.endpoint(
+    "assets/<string:asset_id>",
+    title="Download Asset",
+    methods=["GET"],
+    auth=[support_auth_token_in_url],
+)
 async def get_item(args: RouteArguments, params: RouteParams, request: Request):
     """
     Get media item via the assets endpoint

--- a/newsroom/news_api/news/atom/views.py
+++ b/newsroom/news_api/news/atom/views.py
@@ -11,11 +11,21 @@ class AtomArgs(BaseModel):
     token: str | None = None
 
 
-@atom_endpoints.endpoint("atom/<path:token>", methods=["GET"], auth=[support_auth_token_in_url])
+@atom_endpoints.endpoint(
+    "atom/<path:token>",
+    title="ATOM Feed (URL auth)",
+    methods=["GET"],
+    auth=[support_auth_token_in_url],
+)
 async def get_atom_token(args: AtomArgs, params: None, request: Request) -> Response:
     return await AtomFormatter().format_feed(args.token, request)
 
 
-@atom_endpoints.endpoint("atom", methods=["GET"], auth=[support_auth_token_in_url])
+@atom_endpoints.endpoint(
+    "atom",
+    title="ATOM Feed (Header auth)",
+    methods=["GET"],
+    auth=[support_auth_token_in_url],
+)
 async def get_atom_authed(args: None, params: AtomArgs, request: Request) -> Response:
     return await AtomFormatter().format_feed(params.token, request)

--- a/newsroom/news_api/news/feed/views.py
+++ b/newsroom/news_api/news/feed/views.py
@@ -6,6 +6,6 @@ from .service import NewsAPIFeedSearchService
 news_api_feed_endpoints = EndpointGroup("news_api_feed", __name__)
 
 
-@news_api_feed_endpoints.endpoint("news/feed", methods=["GET"])
+@news_api_feed_endpoints.endpoint("news/feed", title="News Search", methods=["GET"])
 async def news_api_search(request: Request):
     return await NewsAPIFeedSearchService().process_web_request(request)

--- a/newsroom/news_api/news/item/item.py
+++ b/newsroom/news_api/news/item/item.py
@@ -26,7 +26,7 @@ class RouteParams(BaseModel):
     format: str = "NINJSFormatter"
 
 
-@news_item_endpoints.endpoint("news/item/<path:item_id>", methods=["GET"])
+@news_item_endpoints.endpoint("news/item/<path:item_id>", title="Get News Item", methods=["GET"])
 async def get_item(args: RouteArguments, params: RouteParams, request: Request) -> Response:
     app = get_current_app()
     formatter = get_formatter_by_classname(params.format)

--- a/newsroom/news_api/news/rss/views.py
+++ b/newsroom/news_api/news/rss/views.py
@@ -11,11 +11,21 @@ class RSSArgs(BaseModel):
     token: str | None = None
 
 
-@rss_endpoints.endpoint("rss/<path:token>", methods=["GET"], auth=[support_auth_token_in_url])
+@rss_endpoints.endpoint(
+    "rss/<path:token>",
+    title="RSS Feed (URL auth)",
+    methods=["GET"],
+    auth=[support_auth_token_in_url],
+)
 async def get_rss_token(args: RSSArgs, params: None, request: Request) -> Response:
     return await RSSFormatter().format_feed(args.token, request)
 
 
-@rss_endpoints.endpoint("rss", methods=["GET"], auth=[support_auth_token_in_url])
+@rss_endpoints.endpoint(
+    "rss",
+    title="RSS Feed (Header auth)",
+    methods=["GET"],
+    auth=[support_auth_token_in_url],
+)
 async def get_rss_authed(args: None, params: RSSArgs, request: Request) -> Response:
     return await RSSFormatter().format_feed(params.token, request)

--- a/newsroom/news_api/news/search/views.py
+++ b/newsroom/news_api/news/search/views.py
@@ -6,6 +6,6 @@ from ..search_service import NewsApiSearchServiceAsync
 news_api_search_endpoints = EndpointGroup("news_api_search", __name__)
 
 
-@news_api_search_endpoints.endpoint("news/search", methods=["GET"])
+@news_api_search_endpoints.endpoint("news/search", title="News Feed", methods=["GET"])
 async def news_api_search(request: Request):
     return await NewsApiSearchServiceAsync().process_web_request(request)

--- a/newsroom/news_api/products.py
+++ b/newsroom/news_api/products.py
@@ -27,7 +27,7 @@ def get_product_links(product: ProductResourceModel) -> dict[str, Any]:
     }
 
 
-@product_endpoints.endpoint("account/products", methods=["GET"])
+@product_endpoints.endpoint("account/products", title="Account Products Search", methods=["GET"])
 async def get_products(request: Request) -> Response:
     company = get_company_from_newsapi_request(request)
     products = await get_products_by_company_async(company, None, SectionEnum.NEWS_API)
@@ -57,7 +57,7 @@ class GetProductArgs(BaseModel):
     product_id: ObjectId
 
 
-@product_endpoints.endpoint("account/products/<string:product_id>")
+@product_endpoints.endpoint("account/products/<string:product_id>", title="Get Account Product")
 async def get_product(args: GetProductArgs, params: None, request: Request) -> Response:
     company = get_company_from_newsapi_request(request)
     company_product_ids = [product._id for product in company.products if product.section == SectionEnum.NEWS_API]

--- a/newsroom/products/__init__.py
+++ b/newsroom/products/__init__.py
@@ -8,6 +8,7 @@ from superdesk.core.resources import ResourceConfig
 
 from newsroom import MONGO_PREFIX
 from newsroom.types import ProductResourceModel
+from newsroom.core import NewshubModuleConfig
 
 from . import products
 from .service import ProductsService
@@ -31,11 +32,15 @@ __all__ = [
 
 
 def init_module(app: SuperdeskAsyncApp):
-    app.wsgi.settings_app("products", lazy_gettext("Products"), weight=400, data=get_settings_data)
+    if products_config.register_settings:
+        app.wsgi.settings_app("products", lazy_gettext("Products"), weight=400, data=get_settings_data)
 
     # TODO-ASYNC: Remove when products is fully async
     products.products_service = products.ProductsService("products", superdesk.get_backend())
     products.ProductsResource("products", app.wsgi, products.products_service)
+
+    if products_config.register_endpoints:
+        app.wsgi.register_endpoint(products_endpoints)
 
 
 products_resource_config = ResourceConfig(
@@ -46,9 +51,11 @@ products_resource_config = ResourceConfig(
     mongo=MongoResourceConfig(prefix=MONGO_PREFIX),
 )
 
+products_config = NewshubModuleConfig()
 module = Module(
     name="newsroom.products",
     resources=[products_resource_config],
+    config=products_config,
     init=init_module,
-    endpoints=[products_endpoints],
+    endpoints=[],
 )

--- a/newsroom/section_filters/module.py
+++ b/newsroom/section_filters/module.py
@@ -1,10 +1,12 @@
 from quart_babel import lazy_gettext
 
-from newsroom import MONGO_PREFIX
-from newsroom.types import SectionFilterModel
-from newsroom.web.factory import NewsroomWebApp
 from superdesk.core.module import Module
 from superdesk.core.resources import ResourceConfig, MongoIndexOptions, MongoResourceConfig
+
+from newsroom import MONGO_PREFIX
+from newsroom.types import SectionFilterModel
+from newsroom.core import NewshubModuleConfig
+from newsroom.web.factory import NewsroomWebApp
 
 from .service import SectionFiltersService
 from .views import get_settings_data, section_filters_endpoints
@@ -29,17 +31,23 @@ section_filters_config = ResourceConfig(
 
 
 def init_module(app: NewsroomWebApp):
-    app.wsgi.settings_app(
-        "section-filters",
-        lazy_gettext("Section Filters"),
-        weight=450,
-        data=get_settings_data,
-    )
+    if section_filter_config.register_settings:
+        app.wsgi.settings_app(
+            "section-filters",
+            lazy_gettext("Section Filters"),
+            weight=450,
+            data=get_settings_data,
+        )
+
+    if section_filter_config.register_endpoints:
+        app.wsgi.register_endpoint(section_filters_endpoints)
 
 
+section_filter_config = NewshubModuleConfig()
 module = Module(
     name="newsroom.section_filters",
     resources=[section_filters_config],
-    endpoints=[section_filters_endpoints],
+    endpoints=[],
+    config=section_filter_config,
     init=init_module,
 )

--- a/newsroom/settings/__init__.py
+++ b/newsroom/settings/__init__.py
@@ -4,8 +4,8 @@ from typing import cast
 from quart_babel import lazy_gettext
 
 from superdesk.core.module import Module, SuperdeskAsyncApp
-from superdesk.core.config import ConfigModel
 
+from newsroom.core import NewshubModuleConfig
 from .views import settings_endpoints
 from .resource import register_resource, get_setting, get_client_config, get_settings_collection
 
@@ -99,12 +99,7 @@ class SettingsApp:
         return {}
 
 
-class SettingsModuleConfig(ConfigModel):
-    register_endpoints: bool = True
-    register_settings: bool = True
-
-
-settings_module_config = SettingsModuleConfig()
+settings_module_config = NewshubModuleConfig()
 module = Module(
     name="newsroom.settings",
     init=init_app,

--- a/newsroom/wire/module.py
+++ b/newsroom/wire/module.py
@@ -4,6 +4,7 @@ from superdesk.core.web import EndpointGroup
 
 from newsroom import MONGO_PREFIX, ELASTIC_PREFIX
 from newsroom.types import WireItem
+from newsroom.core import NewshubModuleConfig
 from newsroom.formatters import register_formatter
 
 from .service import WireItemService
@@ -73,7 +74,17 @@ def init_module(app: SuperdeskAsyncApp) -> None:
     if app.wsgi.config.get("ALLOW_PICTURE_DOWNLOAD", True):
         register_formatter(PictureFormatter)
 
+    if wire_module_config.register_endpoints:
+        app.wsgi.register_endpoint(wire_endpoints)
 
-module = Module("newsroom.wire", endpoints=[wire_endpoints], resources=[wire_items_resource_config], init=init_module)
+
+wire_module_config = NewshubModuleConfig()
+module = Module(
+    "newsroom.wire",
+    endpoints=[],
+    resources=[wire_items_resource_config],
+    init=init_module,
+    config=wire_module_config,
+)
 
 from . import views  # noqa

--- a/tests/news_api/test_news_api.py
+++ b/tests/news_api/test_news_api.py
@@ -1,0 +1,30 @@
+from bson import ObjectId
+
+from tests.core.utils import create_entries_for, find_one_for
+
+
+async def test_news_api_root_links(client, app):
+    company_id = ObjectId()
+    await create_entries_for(
+        "companies",
+        [{"_id": company_id, "name": "Test Company", "is_enabled": True}],
+    )
+    await create_entries_for("news_api_tokens", [{"company": company_id, "enabled": True}])
+    token = await find_one_for("news_api_tokens", company=company_id)
+
+    response = await client.get("/api/v1", headers={"Authorization": token.get("token")})
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert {child["href"]: child["title"] for child in data["_links"]["child"]} == {
+        "assets/<path:asset_id>/<item_id>": "Download Asset (with Wire ID)",
+        "assets/<string:asset_id>": "Download Asset",
+        "atom/<path:token>": "ATOM Feed (URL auth)",
+        "atom": "ATOM Feed (Header auth)",
+        "rss/<path:token>": "RSS Feed (URL auth)",
+        "rss": "RSS Feed (Header auth)",
+        "news/search": "News Feed",
+        "news/feed": "News Search",
+        "news/item/<path:item_id>": "Get News Item",
+        "account/products": "Account Products Search",
+        "account/products/<string:product_id>": "Get Account Product",
+    }


### PR DESCRIPTION
### Purpose
For the NewsAPI, there were loads of web endpoints that expose CRUD operations for system resources (such as companies, section filters etc). This exposes a security issue, as the NewsAPI is about read-only news feeds.

### What has changed
* Create a common NewshubModuleConfig
* Use that config on modules where their WebEndpoints are not required in NewsAPI
* Update NewsAPI `MODULES` config to exclude WebEndpoints for system resources

Resolves: [SDAN-741](https://sofab.atlassian.net/browse/SDAN-741)


[SDAN-741]: https://sofab.atlassian.net/browse/SDAN-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ