### PR TITLE
[SDAN-751] Restrict the ability to open items from the home page if not available to the user

### DIFF
--- a/assets/home/actions.ts
+++ b/assets/home/actions.ts
@@ -1,5 +1,5 @@
 import server from '../server';
-import {errorHandler, recordAction} from 'utils';
+import {errorHandler, recordAction, notify, gettext} from 'utils';
 import {pushNotification as wirePushNotification} from 'wire/actions';
 import {get} from 'lodash';
 
@@ -15,8 +15,12 @@ function openItem(item: any) {
 export const OPEN_ITEM = 'OPEN_ITEM';
 export function openItemDetails(item: any) {
     return (dispatch: any) => {
-        dispatch(openItem(item));
-        recordAction(item, 'open');
+        if (item._access) {
+            dispatch(openItem(item));
+            recordAction(item, 'open');
+        } else {
+            notify.warning(gettext('This item is not part of your subscription'));
+        }
     };
 }
 

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -891,3 +891,10 @@ USE_EMBED_PERMISSIONS_IN_DASHBOARD = True
 #: .. versionadded: 3.0
 #:
 MAX_CONTENT_LENGTH = int(os.environ.get("MAX_CONTENT_LENGTH", 1024 * 1024 * 1000))  # 1GB
+
+#: Enable/Disable the application of setting the "user_has_access"/"_access" flag on items in the dashboard cards
+#: If true Items that are not permissioned for the Company will have the _access flag set to False
+#:
+#: .. versionadded: 3.?
+#:
+PERMISSION_DASHBOARD_CARDS = False

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -80,7 +80,10 @@ HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
 
 
 async def set_permissions(
-    wire_item: WireItem, ignore_latest: bool = False, service: WireSearchServiceAsync | None = None
+    wire_item: WireItem,
+    ignore_latest: bool = False,
+    service: WireSearchServiceAsync | None = None,
+    strip_associations: bool = True,
 ):
     try:
         if not service:
@@ -97,10 +100,10 @@ async def set_permissions(
     except Exception:
         permitted = False
 
-    set_item_permission(wire_item, permitted)
+    set_item_permission(wire_item, permitted, strip_associations)
 
 
-def set_item_permission(wire_item: WireItem, permitted=True):
+def set_item_permission(wire_item: WireItem, permitted=True, strip_associations=True):
     if not wire_item:
         return
 
@@ -108,8 +111,42 @@ def set_item_permission(wire_item: WireItem, permitted=True):
     if not wire_item.user_has_access:
         wire_item.body_text = ""
         wire_item.body_html = ""
-        wire_item.renditions = None
-        wire_item.associations = None
+        if strip_associations:
+            wire_item.renditions = None
+            wire_item.associations = None
+
+
+async def set_permissions_on_cards(items_by_card):
+    """
+    Sets permissions flag "user_has_access"/"_access" on the items in each card based on what is allowed for the
+    Company
+    @param items_by_card:
+    @return:
+    """
+    # If the feature is not enabled then flag all items as being accessible
+    if not get_app_config("PERMISSION_DASHBOARD_CARDS"):
+        for card_items in items_by_card.values():
+            for item_dict in card_items:
+                item_dict["_access"] = True
+        return
+
+    card_item_ids = []
+    for _c, card_items in items_by_card.items():
+        card_item_ids.extend([itm.get("_id") for itm in card_items if itm.get("_id")])
+    service = WireSearchServiceAsync()
+    cursor = await service.get_items_by_id(
+        card_item_ids, WireSearchRequestArgs(ignore_latest=False), apply_permissions=True
+    )
+    allowed_ids_list = await cursor.to_list()
+    allowed_ids_set = {itm.id for itm in allowed_ids_list if itm.id}
+
+    for card, card_items in items_by_card.items():
+        for i, card_item in enumerate(card_items):
+            wire_item = WireItem.from_dict(card_item)
+
+            is_permitted = wire_item.id in allowed_ids_set
+            set_item_permission(wire_item, permitted=is_permitted, strip_associations=False)
+            card_items[i] = wire_item.to_dict()
 
 
 async def get_view_data() -> dict:
@@ -150,6 +187,9 @@ async def get_items_by_card(cards: list[CardResourceModel], company_id: ObjectId
         return app.cache.get(cache_key)
 
     items_by_card = await get_items_for_dashboard(cards)
+
+    await set_permissions_on_cards(items_by_card)
+
     app.cache.set(cache_key, items_by_card, timeout=get_app_config("DASHBOARD_CACHE_TIMEOUT", 300))
     return items_by_card
 
@@ -194,7 +234,12 @@ async def get_personal_dashboards_data(
                     topic=topic,
                 )
             )
-            topic_items = await cursor.to_list_raw()
+            topic_items = []
+            topic_items_list = await cursor.to_list()
+            # All items on the personal dashboard have user access
+            for topic_item in topic_items_list:
+                topic_item.user_has_access = True
+                topic_items.append(topic_item.to_dict())
             await apply_company_permissions_to_embeds(topic_items, topic.topic_type)
             return topic_items
         except AuthorizationError:

--- a/tests/core/test_home.py
+++ b/tests/core/test_home.py
@@ -1,6 +1,9 @@
 from bson import ObjectId
 
-from newsroom.wire.views import get_home_data
+from newsroom import UserRole
+from newsroom.cards import CardsResourceService
+from newsroom.types import CardResourceModel, DashboardCardType, SectionEnum
+from newsroom.wire.views import get_home_data, get_items_by_card
 from newsroom.tests.fixtures import PUBLIC_USER_ID
 
 from tests.core.utils import create_entries_for, update_entries_for, find_one_by_id
@@ -40,3 +43,74 @@ async def test_personal_dashboard_data(client, app, company_products):
     assert topic_items[0]["_id"] == topics[0]["_id"]
     assert 1 == len(topic_items[0]["items"])
     assert "Weather" == topic_items[0]["items"][0]["headline"]
+    assert topic_items[0]["items"][0]["_access"]
+
+
+async def test_dashboard_data(client, app, company_products):
+    app.config["PERMISSION_DASHBOARD_CARDS"] = True
+    user = await find_one_by_id("users", PUBLIC_USER_ID)
+    assert user
+
+    company_id = ObjectId()
+    wire_product_id = ObjectId()
+    wire_product_restrictive_id = ObjectId()
+    card_id = ObjectId()
+
+    await create_entries_for(
+        "companies",
+        [
+            {
+                "_id": company_id,
+                "name": "Test Company",
+                "is_enabled": True,
+                "products": [
+                    {"_id": wire_product_restrictive_id, "section": SectionEnum.WIRE.value},
+                ],
+                "sections": {"wire": True},
+            }
+        ],
+    )
+    await update_entries_for("users", user["_id"], {"company": company_id, "user_type": UserRole.PUBLIC.value}, user)
+
+    await create_entries_for(
+        "products",
+        [
+            {
+                "_id": wire_product_id,
+                "name": "Test Wire Product",
+                "is_enabled": True,
+                "product_type": SectionEnum.WIRE,
+                "query": "*",
+            },
+            {
+                "_id": wire_product_restrictive_id,
+                "name": "Test Wire restrictive Product",
+                "is_enabled": True,
+                "product_type": SectionEnum.WIRE,
+                "query": "headline:Amazon",
+            },
+        ],
+    )
+
+    card = await CardsResourceService().create(
+        [
+            CardResourceModel(
+                id=card_id,
+                label="News",
+                dashboard_type=DashboardCardType.PIC_TEXT_4,
+                dashboard="newsroom",
+                config=dict(
+                    product=str(wire_product_id),
+                    size=6,
+                ),
+            )
+        ]
+    )
+
+    async with app.test_request_context("/card_items") as request:
+        request.session["user"] = str(PUBLIC_USER_ID)
+        data = await get_items_by_card(card, company_id)
+        assert len(data.get("News")) == 3
+        assert data.get("News")[0].get("_access")
+        assert not data.get("News")[1].get("_access")
+        assert not data.get("News")[2].get("_access")


### PR DESCRIPTION
### Purpose
The homepage cards can legitimately display items even if those items are outside of a user's subscription.

However, the current issue is that users can still open or initiate access to these unauthorized items. The goal is to restrict the ability to open any item that the user is not entitled to access, while still allowing the card itself to be shown.

### What has changed
An optional feature has been added to control the access to items that fall outside the users subscription. It is enabled/disable by the setting "PERMISSION_DASHBOARD_CARDS"

Content returned by the "/card_items" endpoint will have the "_access" to either true of false depending on if the user has the right s to open the item.

### Steps to test
Create a product that allows broad access to content.
Create a dashboard using the product above
Create a restrictive wire product
Create a Company/user and associate the product above.
Log in to Newshub using that user and try opening an item from the Dashboard that is not in the restrictive product results in a message at the bottom right of the page.

<img width="1785" height="771" alt="image" src="https://github.com/user-attachments/assets/b94358b4-e56e-4a3c-a7c2-a5708d42fbfb" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-751
