### PR TITLE
fix runtime error when locking

### DIFF
--- a/newsroom/push/tasks.py
+++ b/newsroom/push/tasks.py
@@ -1,6 +1,5 @@
 import logging
 
-from contextlib import contextmanager
 from superdesk.lock import lock, unlock
 
 from newsroom.celery_app import celery
@@ -13,33 +12,34 @@ logger = logging.getLogger(__name__)
 notifier = NotificationManager()
 
 
-@contextmanager
-def locked(_id: str, service: str):
+def get_lock(_id: str, service: str) -> str | None:
     lock_name = f"notify-{service}-{_id}"
     if not lock(lock_name, expire=300):
         logger.debug(f"Lock conflict on {lock_name}")
-        return
-
-    logger.debug("Starting task %s", lock_name)
-    try:
-        yield lock_name
-    finally:
-        unlock(lock_name)
-        logger.debug("Done with %s", lock_name)
+        return None
+    return lock_name
 
 
 @celery.task
 async def notify_new_wire_item(_id, check_topics=True):
-    with locked(_id, "wire"):
+    lock = get_lock(_id, "wire")
+    if not lock:
+        return
+    try:
         logger.info("Send notifications for wire item %s", _id)
         item = await WireSearchServiceAsync().service.find_by_id(_id)
         if item:
             await notifier.notify_new_item(item.to_dict(), check_topics=check_topics)
+    finally:
+        unlock(lock)
 
 
 @celery.task
 async def notify_new_agenda_item(_id, check_topics=True, is_new=False):
-    with locked(_id, "agenda"):
+    lock = get_lock(_id, "wire")
+    if not lock:
+        return
+    try:
         logger.info("Send notifications for agenda item %s", _id)
         service = AgendaItemService()
         agenda = await service.find_by_id(_id)
@@ -54,3 +54,5 @@ async def notify_new_agenda_item(_id, check_topics=True, is_new=False):
         agenda_dict = agenda.to_dict()
         await AgendaItemService().enhance_item(agenda_dict)
         await notifier.notify_new_item(agenda_dict, check_topics=check_topics)
+    finally:
+        unlock(lock)

--- a/newsroom/push/tasks.py
+++ b/newsroom/push/tasks.py
@@ -22,8 +22,8 @@ def get_lock(_id: str, service: str) -> str | None:
 
 @celery.task
 async def notify_new_wire_item(_id, check_topics=True):
-    lock = get_lock(_id, "wire")
-    if not lock:
+    lock_name = get_lock(_id, "wire")
+    if not lock_name:
         return
     try:
         logger.info("Send notifications for wire item %s", _id)
@@ -31,13 +31,13 @@ async def notify_new_wire_item(_id, check_topics=True):
         if item:
             await notifier.notify_new_item(item.to_dict(), check_topics=check_topics)
     finally:
-        unlock(lock)
+        unlock(lock_name)
 
 
 @celery.task
 async def notify_new_agenda_item(_id, check_topics=True, is_new=False):
-    lock = get_lock(_id, "wire")
-    if not lock:
+    lock_name = get_lock(_id, "agenda")
+    if not lock_name:
         return
     try:
         logger.info("Send notifications for agenda item %s", _id)
@@ -55,4 +55,4 @@ async def notify_new_agenda_item(_id, check_topics=True, is_new=False):
         await AgendaItemService().enhance_item(agenda_dict)
         await notifier.notify_new_item(agenda_dict, check_topics=check_topics)
     finally:
-        unlock(lock)
+        unlock(lock_name)


### PR DESCRIPTION
there is

```
RuntimeError: generator didn't yield
```

when lock is already taken.

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
