### PR TITLE
[STT-1455] - Fix newshub `initialize_data` command to handle `ui_config.json` loading

### DIFF
--- a/newsroom/commands/initialize_data.py
+++ b/newsroom/commands/initialize_data.py
@@ -94,7 +94,7 @@ class AppInitializeWithDataCommand:
 
             except Exception as ex:
                 logger.exception(ex)
-                logger.error("Unexpected error processing entity %s", name)
+                logger.error("Exception loading entity %s", name)
 
         logger.info("Data import finished")
         return 0

--- a/newsroom/commands/initialize_data.py
+++ b/newsroom/commands/initialize_data.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from superdesk.core import get_current_app
 from apps.prepopulate.app_initialize import import_file
 from .cli import newsroom_cli
+from .utils import async_entity_import
 
 from .elastic_rebuild import elastic_rebuild
 
@@ -63,16 +64,37 @@ class AppInitializeWithDataCommand:
 
         for name in entity_name:
             try:
-                (file_name, index_params, do_patch) = __entities__[name]
+                try:
+                    (file_name, index_params, do_patch) = __entities__[name]
+                except KeyError:
+                    logger.warning("Entity %s not configured in __entities__, skipping", name)
+                    continue
+
+                file_found = False
+                file_path = None
                 for path in data_paths:
                     if path.joinpath(file_name).exists():
-                        import_file(name, path, file_name, index_params, do_patch, force)
+                        file_found = True
+                        file_path = path
                         break
-            except KeyError:
-                continue
+
+                if not file_found:
+                    logger.warning("Data file %s not found for entity %s", file_name, name)
+                    continue
+
+                try:
+                    if name in ["ui_config"]:
+                        await async_entity_import(name, file_path, file_name, index_params, do_patch, force)
+                    else:
+                        import_file(name, file_path, file_name, index_params, do_patch, force)
+                    logger.info("Successfully imported entity %s", name)
+                except Exception as ex:
+                    logger.exception(ex)
+                    logger.error("Failed to import entity %s", name)
+
             except Exception as ex:
                 logger.exception(ex)
-                logger.info("Exception loading entity %s", name)
+                logger.error("Unexpected error processing entity %s", name)
 
         logger.info("Data import finished")
         return 0

--- a/newsroom/commands/utils.py
+++ b/newsroom/commands/utils.py
@@ -1,0 +1,72 @@
+import logging
+from pathlib import Path
+
+from superdesk.core import get_current_app
+from apps.prepopulate.app_initialize import fillEnvironmentVariables
+
+logger = logging.getLogger(__name__)
+
+
+async def async_entity_import(entity_name, path, file_name, index_params, do_patch=False, force=False):
+    """Custom import function for newsroom async entities"""
+    logger.info("Process %r", entity_name)
+    file_path = Path(path) / file_name
+    app = get_current_app()
+
+    if not file_path.exists():
+        logger.info(" - file not exists: %s", file_path)
+        return
+
+    logger.info(" - got file path: %s", file_path)
+
+    with file_path.open("rt", encoding="utf-8") as f:
+        import json
+
+        json_data = json.loads(f.read())
+
+    data = [fillEnvironmentVariables(item) for item in json_data if fillEnvironmentVariables(item) is not None]
+
+    # Use async service
+    async_app = app.async_app
+    service = async_app.resources.get_resource_service(entity_name)
+
+    # Get existing data using service
+    existing_data = []
+    existing = [item.to_dict() async for item in service.get_all()]
+    update_data = True
+    if not do_patch and len(existing) > 0:
+        logger.info(" - data already exists none will be loaded")
+        update_data = False
+    elif do_patch and len(existing) > 0:
+        logger.info(" - data already exists it will be updated")
+
+    if update_data:
+        if do_patch:
+            for item in existing:
+                for loaded_item in data:
+                    if "_id" in loaded_item and loaded_item["_id"] == item["_id"]:
+                        data.remove(loaded_item)
+                        if force or item.get("init_version", 0) < loaded_item.get("init_version", 0):
+                            existing_data.append(loaded_item)
+
+        if data:
+            for item in data:
+                if not item.get("_etag"):
+                    item["_etag"] = "init"
+            await service.create(data)
+
+        if existing_data and do_patch:
+            for item in existing_data:
+                item["_etag"] = "init"
+                await service.update(item["_id"], item)
+
+    logger.info(" - file imported successfully: %s", file_name)
+
+    if index_params:
+        for index in index_params:
+            crt_index = list(index) if isinstance(index, list) else index
+            options = crt_index.pop() if isinstance(crt_index[-1], dict) and isinstance(index, list) else {}
+            collection = app.data.mongo.pymongo(resource=entity_name).db[entity_name]
+            options.setdefault("background", True)
+            index_name = collection.create_index(crt_index, **options)
+            logger.info(" - index: %s for collection %s created successfully.", index_name, entity_name)

--- a/newsroom/commands/utils.py
+++ b/newsroom/commands/utils.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from pathlib import Path
 
 from superdesk.core import get_current_app
@@ -18,10 +19,7 @@ async def async_entity_import(entity_name, path, file_name, index_params, do_pat
         return
 
     logger.info(" - got file path: %s", file_path)
-
     with file_path.open("rt", encoding="utf-8") as f:
-        import json
-
         json_data = json.loads(f.read())
 
     data = [fillEnvironmentVariables(item) for item in json_data if fillEnvironmentVariables(item) is not None]


### PR DESCRIPTION
### Purpose
This PR fixes the `initialize_data --entity-name ui_config` command which was failing silently since the service was not being found. This is because it is an async entity but the command was trying to use the legacy superdesk service registry to find the service in the `import_file` function

### What has changed
- Created a new `async_entity_import` function in `newsroom/commands/utils.py` that handles async entities 
- Modified `initialize_data.py` to use the new async import function specifically for ui_config entities
- Improved error handling and logging for missing entities and files in the command itself

### Steps to test
1. Run the initialize data command for ui_config: `python3 manage.py initialize_data --entity-name ui_config`
2. Verify that the ui_config collection is created in the database and the config is loaded on the UI

Resolves: #[STT-1455](https://sofab.atlassian.net/browse/STT-1455)


[STT-1455]: https://sofab.atlassian.net/browse/STT-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ