### PR TITLE
[STT-1431] - Changes required to support hiding Coverage schedule

### DIFF
--- a/assets/agenda/components/AgendaCoverages.tsx
+++ b/assets/agenda/components/AgendaCoverages.tsx
@@ -22,6 +22,7 @@ interface IProps {
     hideViewContentItems?: Array<IArticle['_id']>;
     previewConfig?: IAgendaPreviewConfig;
     onClick?(): void;
+    restrictCoverageInfo?: boolean;
 }
 
 export default function AgendaCoverages({
@@ -33,6 +34,7 @@ export default function AgendaCoverages({
     onClick,
     hideViewContentItems,
     previewConfig,
+    restrictCoverageInfo,
 }: IProps) {
     if (coverages == null || coverages.length === 0) {
         return null;
@@ -50,7 +52,7 @@ export default function AgendaCoverages({
                         <i
                             className={`icon--coverage-${getCoverageIcon(coverage.coverage_type)} me-2`}
                             key={coverage.coverage_id}
-                            title={getCoverageTooltip(coverage)}
+                            title={getCoverageTooltip(coverage, undefined, restrictCoverageInfo)}
                         />
                     ))}
                 </div>
@@ -84,6 +86,7 @@ export default function AgendaCoverages({
                                         actions={actions}
                                         user={user}
                                         hideViewContentItems={hideViewContentItems}
+                                        restrictCoverageInfo={restrictCoverageInfo}
                                         fullCoverage={
                                             (item.planning_items || [])
                                                 .find((planningItem) => planningItem._id === coverage.planning_id)

--- a/assets/agenda/components/AgendaList.tsx
+++ b/assets/agenda/components/AgendaList.tsx
@@ -123,6 +123,7 @@ interface IStateProps {
     hiddenGroupsShown: {[dateString: string]: boolean};
     itemTypeFilter: IAgendaState['agenda']['itemType'];
     activeSortQuery: string;
+    restrictCoverageInfo: boolean;
 }
 
 interface IDispatchProps {
@@ -385,6 +386,7 @@ class AgendaList extends React.Component<IProps, IState> {
                                     resetActioningItem={this.resetActioningItem}
                                     showShortcutActionIcons={showShortcutActionIcons}
                                     listConfig={this.props.listConfig}
+                                    restrictCoverageInfo={this.props.restrictCoverageInfo}
                                 />
                             ))}
                         </React.Fragment>
@@ -411,6 +413,7 @@ class AgendaList extends React.Component<IProps, IState> {
                             resetActioningItem={this.resetActioningItem}
                             showShortcutActionIcons={showShortcutActionIcons}
                             listConfig={this.props.listConfig}
+                            restrictCoverageInfo={this.props.restrictCoverageInfo}
                         />
                     );
                 })}
@@ -497,6 +500,7 @@ const mapStateToProps = (state: IAgendaState): IStateProps => ({
     hiddenGroupsShown: hiddenGroupsShownSelector(state),
     itemTypeFilter: state.agenda?.itemType,
     activeSortQuery: state.search.activeSortQuery || '',
+    restrictCoverageInfo: state.agenda.restrictCoverageInfo,
 });
 
 const mapDispatchToProps: IDispatchProps = {

--- a/assets/agenda/components/AgendaListCoverageItem.tsx
+++ b/assets/agenda/components/AgendaListCoverageItem.tsx
@@ -20,6 +20,7 @@ interface IProps {
     user: IUser['_id'];
     coverage: ICoverage;
     showBorder?: boolean;
+    restrictCoverageInfo?: boolean;
 }
 
 interface IState {
@@ -59,7 +60,7 @@ class AgendaListCoverageItem extends React.Component<IProps, IState> {
             isWatched: watched,
             watchText: watchText,
             isCoverageForExtraDay: isCoverageForExtraDay(this.props.coverage, this.props.group),
-            tooltip: `${watchText} ${getCoverageTooltip(this.props.coverage, beingUpdated)}`,
+            tooltip: `${watchText} ${getCoverageTooltip(this.props.coverage, beingUpdated, this.props.restrictCoverageInfo)}`,
         };
     }
 

--- a/assets/agenda/components/AgendaListItem.tsx
+++ b/assets/agenda/components/AgendaListItem.tsx
@@ -39,6 +39,7 @@ interface IProps {
     planningId?: IAgendaItem['_id'];
     showShortcutActionIcons: boolean;
     listConfig: IListConfig;
+    restrictCoverageInfo?: boolean;
 
     onClick(item: IAgendaItem, date: string, planningId?: IAgendaItem['_id']): void;
     onDoubleClick(item: IAgendaItem, date: string, planningId?: IAgendaItem['_id']): void;
@@ -351,6 +352,7 @@ class AgendaListItem extends React.Component<IProps> {
                             isMobilePhone={isMobile}
                             user={this.props.user}
                             listConfig={listConfig}
+                            restrictCoverageInfo={this.props.restrictCoverageInfo}
                         />
 
                         {(isMobile || isExtended) && description && (

--- a/assets/agenda/components/AgendaListItemIcons.tsx
+++ b/assets/agenda/components/AgendaListItemIcons.tsx
@@ -30,6 +30,7 @@ interface IProps {
     row?: boolean;
     isMobilePhone?: boolean;
     listConfig: IListConfig;
+    restrictCoverageInfo?: boolean;
 }
 
 interface IState {
@@ -120,6 +121,7 @@ class AgendaListItemIcons extends React.Component<IProps, IState> {
                                 showBorder={props.isMobilePhone && index === state.coveragesToDisplay.length - 1}
                                 group={props.group}
                                 planningItem={props.planningItem}
+                                restrictCoverageInfo={props.restrictCoverageInfo}
                             />
                         ))}
                     </div>

--- a/assets/agenda/components/AgendaPreviewCoverages.tsx
+++ b/assets/agenda/components/AgendaPreviewCoverages.tsx
@@ -61,6 +61,7 @@ class AgendaPreviewCoverages extends React.Component<IProps, IState> {
                             actions={actions}
                             user={user}
                             previewConfig={this.props.previewConfig}
+                            restrictCoverageInfo={restrictCoverageInfo}
                         />
                     </PreviewBox>
                 )}
@@ -74,6 +75,7 @@ class AgendaPreviewCoverages extends React.Component<IProps, IState> {
                             actions={actions}
                             user={user}
                             previewConfig={this.props.previewConfig}
+                            restrictCoverageInfo={restrictCoverageInfo}
                         />
                     </PreviewBox>
                 )}
@@ -139,6 +141,7 @@ class AgendaPreviewCoverages extends React.Component<IProps, IState> {
                                     actions={actions}
                                     user={user}
                                     previewConfig={this.props.previewConfig}
+                                    restrictCoverageInfo={restrictCoverageInfo}
                                 />
                             </PreviewBox>
                         )}
@@ -152,6 +155,7 @@ class AgendaPreviewCoverages extends React.Component<IProps, IState> {
                                     actions={actions}
                                     user={user}
                                     previewConfig={this.props.previewConfig}
+                                    restrictCoverageInfo={restrictCoverageInfo}
                                 />
                             </PreviewBox>
                         )}

--- a/assets/agenda/components/AgendaPreviewPlanning.tsx
+++ b/assets/agenda/components/AgendaPreviewPlanning.tsx
@@ -137,6 +137,7 @@ class AgendaPreviewPlanningComponent extends React.Component<IProps, IState> {
                                 user={user}
                                 previewGroup={previewGroup}
                                 previewConfig={previewConfig}
+                                restrictCoverageInfo={restrictCoverageInfo}
                             />
                         </div>
                     </div>

--- a/assets/agenda/components/preview/coverage/CoverageMetadataPreviewHeader.tsx
+++ b/assets/agenda/components/preview/coverage/CoverageMetadataPreviewHeader.tsx
@@ -12,13 +12,13 @@ import {
     WORKFLOW_COLORS,
 } from 'agenda/utils';
 
-export function CoverageMetadataPreviewHeader({coverage}: ICoverageMetadataPreviewProps) {
+export function CoverageMetadataPreviewHeader({coverage, restrictCoverageInfo}: ICoverageMetadataPreviewProps) {
     const slugline = coverage.slugline || '';
 
     return (
         <div
             className='coverage-item__row coverage-item__row--header-row'
-            title={getCoverageTooltip(coverage, isCoverageBeingUpdated(coverage))}
+            title={getCoverageTooltip(coverage, isCoverageBeingUpdated(coverage), restrictCoverageInfo)}
         >
             <span
                 className={classNames('coverage-item__coverage-icon', WORKFLOW_COLORS[coverage.workflow_status])}>

--- a/assets/agenda/reducers.ts
+++ b/assets/agenda/reducers.ts
@@ -74,6 +74,7 @@ const initialState: IAgendaState = {
         itemType: undefined,
         featuredOnly: false,
         agendaWireItems: [],
+        restrictCoverageInfo: false,
     },
     search: searchReducer(undefined, undefined, 'agenda'),
     detail: false,

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -989,7 +989,7 @@ export function formatCoverageDate(coverage: ICoverage) {
         parseDate(coverage.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
 }
 
-export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
+export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCoverageInfo?: boolean) => {
     const slugline = coverage.item_slugline || coverage.slugline;
     const coverageType = getCoverageDisplayName(coverage.coverage_type);
     const coverageScheduled = moment(coverage.scheduled);
@@ -1010,21 +1010,37 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any) => {
             assignedDetails,
         });
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ASSIGNED) {
-        return gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
-            type: coverageType,
-            slugline: slugline,
-            date: formatDate(coverageScheduled),
-            time: formatTime(coverageScheduled),
-            assignedDetails,
-        });
+        if (restrictCoverageInfo) {
+            return gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                assignedDetails,
+            });
+        } else {
+            return gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                date: formatDate(coverageScheduled),
+                time: formatTime(coverageScheduled),
+                assignedDetails,
+            });
+        }
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ACTIVE) {
-        return gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
-            type: coverageType,
-            slugline: slugline,
-            date: formatDate(coverageScheduled),
-            time: formatTime(coverageScheduled),
-            assignedDetails,
-        });
+        if (restrictCoverageInfo) {
+            return gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                assignedDetails,
+            });
+        } else {
+            return gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                date: formatDate(coverageScheduled),
+                time: formatTime(coverageScheduled),
+                assignedDetails,
+            });
+        }
     } else if (coverage.workflow_status === WORKFLOW_STATUS.CANCELLED) {
         return gettext('{{ type }} coverage {{slugline}} cancelled {{assignedDetails}}', {
             type: coverageType,

--- a/assets/interfaces/agenda.ts
+++ b/assets/interfaces/agenda.ts
@@ -294,6 +294,7 @@ export interface IAgendaState {
         itemType?: 'events' | 'planning';
         featuredOnly: boolean;
         agendaWireItems: Array<IArticle>;
+        restrictCoverageInfo: boolean;
     };
     search: ISearchState;
     detail: boolean;
@@ -348,4 +349,5 @@ export interface ICoverageMetadataPreviewProps {
     actions?: Array<ICoverageItemAction>;
     user?: IUser['_id'];
     hideViewContentItems?: Array<IArticle['_id']>;
+    restrictCoverageInfo?: boolean;
 }


### PR DESCRIPTION
### Purpose
This PR uses `restrictCoverageInfo` to hide scheduled date and time from coverage tooltips when the company has coverage info restrictions set as true.

### What has changed
- Updated `getCoverageTooltip()` function to have the `restrictCoverageInfo` variable
- Modified tooltip logic to exclude scheduled date/time for active/assigned coverage statuses
- Added prop through needed components hierarchy to pass the flag to the tooltip function

### Steps to test
1. Set up a company with Restrict Coverage Info permission set to True.
2. Navigate to Agenda section
3. Hover over coverage icons in list items and preview panels
4. Verify tooltips show coverage info without scheduled times
5. Test with company that has Restrict Coverage Info permission set to False, to ensure normal details show

Resolves: #[STT-1431](https://sofab.atlassian.net/browse/STT-1431)


[STT-1431]: https://sofab.atlassian.net/browse/STT-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ