### PR TITLE
[STT-1431] - Changes required to support hiding Coverage schedule

### DIFF
--- a/assets/agenda/components/AgendaApp.tsx
+++ b/assets/agenda/components/AgendaApp.tsx
@@ -385,7 +385,7 @@ const mapStateToProps = (state: any) => ({
     activeDate: get(state, 'agenda.activeDate'),
     activeGrouping: get(state, 'agenda.activeGrouping'),
     eventsOnlyAccess: get(state, 'agenda.eventsOnlyAccess', false),
-    restrictCoverageInfo: get(state, 'agenda.restrictCoverageInfo', false),
+    restrictCoverageInfo: state.agenda ? state.agenda.restrictCoverageInfo : false,
     itemTypeFilter: get(state, 'agenda.itemType'),
     detail: get(state, 'detail', false),
     savedItemsCount: state.savedItemsCount,

--- a/assets/wire/components/AgendaLinks.tsx
+++ b/assets/wire/components/AgendaLinks.tsx
@@ -95,7 +95,8 @@ export default class AgendaLinks extends React.PureComponent<any, any> {
                             coverages={coverages}
                             wireItems={agendaWireItems}
                             onClick={this.openAgenda}
-                            hideViewContentItems={[get(this.props, 'item._id')]} />
+                            hideViewContentItems={[get(this.props, 'item._id')]}
+                            restrictCoverageInfo={this.props.restrictCoverageInfo} />
                     </div>
                 </PreviewBox>}
             </Fragment>
@@ -110,4 +111,5 @@ AgendaLinks.propTypes = {
         coverage_id: PropTypes.string,
     }),
     preview: PropTypes.bool,
+    restrictCoverageInfo: PropTypes.bool,
 };

--- a/assets/wire/components/ItemDetails.tsx
+++ b/assets/wire/components/ItemDetails.tsx
@@ -46,6 +46,7 @@ interface IProps {
     followStory: any;
     listConfig: any;
     filterGroupLabels: any;
+    restrictCoverageInfo?: boolean;
 }
 function ItemDetails({
     item,
@@ -58,6 +59,7 @@ function ItemDetails({
     followStory,
     listConfig,
     filterGroupLabels,
+    restrictCoverageInfo,
 }: IProps) {
     const featureMedia = getFeatureMedia(item);
     const media = getOtherMedia(item);
@@ -144,7 +146,7 @@ function ItemDetails({
                                 <ListItemPreviousVersions item={item} displayConfig={detailsConfig} isPreview={true}/>
                             }
 
-                            {isDisplayed('agenda_links', detailsConfig) && <AgendaLinks item={item} />}
+                            {isDisplayed('agenda_links', detailsConfig) && <AgendaLinks item={item} restrictCoverageInfo={restrictCoverageInfo} />}
                         </ArticleContentInfoWrapper>
                     </ArticleContentWrapper>
                 </ArticleContent>
@@ -161,6 +163,7 @@ ItemDetails.propTypes = {
     listConfig: PropTypes.object,
     detailsConfig: PropTypes.object,
     filterGroupLabels: PropTypes.object,
+    restrictCoverageInfo: PropTypes.bool,
 
     onClose: PropTypes.func,
     downloadMedia: PropTypes.func,

--- a/assets/wire/components/WireApp.tsx
+++ b/assets/wire/components/WireApp.tsx
@@ -373,7 +373,7 @@ const mapStateToProps = (state: any) => ({
     filterGroupLabels: filterGroupsToLabelMap(state),
     errorMessage: state.errorMessage,
     dateFilters: state.dateFilters,
-    restrictCoverageInfo: !!get(state, 'restrictCoverageInfo', false)
+    restrictCoverageInfo: state.restrictCoverageInfo ? state.restrictCoverageInfo : false
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/assets/wire/components/WireApp.tsx
+++ b/assets/wire/components/WireApp.tsx
@@ -149,6 +149,7 @@ class WireApp extends SearchBase<any> {
                 followStory={this.props.followStory}
                 onClose={() => this.props.actions.filter((a: any) => a.id === 'open')[0].action(null)}
                 filterGroupLabels={this.props.filterGroupLabels}
+                restrictCoverageInfo={this.props.restrictCoverageInfo}
             />] : [
                 <section key="contentHeader" className='content-header'>
                     <h3 className="a11y-only">{gettext('{{wire}} Content', window.sectionNames)}</h3>
@@ -332,6 +333,7 @@ WireApp.propTypes = {
     showSaveTopic: PropTypes.bool,
     filterGroupLabels: PropTypes.object,
     dateFilters: PropTypes.arrayOf(PropTypes.object),
+    restrictCoverageInfo: PropTypes.bool,
 };
 
 const mapStateToProps = (state: any) => ({
@@ -370,7 +372,8 @@ const mapStateToProps = (state: any) => ({
     showSaveTopic: showSaveTopicSelector(state),
     filterGroupLabels: filterGroupsToLabelMap(state),
     errorMessage: state.errorMessage,
-    dateFilters: state.dateFilters
+    dateFilters: state.dateFilters,
+    restrictCoverageInfo: !!get(state, 'restrictCoverageInfo', false)
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/assets/wire/reducers.ts
+++ b/assets/wire/reducers.ts
@@ -173,6 +173,7 @@ export default function wireReducer(state: any = initialState, action: any) {
             bookmarks: action.wireData.bookmarks || false,
             formats: action.wireData.formats || [],
             secondaryFormats: get(action, 'wireData.secondary_formats') || [],
+            restrictCoverageInfo: action.wireData.company?.restrict_coverage_info || false,
             wire: Object.assign({}, state.wire, {
                 newsOnly: action.newsOnly,
                 searchAllVersions: action.searchAllVersions,

--- a/newsroom/agenda/utils.py
+++ b/newsroom/agenda/utils.py
@@ -11,6 +11,7 @@ from newsroom.gettext import get_session_locale
 from newsroom.notifications import push_notification
 from newsroom.companies.companies_async import CompanyService
 from newsroom.template_filters import time_short, parse_date, format_datetime
+from newsroom.agenda.filters import PRIVATE_FIELDS
 
 DAY_IN_MINUTES = 24 * 60 - 1
 TO_BE_CONFIRMED_FIELD = "_time_to_be_confirmed"
@@ -149,6 +150,11 @@ def remove_fields_for_public_user(item):
         for c in coverages:
             c.pop("internal_note", None)
             c.get("planning", {}).pop("internal_note", None)
+            # Handle additional PRIVATE_FIELDS for coverages if defined
+            for field in PRIVATE_FIELDS:
+                if field.startswith("coverages.") and field != "coverages":
+                    coverage_field = field.split(".", 1)[1]
+                    c.pop(coverage_field, None)
 
     item.get("event", {}).pop("files", None)
     item.get("event", {}).pop("internal_note", None)

--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -386,6 +386,10 @@ async def related_wire_items(args: RelatedWireUrlArgs, params: None, request: Re
     if company and company.restrict_coverage_info:
         remove_restricted_coverage_info([agenda_item])
 
+    user = get_user_from_request(None)
+    if not user.is_admin_or_internal():
+        remove_fields_for_public_user(agenda_item)
+
     wire_ids = []
     for cov in agenda_item.get("coverages") or []:
         if cov.get("coverage_type") == "text" and cov.get("delivery_id"):


### PR DESCRIPTION
This PR adds logic to also remove the private fields when requesting individual agenda item from the /agenda/wire_items endpoint. Also, pass restrictCoverageInfo into AgendaCoverages in that component.

Resolves: #[STT-1431](https://sofab.atlassian.net/browse/STT-1431)


[STT-1431]: https://sofab.atlassian.net/browse/STT-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ