### PR TITLE
[STT-1431] - Changes required to support hiding Coverage schedule 

### DIFF
--- a/assets/agenda/components/preview/coverage/CoverageExpectedDate.tsx
+++ b/assets/agenda/components/preview/coverage/CoverageExpectedDate.tsx
@@ -5,11 +5,11 @@ import {formatCoverageDate, WORKFLOW_STATUS} from 'agenda/utils';
 import {gettext} from 'utils';
 
 export function CoverageExpectedDate({coverage}: ICoverageMetadataPreviewProps) {
-    if (coverage.workflow_status === WORKFLOW_STATUS.COMPLETED || coverage.scheduled == null) {
+    if (coverage.workflow_status === WORKFLOW_STATUS.COMPLETED) {
         return null;
     }
 
-    return (
+    return coverage.scheduled ? (
         <div
             className='coverage-item__row align-items-center'
         >
@@ -18,5 +18,5 @@ export function CoverageExpectedDate({coverage}: ICoverageMetadataPreviewProps) 
                 <span className=''>{formatCoverageDate(coverage)}</span>
             </span>
         </div>
-    );
+    ) : null;
 }

--- a/assets/agenda/components/preview/coverage/CoverageScheduledStatus.tsx
+++ b/assets/agenda/components/preview/coverage/CoverageScheduledStatus.tsx
@@ -16,13 +16,15 @@ export function CoverageScheduledStatus({coverage, fullCoverage}: ICoverageMetad
         return null;
     }
 
-    const dateString = moment(scheduledUpdate.planning.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
+    const dateString = scheduledUpdate.planning.scheduled ? 
+        moment(scheduledUpdate.planning.scheduled).format(COVERAGE_DATE_TIME_FORMAT) : 
+        null;
 
-    return (
+    return dateString ? (
         <div className='coverage-item__row'>
             <span>
                 {gettext('Updated expected @ {{dateString}}', {dateString: dateString})}
             </span>
         </div>
-    );
+    ) : null;
 }

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -993,7 +993,7 @@ export function formatCoverageDate(coverage: ICoverage) {
         parseDate(coverage.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
 }
 
-export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCoverageInfo?: boolean) => {
+const prepareTooltipData = (coverage: any) => {
     const slugline = coverage.item_slugline || coverage.slugline;
     const coverageType = getCoverageDisplayName(coverage.coverage_type);
     const coverageScheduled = coverage.scheduled ? moment(coverage.scheduled) : null;
@@ -1004,71 +1004,78 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCo
         desk ? gettext('desk: {{name}}', {name: desk}) : '',
     ].filter((x) => x !== '').join(', ');
 
-    if (coverage.coverage_status !== COVERAGE_INTENDED) {
-        return get(DRAFT_STATUS_TEXTS, coverage.coverage_status, '');
-    } else if (coverage.workflow_status === WORKFLOW_STATUS.DRAFT) {
+    return {slugline, coverageType, coverageScheduled, assignedDetails};
+};
+
+const handleStatus = (coverage: any, data: any, beingUpdated?: any, restrictCoverageInfo?: boolean) => {
+    const {slugline, coverageType, coverageScheduled, assignedDetails} = data;
+    const {workflow_status} = coverage;
+
+    switch (workflow_status) {
+    case WORKFLOW_STATUS.DRAFT:
         return gettext('{{ type }} coverage {{ slugline }} {{ status_text }} {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,
             status_text: getCoverageStatusText(coverage),
             assignedDetails,
         });
-    } else if (coverage.workflow_status === WORKFLOW_STATUS.ASSIGNED) {
+
+    case WORKFLOW_STATUS.ASSIGNED:
         if (restrictCoverageInfo) {
             return gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
                 type: coverageType,
                 slugline: slugline,
                 assignedDetails,
             });
-        } else {
-            return coverageScheduled ? 
-                gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
-                    type: coverageType,
-                    slugline: slugline,
-                    date: formatDate(coverageScheduled),
-                    time: formatTime(coverageScheduled),
-                    assignedDetails,
-                }) :
-                gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
-                    type: coverageType,
-                    slugline: slugline,
-                    assignedDetails,
-                });
         }
-    } else if (coverage.workflow_status === WORKFLOW_STATUS.ACTIVE) {
+        return coverageScheduled ? 
+            gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                date: formatDate(coverageScheduled),
+                time: formatTime(coverageScheduled),
+                assignedDetails,
+            }) :
+            gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                assignedDetails,
+            });
+
+    case WORKFLOW_STATUS.ACTIVE:
         if (restrictCoverageInfo) {
             return gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
                 type: coverageType,
                 slugline: slugline,
                 assignedDetails,
             });
-        } else {
-            return coverageScheduled ? 
-                gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
-                    type: coverageType,
-                    slugline: slugline,
-                    date: formatDate(coverageScheduled),
-                    time: formatTime(coverageScheduled),
-                    assignedDetails,
-                }) :
-                gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
-                    type: coverageType,
-                    slugline: slugline,
-                    assignedDetails,
-                });
         }
-    } else if (coverage.workflow_status === WORKFLOW_STATUS.CANCELLED) {
+        return coverageScheduled ? 
+            gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                date: formatDate(coverageScheduled),
+                time: formatTime(coverageScheduled),
+                assignedDetails,
+            }) :
+            gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                assignedDetails,
+            });
+
+    case WORKFLOW_STATUS.CANCELLED:
         return gettext('{{ type }} coverage {{slugline}} cancelled {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,
             assignedDetails,
         });
-    } else if (coverage.workflow_status === WORKFLOW_STATUS.COMPLETED) {
+
+    case WORKFLOW_STATUS.COMPLETED: {
         let deliveryState: any;
         if (get(coverage, 'deliveries.length', 0) > 1) {
             deliveryState = beingUpdated ? gettext('(update to come)') : gettext('(updated)');
         }
-
         return gettext('{{ type }} coverage {{ slugline }} available {{deliveryState}} {{assignedDetails}}', {
             type: coverageType,
             slugline: slugline,
@@ -1077,7 +1084,18 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCo
         });
     }
 
-    return gettext('{{ type }} coverage {{assignedDetails}}', {type: coverageType, assignedDetails});
+    default:
+        return gettext('{{ type }} coverage {{assignedDetails}}', {type: coverageType, assignedDetails});
+    }
+};
+
+export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCoverageInfo?: boolean) => {
+    if (coverage.coverage_status !== COVERAGE_INTENDED) {
+        return get(DRAFT_STATUS_TEXTS, coverage.coverage_status, '');
+    }
+
+    const data = prepareTooltipData(coverage);
+    return handleStatus(coverage, data, beingUpdated, restrictCoverageInfo);
 };
 
 function getScheduleType(item: IAgendaItem): string {

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -1008,12 +1008,6 @@ const handleStatus = (coverage: any, data: any, beingUpdated?: any, restrictCove
     const {workflow_status} = coverage;
 
     const showScheduledInfo = !restrictCoverageInfo && coverageScheduled;
-    const scheduledText = showScheduledInfo
-        ? gettext(', expected {{date}} at {{time}}', {
-            date: formatDate(coverageScheduled),
-            time: formatTime(coverageScheduled),
-        })
-        : '';
 
     switch (workflow_status) {
     case WORKFLOW_STATUS.DRAFT:
@@ -1025,20 +1019,38 @@ const handleStatus = (coverage: any, data: any, beingUpdated?: any, restrictCove
         });
 
     case WORKFLOW_STATUS.ASSIGNED:
-        return gettext('Planned {{ type }} coverage {{ slugline }}{{scheduledText}} {{assignedDetails}}', {
-            type: coverageType,
-            slugline: slugline,
-            scheduledText,
-            assignedDetails,
-        });
+        if (showScheduledInfo) {
+            return gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                date: formatDate(coverageScheduled),
+                time: formatTime(coverageScheduled),
+                assignedDetails,
+            });
+        } else {
+            return gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                assignedDetails,
+            });
+        }
 
     case WORKFLOW_STATUS.ACTIVE:
-        return gettext('{{ type }} coverage {{ slugline }} in progress{{scheduledText}} {{assignedDetails}}', {
-            type: coverageType,
-            slugline: slugline,
-            scheduledText,
-            assignedDetails,
-        });
+        if (showScheduledInfo) {
+            return gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                date: formatDate(coverageScheduled),
+                time: formatTime(coverageScheduled),
+                assignedDetails,
+            });
+        } else {
+            return gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
+                type: coverageType,
+                slugline: slugline,
+                assignedDetails,
+            });
+        }
 
     case WORKFLOW_STATUS.CANCELLED:
         return gettext('{{ type }} coverage {{slugline}} cancelled {{assignedDetails}}', {

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -984,10 +984,6 @@ export function isItemTBC(item: IAgendaItem): boolean {
  * @return {String}
  */
 export function formatCoverageDate(coverage: ICoverage) {
-    if (!coverage.scheduled) {
-        return TO_BE_CONFIRMED_TEXT;
-    }
-
     return get(coverage, TO_BE_CONFIRMED_FIELD) ?
         `${parseDate(coverage.scheduled).format(COVERAGE_DATE_FORMAT)} ${TO_BE_CONFIRMED_TEXT}` :
         parseDate(coverage.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
@@ -1011,6 +1007,14 @@ const handleStatus = (coverage: any, data: any, beingUpdated?: any, restrictCove
     const {slugline, coverageType, coverageScheduled, assignedDetails} = data;
     const {workflow_status} = coverage;
 
+    const showScheduledInfo = !restrictCoverageInfo && coverageScheduled;
+    const scheduledText = showScheduledInfo
+        ? gettext(', expected {{date}} at {{time}}', {
+            date: formatDate(coverageScheduled),
+            time: formatTime(coverageScheduled),
+        })
+        : '';
+
     switch (workflow_status) {
     case WORKFLOW_STATUS.DRAFT:
         return gettext('{{ type }} coverage {{ slugline }} {{ status_text }} {{assignedDetails}}', {
@@ -1021,48 +1025,20 @@ const handleStatus = (coverage: any, data: any, beingUpdated?: any, restrictCove
         });
 
     case WORKFLOW_STATUS.ASSIGNED:
-        if (restrictCoverageInfo) {
-            return gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                assignedDetails,
-            });
-        }
-        return coverageScheduled ? 
-            gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                date: formatDate(coverageScheduled),
-                time: formatTime(coverageScheduled),
-                assignedDetails,
-            }) :
-            gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                assignedDetails,
-            });
+        return gettext('Planned {{ type }} coverage {{ slugline }}{{scheduledText}} {{assignedDetails}}', {
+            type: coverageType,
+            slugline: slugline,
+            scheduledText,
+            assignedDetails,
+        });
 
     case WORKFLOW_STATUS.ACTIVE:
-        if (restrictCoverageInfo) {
-            return gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                assignedDetails,
-            });
-        }
-        return coverageScheduled ? 
-            gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                date: formatDate(coverageScheduled),
-                time: formatTime(coverageScheduled),
-                assignedDetails,
-            }) :
-            gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                assignedDetails,
-            });
+        return gettext('{{ type }} coverage {{ slugline }} in progress{{scheduledText}} {{assignedDetails}}', {
+            type: coverageType,
+            slugline: slugline,
+            scheduledText,
+            assignedDetails,
+        });
 
     case WORKFLOW_STATUS.CANCELLED:
         return gettext('{{ type }} coverage {{slugline}} cancelled {{assignedDetails}}', {

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -984,6 +984,10 @@ export function isItemTBC(item: IAgendaItem): boolean {
  * @return {String}
  */
 export function formatCoverageDate(coverage: ICoverage) {
+    if (!coverage.scheduled) {
+        return TO_BE_CONFIRMED_TEXT;
+    }
+
     return get(coverage, TO_BE_CONFIRMED_FIELD) ?
         `${parseDate(coverage.scheduled).format(COVERAGE_DATE_FORMAT)} ${TO_BE_CONFIRMED_TEXT}` :
         parseDate(coverage.scheduled).format(COVERAGE_DATE_TIME_FORMAT);
@@ -992,7 +996,7 @@ export function formatCoverageDate(coverage: ICoverage) {
 export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCoverageInfo?: boolean) => {
     const slugline = coverage.item_slugline || coverage.slugline;
     const coverageType = getCoverageDisplayName(coverage.coverage_type);
-    const coverageScheduled = moment(coverage.scheduled);
+    const coverageScheduled = coverage.scheduled ? moment(coverage.scheduled) : null;
     const assignee = getCoverageAsigneeName(coverage);
     const desk = getCoverageDeskName(coverage);
     const assignedDetails = [
@@ -1017,13 +1021,19 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCo
                 assignedDetails,
             });
         } else {
-            return gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                date: formatDate(coverageScheduled),
-                time: formatTime(coverageScheduled),
-                assignedDetails,
-            });
+            return coverageScheduled ? 
+                gettext('Planned {{ type }} coverage {{ slugline }}, expected {{date}} at {{time}} {{assignedDetails}}', {
+                    type: coverageType,
+                    slugline: slugline,
+                    date: formatDate(coverageScheduled),
+                    time: formatTime(coverageScheduled),
+                    assignedDetails,
+                }) :
+                gettext('Planned {{ type }} coverage {{ slugline }} {{assignedDetails}}', {
+                    type: coverageType,
+                    slugline: slugline,
+                    assignedDetails,
+                });
         }
     } else if (coverage.workflow_status === WORKFLOW_STATUS.ACTIVE) {
         if (restrictCoverageInfo) {
@@ -1033,13 +1043,19 @@ export const getCoverageTooltip = (coverage: any, beingUpdated?: any, restrictCo
                 assignedDetails,
             });
         } else {
-            return gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
-                type: coverageType,
-                slugline: slugline,
-                date: formatDate(coverageScheduled),
-                time: formatTime(coverageScheduled),
-                assignedDetails,
-            });
+            return coverageScheduled ? 
+                gettext('{{ type }} coverage {{ slugline }} in progress, expected {{date}} at {{time}} {{assignedDetails}}', {
+                    type: coverageType,
+                    slugline: slugline,
+                    date: formatDate(coverageScheduled),
+                    time: formatTime(coverageScheduled),
+                    assignedDetails,
+                }) :
+                gettext('{{ type }} coverage {{ slugline }} in progress {{assignedDetails}}', {
+                    type: coverageType,
+                    slugline: slugline,
+                    assignedDetails,
+                });
         }
     } else if (coverage.workflow_status === WORKFLOW_STATUS.CANCELLED) {
         return gettext('{{ type }} coverage {{slugline}} cancelled {{assignedDetails}}', {


### PR DESCRIPTION
### Purpose
This PR adds to the previous [PR](https://github.com/superdesk/newsroom-core/pull/1396) on the same ticket to make sure where coverage is null it is handled gracefully

### What has changed
- Added null checks for `coverage.scheduled` to be handled gracefully
- Refactored `getCoverageTooltip` from nested if-else to be more cleaner

Resolves: #[STT-1431](https://sofab.atlassian.net/browse/STT-1431)


[STT-1431]: https://sofab.atlassian.net/browse/STT-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ