### PR TITLE
Fix gallery card text visibility

### DIFF
--- a/assets/components/cards/render/MediaGalleryCard.tsx
+++ b/assets/components/cards/render/MediaGalleryCard.tsx
@@ -23,7 +23,7 @@ const getMediaPanel = (item: IArticle, picture: IArticle | null, openItem: any, 
                         <span>{shortDate(item.versioncreated)}</span>
                     </div>
                 </div>
-                <h4 className='card-title'>{item.headline}</h4>
+                <h4 className='card-title card-title--overlaid'>{item.headline}</h4>
                 <Embargo item={item} isCard={true} />
             </div>
         </div>

--- a/assets/components/cards/render/PhotoGalleryCard.tsx
+++ b/assets/components/cards/render/PhotoGalleryCard.tsx
@@ -8,7 +8,7 @@ const getMediaPanel = (photo: any, index: any) => {
             onClick={()=>{window.open(photo.href,'_blank');}}>
             <img className='card-img-top' src={photo.media_url} alt={photo.description} />
             <div className='card-body'>
-                <h4 className='card-title'>{photo.description}</h4>
+                <h4 className='card-title card-title--overlaid'>{photo.description}</h4>
             </div>
         </div>
     </div>);


### PR DESCRIPTION
### Purpose
This change resolves a readability issue within the Dashboard Galleries. Previously, text displayed directly over the top of images was difficult to read, which negatively impacted user experience.

### What has changed
An additional class has been added to the element displaying the text "card-title--overlaid"

In the application theme the following style definition is used to invert the text colour.

```
/* Invert the text colour when it overlays an image */
.card-title--overlaid {
    color: var(--color-text--inverse) !important;
}
```

### Steps to test
Create a 4-media-gallery entry on the home page and publish an item that will be displayed on the home page by matching the associated product definition.

Before 
<img width="1405" height="389" alt="image" src="https://github.com/user-attachments/assets/b80b70ad-352e-4804-9641-096364127ed3" />

and 

<img width="659" height="419" alt="image" src="https://github.com/user-attachments/assets/e4a93934-616d-4fc3-94ba-0412c4a7dca7" />


After
<img width="1408" height="399" alt="image" src="https://github.com/user-attachments/assets/0b3be07d-93c1-4214-801c-4c62a3975202" />

and

<img width="566" height="411" alt="image" src="https://github.com/user-attachments/assets/d8ed4bb4-6431-4d41-966c-bb6daf46705a" />



### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
