### PR TITLE
[STT1464] fix: Use first/version created for Agenda item update tag

### DIFF
--- a/assets/agenda/components/AgendaItemTimeUpdater.tsx
+++ b/assets/agenda/components/AgendaItemTimeUpdater.tsx
@@ -21,7 +21,7 @@ class AgendaItemTimeUpdater extends React.Component<IProps, IState> {
     interval: number;
     timerIntervalId: number;
 
-    constructor(props: any) {
+    constructor(props: IProps) {
         super(props);
 
         this.state = {timeText: ''};
@@ -37,8 +37,8 @@ class AgendaItemTimeUpdater extends React.Component<IProps, IState> {
 
     componentDidUpdate(prevProps: Readonly<IProps>) {
         if (
-            this.props.item._created !== prevProps.item._created ||
-            this.props.item._updated !== prevProps.item._updated
+            this.props.item.firstcreated !== prevProps.item.firstcreated ||
+            this.props.item.versioncreated !== prevProps.item.versioncreated
         ) {
             this.activateTimer(this.props.item);
         }
@@ -70,10 +70,10 @@ class AgendaItemTimeUpdater extends React.Component<IProps, IState> {
         }
     }
 
-    isItemPastTime(item: any) {
+    isItemPastTime(item: IAgendaItem) {
         // Check if the updated (and created) time is past the interval duration
-        return item && (moment().diff(moment(item._created), 'minutes') >= this.interval &&
-            moment().diff(moment(item._updated), 'minutes') >= this.interval);
+        return item && (moment().diff(moment(item.firstcreated), 'minutes') >= this.interval &&
+            moment().diff(moment(item.versioncreated), 'minutes') >= this.interval);
     }
 
     updateState(item: IAgendaItem, checkPastTime = true) {


### PR DESCRIPTION
### Purpose
The `AgendaItemTimeUpdater` component for the list view used `_updated` to show the last time the item was updated. This is the incorrect data to use, because the item could have `_updated` when a user bookmarks the item.

### What has changed
Use `firstcreated` and `versioncreated` which is the correct data to use, as that was the date/time the item itself was published into Newshub.

### Checklist
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: [STT-1464](https://sofab.atlassian.net/browse/STT-1464)


[STT-1464]: https://sofab.atlassian.net/browse/STT-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ