### PR TITLE
[SDAN-749] Product endpoint returns error

### DIFF
--- a/newsroom/news_api/news/filters.py
+++ b/newsroom/news_api/news/filters.py
@@ -35,16 +35,20 @@ async def prefill_products(request: NewshubSearchRequest[NewsApiSearchRequestArg
     products_service = ProductsService()
     assert request.company is not None
 
+    company_products = await get_products_by_company_async(request.company, product_type=request.section)
+    company_products_ids = set(item.id for item in company_products)
     if request.args.product_ids:
         cursor = await products_service.find(
-            {"is_enabled": True, "companies": request.company.id, "_id": {"$in": request.args.product_ids}},
+            {"is_enabled": True, "_id": {"$in": request.args.product_ids}},
         )
         request.products = await cursor.to_list()
         valid_product_ids = set(item.id for item in request.products)
-        if not all(product in valid_product_ids for product in request.args.product_ids):
+        if not all(product in valid_product_ids for product in request.args.product_ids) or not all(
+            product in company_products_ids for product in request.args.product_ids
+        ):
             raise BadParameterValueError(gettext("Bad product value"))
     else:
-        request.products = await get_products_by_company_async(request.company, product_type=request.section)
+        request.products = company_products
 
 
 def validate_page(request: NewshubSearchRequest[NewsApiSearchRequestArgs]):

--- a/tests/news_api/test_news_api.py
+++ b/tests/news_api/test_news_api.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
-
-from tests.core.utils import create_entries_for, find_one_for
+from newsroom.types import SectionEnum
+from tests.core.utils import create_entries_for, find_one_for, update_entries_for
 
 
 async def test_news_api_root_links(client, app):
@@ -28,3 +28,80 @@ async def test_news_api_root_links(client, app):
         "account/products": "Account Products Search",
         "account/products/<string:product_id>": "Get Account Product",
     }
+
+
+async def test_product_search(client, app):
+    company_id = ObjectId()
+    product_id = ObjectId()
+    company = await create_entries_for(
+        "companies",
+        [
+            {
+                "_id": company_id,
+                "name": "Test Company",
+                "is_enabled": True,
+                "products": [{"_id": product_id, "section": SectionEnum.NEWS_API}],
+            }
+        ],
+    )
+    await create_entries_for(
+        "products",
+        [
+            {
+                "_id": product_id,
+                "name": "Test Product",
+                "is_enabled": True,
+                "product_type": SectionEnum.NEWS_API,
+                "query": "*",
+            }
+        ],
+    )
+    await create_entries_for("news_api_tokens", [{"company": company_id, "enabled": True}])
+    token = await find_one_for("news_api_tokens", company=company_id)
+    response = await client.get("/api/v1/account/products", headers={"Authorization": token.get("token")})
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["_items"][0].get("_id") == str(product_id)
+    response = await client.get(f"/api/v1/account/products/{product_id}", headers={"Authorization": token.get("token")})
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data.get("_links").get("search").get("href") == f"news/search/?products={product_id}"
+    assert data.get("_links").get("feed").get("href") == f"news/feed/?products={product_id}"
+    response = await client.get(
+        f"/api/v1/news/search/?products={product_id}", headers={"Authorization": token.get("token")}
+    )
+    assert response.status_code == 200
+    bad_product = ObjectId()
+    response = await client.get(
+        f"/api/v1/news/search/?products={bad_product}", headers={"Authorization": token.get("token")}
+    )
+    assert response.status_code == 400
+
+    wire_product = ObjectId()
+    await update_entries_for(
+        "companies",
+        company_id,
+        {
+            "products": [
+                {"_id": product_id, "section": SectionEnum.NEWS_API},
+                {"_id": wire_product, "section": SectionEnum.WIRE},
+            ]
+        },
+        company,
+    )
+    await create_entries_for(
+        "products",
+        [
+            {
+                "_id": wire_product,
+                "name": "Test Product",
+                "is_enabled": True,
+                "product_type": SectionEnum.WIRE,
+                "query": "*",
+            }
+        ],
+    )
+    response = await client.get(
+        f"/api/v1/news/search/?products={wire_product}", headers={"Authorization": token.get("token")}
+    )
+    assert response.status_code == 400

--- a/tests/news_api/test_news_api.py
+++ b/tests/news_api/test_news_api.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 from newsroom.types import SectionEnum
-from tests.core.utils import create_entries_for, find_one_for, update_entries_for
+from tests.core.utils import create_entries_for, find_one_for
 
 
 async def test_news_api_root_links(client, app):
@@ -32,15 +32,20 @@ async def test_news_api_root_links(client, app):
 
 async def test_product_search(client, app):
     company_id = ObjectId()
-    product_id = ObjectId()
-    company = await create_entries_for(
+    api_product_id = ObjectId()
+    wire_product_id = ObjectId()
+    await create_entries_for(
         "companies",
         [
             {
                 "_id": company_id,
                 "name": "Test Company",
                 "is_enabled": True,
-                "products": [{"_id": product_id, "section": SectionEnum.NEWS_API}],
+                "products": [
+                    {"_id": api_product_id, "section": SectionEnum.NEWS_API},
+                    {"_id": wire_product_id, "section": SectionEnum.WIRE.value},
+                ],
+                "sections": {"news_api": True, "wire": True},
             }
         ],
     )
@@ -48,60 +53,54 @@ async def test_product_search(client, app):
         "products",
         [
             {
-                "_id": product_id,
-                "name": "Test Product",
+                "_id": api_product_id,
+                "name": "Test API Product",
                 "is_enabled": True,
                 "product_type": SectionEnum.NEWS_API,
                 "query": "*",
-            }
+            },
+            {
+                "_id": wire_product_id,
+                "name": "Test Wire Product",
+                "is_enabled": True,
+                "product_type": SectionEnum.WIRE,
+                "query": "*",
+            },
         ],
     )
     await create_entries_for("news_api_tokens", [{"company": company_id, "enabled": True}])
     token = await find_one_for("news_api_tokens", company=company_id)
+
+    # Ask for all products ensure we only get one, the api one!
     response = await client.get("/api/v1/account/products", headers={"Authorization": token.get("token")})
     assert response.status_code == 200
     data = await response.get_json()
-    assert data["_items"][0].get("_id") == str(product_id)
-    response = await client.get(f"/api/v1/account/products/{product_id}", headers={"Authorization": token.get("token")})
-    assert response.status_code == 200
-    data = await response.get_json()
-    assert data.get("_links").get("search").get("href") == f"news/search/?products={product_id}"
-    assert data.get("_links").get("feed").get("href") == f"news/feed/?products={product_id}"
+    assert data["_items"][0].get("_id") == str(api_product_id)
+    assert data["_items"][0].get("name") == "Test API Product"
+    assert len(data["_items"]) == 1
+
+    # Request the details of that product to ensure we get the feed and the search endpoint references
     response = await client.get(
-        f"/api/v1/news/search/?products={product_id}", headers={"Authorization": token.get("token")}
+        f"/api/v1/account/products/{api_product_id}", headers={"Authorization": token.get("token")}
     )
     assert response.status_code == 200
+    data = await response.get_json()
+    assert data.get("_links").get("search").get("href") == f"news/search/?products={api_product_id}"
+    assert data.get("_links").get("feed").get("href") == f"news/feed/?products={api_product_id}"
+    response = await client.get(
+        f"/api/v1/news/search/?products={api_product_id}", headers={"Authorization": token.get("token")}
+    )
+    assert response.status_code == 200
+
+    # Ensure you can't jus make up a product
     bad_product = ObjectId()
     response = await client.get(
         f"/api/v1/news/search/?products={bad_product}", headers={"Authorization": token.get("token")}
     )
     assert response.status_code == 400
 
-    wire_product = ObjectId()
-    await update_entries_for(
-        "companies",
-        company_id,
-        {
-            "products": [
-                {"_id": product_id, "section": SectionEnum.NEWS_API},
-                {"_id": wire_product, "section": SectionEnum.WIRE},
-            ]
-        },
-        company,
-    )
-    await create_entries_for(
-        "products",
-        [
-            {
-                "_id": wire_product,
-                "name": "Test Product",
-                "is_enabled": True,
-                "product_type": SectionEnum.WIRE,
-                "query": "*",
-            }
-        ],
-    )
+    # Ensure an error is returned for none API products
     response = await client.get(
-        f"/api/v1/news/search/?products={wire_product}", headers={"Authorization": token.get("token")}
+        f"/api/v1/news/search/?products={wire_product_id}", headers={"Authorization": token.get("token")}
     )
     assert response.status_code == 400


### PR DESCRIPTION
### Purpose
This fixes an error where the search and feed endpoints of the News API would fail when passed a legitimate product id.

### What has changed
The passed product id is now checked against the products allowed for the company against the company rather than against the company list held by the product record which it seems is now redundant.

### Steps to test
Make a request for the top level response for the News API  http://HOST:PORT/api/v1/ and note the response contains the reference "href": "account/products"

Make the corresponding account products request http://HOST:PORT/api/v1/account/products and note a response for  a product e.g. "href": "news/search/?products=682a88a47fa16b095c2712eb"

Make a request for that product e.g. http://HOST:PORT/api/v1/news/search/?products=682a88a47fa16b095c2712eb and note a none error response.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-749]


[SDAN-749]: https://sofab.atlassian.net/browse/SDAN-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ