### PR TITLE
SDAN-750 Track the delivery of stories in the history collection from ATOM/RSS endpoints

### DIFF
--- a/newsroom/news_api/default_settings.py
+++ b/newsroom/news_api/default_settings.py
@@ -17,7 +17,7 @@ server_url = urlparse(NEWSAPI_URL)
 URL_PREFIX = env("NEWSAPI_URL_PREFIX", server_url.path.strip("/")) or "api/v1"
 
 QUERY_MAX_PAGE_SIZE = 100
-
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"
 BLUEPRINTS = []
 
 CORE_APPS = [

--- a/newsroom/news_api/formatters/rss.py
+++ b/newsroom/news_api/formatters/rss.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime, timedelta
 
 from email.utils import format_datetime
+from typing import List, Any
+
 from lxml import etree
 from lxml.etree import Element, SubElement, QName, CDATA
 
@@ -11,6 +13,8 @@ from superdesk.core.utils import str_to_date
 from superdesk.utc import utcnow
 from superdesk.flask import url_for
 
+from newsroom.auth.utils import get_company_from_request
+from newsroom.history_async import HistoryService
 from newsroom.types import SectionEnum
 from newsroom.wire.embeds import apply_company_permissions_to_embeds, update_embed_urls, set_association_links
 from newsroom.news_api.news.search_service import NewsApiSearchServiceAsync
@@ -38,7 +42,9 @@ class RSSFormatter:
         search_service = NewsApiSearchServiceAsync()
         response = await search_service.process_web_request(request)
 
-        for item in response.body.get("_items"):
+        item_ids: List[str] = []
+        items: List[dict] = response.body.get("_items")
+        for item in items:
             try:
                 complete_item = await search_service.service.find_by_id_raw(item.get("_id"))
                 if not complete_item:
@@ -46,14 +52,53 @@ class RSSFormatter:
 
                 entry = SubElement(channel, self.item_field)
                 await self.format_item(entry, complete_item, token)
+                item_ids.append(item.get("_id"))
 
             except Exception as ex:
                 logger.exception("processing {} - {}".format(item.get("_id"), ex))
+
+        await self.log_items(item_ids, {item.get("_id"): item for item in items})
 
         return Response(
             XML_ROOT + etree.tostring(feed, method="xml", pretty_print=True).decode("utf-8"),
             headers=[("Content-Type", self.mimetype)],
         )
+
+    async def log_items(self, item_ids: List[str], items: dict[str, Any]) -> None:
+        """
+        Log the items that have been included Feed as having been retrieved if they have not been logged before
+        @param item_ids:
+        @param items:
+        @return:
+        """
+        if not item_ids:
+            return
+        company = get_company_from_request(None)
+        service = HistoryService()
+        query = {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"term": {"company": company.id}},
+                        {"term": {"section": SectionEnum.NEWS_API.value}},
+                        {"term": {"action": "api"}},
+                        {"terms": {"item": item_ids}},
+                    ]
+                }
+            },
+            "aggs": {"logged_items_agg": {"terms": {"field": "item", "size": len(item_ids)}}},
+        }
+
+        search_logged = await service.search(query)
+        aggregations = (search_logged.hits or {}).get("aggregations") or {}
+        buckets = aggregations.get("logged_items_agg", {}).get("buckets", [])
+
+        logged_ids = {bucket.get("key") for bucket in buckets}
+        unlogged_ids = set(item_ids) - logged_ids
+        items_to_log = [items.get(unlogged_id) for unlogged_id in unlogged_ids if unlogged_id]
+        if items_to_log:
+            await service.create_history_record(items_to_log, "api", None, company.id, SectionEnum.NEWS_API.value, None)
 
     def get_root_xml(self) -> tuple[Element, Element]:
         feed = Element("rss", attrib={"version": "2.0"}, nsmap=self.nsmap)
@@ -83,7 +128,9 @@ class RSSFormatter:
 
         try:
             if item["associations"]["featuremedia"]["renditions"]:
-                self.set_item_featuremedia_details(entry, item["associations"]["featuremedia"], token)
+                self.set_item_featuremedia_details(
+                    entry, item["associations"]["featuremedia"], token=token, item_id=item.get("_id")
+                )
         except (KeyError, TypeError):
             pass
 
@@ -197,7 +244,9 @@ class RSSFormatter:
     def set_item_content(self, entry: SubElement, item: dict) -> None:
         SubElement(entry, QName(self.nsmap.get("content"), "encoded")).text = CDATA(item.get("body_html", ""))
 
-    def set_item_featuremedia_details(self, entry: SubElement, featuremedia: dict, token: str | None) -> None:
+    def set_item_featuremedia_details(
+        self, entry: SubElement, featuremedia: dict, token: str | None, item_id: str | None
+    ) -> None:
         try:
             image: dict | None = featuremedia["renditions"]["16-9"]
         except (KeyError, TypeError):
@@ -207,11 +256,16 @@ class RSSFormatter:
             # 16x9 rendition not found, not including featuremedia details
             return
 
-        url = (
-            url_for("assets.get_item", _external=True, asset_id=image.get("media"), token=token)
-            if token
-            else url_for("assets.get_item", _external=True, asset_id=image.get("media"))
-        )
+        url_kwargs = {
+            "asset_id": image.get("media"),
+            "item_id": item_id,
+            "_external": True,
+        }
+        if token:
+            url_kwargs["token"] = token
+
+        endpoint_name = "assets.download" if token else "assets.get_item"
+        url = url_for(endpoint_name, **url_kwargs)
 
         media = SubElement(
             entry,

--- a/newsroom/news_api/formatters/rss.py
+++ b/newsroom/news_api/formatters/rss.py
@@ -92,11 +92,15 @@ class RSSFormatter:
             "aggs": {"logged_items_agg": {"terms": {"field": "item", "size": len(item_ids)}}},
         }
 
-        search_logged = await service.search(query)
-        aggregations = (search_logged.hits or {}).get("aggregations") or {}
-        buckets = aggregations.get("logged_items_agg", {}).get("buckets", [])
+        try:
+            search_logged = await service.search(query)
+            aggregations = (search_logged.hits or {}).get("aggregations") or {}
+            buckets = aggregations.get("logged_items_agg", {}).get("buckets", [])
+            logged_ids = {bucket.get("key") for bucket in buckets}
+        except Exception as e:
+            logger.warning(f"Exception raised on search: {e}")
+            logged_ids = set()
 
-        logged_ids = {bucket.get("key") for bucket in buckets}
         unlogged_ids = set(item_ids) - logged_ids
         items_to_log: list[dict[str, Any]] = [
             cast(dict[str, Any], items.get(unlogged_id))

--- a/newsroom/news_api/formatters/rss.py
+++ b/newsroom/news_api/formatters/rss.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta
 
 from email.utils import format_datetime
-from typing import List, Any
+from typing import List, Any, cast
 
 from lxml import etree
 from lxml.etree import Element, SubElement, QName, CDATA
@@ -52,12 +52,12 @@ class RSSFormatter:
 
                 entry = SubElement(channel, self.item_field)
                 await self.format_item(entry, complete_item, token)
-                item_ids.append(item.get("_id"))
+                item_ids.append(item.get("_id", ""))
 
             except Exception as ex:
                 logger.exception("processing {} - {}".format(item.get("_id"), ex))
 
-        await self.log_items(item_ids, {item.get("_id"): item for item in items})
+        await self.log_items(item_ids, {item.get("_id", ""): item for item in items})
 
         return Response(
             XML_ROOT + etree.tostring(feed, method="xml", pretty_print=True).decode("utf-8"),
@@ -74,6 +74,8 @@ class RSSFormatter:
         if not item_ids:
             return
         company = get_company_from_request(None)
+        if company is None:
+            return
         service = HistoryService()
         query = {
             "size": 0,
@@ -96,7 +98,11 @@ class RSSFormatter:
 
         logged_ids = {bucket.get("key") for bucket in buckets}
         unlogged_ids = set(item_ids) - logged_ids
-        items_to_log = [items.get(unlogged_id) for unlogged_id in unlogged_ids if unlogged_id]
+        items_to_log: list[dict[str, Any]] = [
+            cast(dict[str, Any], items.get(unlogged_id))
+            for unlogged_id in unlogged_ids
+            if items.get(unlogged_id) is not None
+        ]
         if items_to_log:
             await service.create_history_record(items_to_log, "api", None, company.id, SectionEnum.NEWS_API.value, None)
 

--- a/tests/news_api/test_news_api.py
+++ b/tests/news_api/test_news_api.py
@@ -1,6 +1,9 @@
 from bson import ObjectId
+import lxml.etree
 from newsroom.types import SectionEnum
+from superdesk.utc import utcnow
 from tests.core.utils import create_entries_for, find_one_for
+from newsroom.tests import test_utils
 
 
 async def test_news_api_root_links(client, app):
@@ -28,6 +31,80 @@ async def test_news_api_root_links(client, app):
         "account/products": "Account Products Search",
         "account/products/<string:product_id>": "Get Account Product",
     }
+
+
+async def test_rss_item_history(client, app):
+    api_product_id = ObjectId()
+    await create_entries_for(
+        "products",
+        [
+            {
+                "_id": api_product_id,
+                "name": "Test Product",
+                "is_enabled": True,
+                "product_type": SectionEnum.NEWS_API,
+                "query": "story",
+            }
+        ],
+    )
+    company_id = ObjectId()
+    await create_entries_for(
+        "companies",
+        [
+            {
+                "_id": company_id,
+                "name": "Test Company",
+                "is_enabled": True,
+                "products": [
+                    {"_id": api_product_id, "section": SectionEnum.NEWS_API},
+                ],
+                "sections": {"news_api": True},
+            }
+        ],
+    )
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "111",
+                "firstpublished": utcnow(),
+                "pubstatus": "usable",
+                "headline": "Headline of the story",
+                "version": "1",
+            },
+            {
+                "_id": "222",
+                "firstpublished": utcnow(),
+                "pubstatus": "usable",
+                "headline": "Headline of the story 2",
+                "version": "1",
+            },
+        ],
+    )
+    await create_entries_for(
+        "history",
+        [
+            {
+                "item": "222",
+                "action": "api",
+                "section": "news_api",
+                "version": "1",
+                "versioncreated": utcnow(),
+                "company": company_id,
+            }
+        ],
+    )
+
+    await create_entries_for("news_api_tokens", [{"company": company_id, "enabled": True}])
+    token = await find_one_for("news_api_tokens", company=company_id)
+
+    response = await client.get("/api/v1/rss", headers={"Authorization": token.get("token")})
+    assert response.status_code == 200
+    body = await response.get_data()
+    tree = lxml.etree.fromstring(body)
+    assert "rss" == tree.tag, tree.tag
+    history_items = await test_utils.get_all("history")
+    assert len(history_items) == 2
 
 
 async def test_product_search(client, app):


### PR DESCRIPTION

### Purpose
The "Subscriber Activity" report currently does not track when clients receive content via ATOM or RSS feeds. This was a conscious decision because these feeds are checked (polled) very often, and logging every single check would create an overwhelming number of records in the system's History collection. This change is to start tracking this activity. The system will now specifically log only the very first time a particular news item is delivered to a client through the feed.

### What has changed
The items returned in the feed are checked against the history and only items that have not been returned to the client are logged in the History collection. Improvements have also been made to the logging of downloads of the assets.

### Steps to test
Setup an ATOM or RSS feed and retrieve the feed using Postman or similar.
Run the Subscriber Activity report and note the items have been logged as "API retrieval"
Retrieve the feed again an note that the items are not logged again

Example of the report
<img width="1863" height="480" alt="image" src="https://github.com/user-attachments/assets/f0da7ec2-c6d0-4a72-99c5-53f927fcddef" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-750
