### PR TITLE
SDAN-753 The News API does not allow multiple products specified to the search…

### DIFF
--- a/features/news_api/news_api_search.feature
+++ b/features/news_api/news_api_search.feature
@@ -679,3 +679,35 @@ Feature: News API News Search
          {"body_html": "<p>Updated fish story</p>"}
      ]}
      """
+
+  Scenario: search with multiple products
+    Given "products"
+        """
+        [{
+            "_id": "111111111111111111111111",
+            "name": "A Product",
+            "decsription": "a product for text",
+            "companies" : ["#companies._id#"],
+            "query": "NOT aardvark",
+            "product_type": "news_api"
+        },
+        {
+            "_id": "222222222222222222222222",
+            "name": "A Product",
+            "decsription": "a product for text",
+            "companies" : ["#companies._id#"],
+            "query": "aardvark",
+            "product_type": "news_api"
+        }]
+        """
+    Given "items"
+        """
+        [{
+            "body_html": "Three aardvark story",
+            "versioncreated": "#DATE-3#",
+            "headline": "Headline 1"
+        }]
+        """
+    When we get "news/search?start_date=now-10d&products=222222222222222222222222,111111111111111111111111"
+    Then we get OK response
+    Then we get list with 1 items

--- a/newsroom/search/types.py
+++ b/newsroom/search/types.py
@@ -249,7 +249,10 @@ class BaseSearchRequestArgs(BaseModel):
         if not value:
             return []
         elif isinstance(value, (str, ObjectId)):
-            return [str(value)]
+            if "," in value:
+                return [part.strip() for part in value.split(",") if part.strip()]
+            else:
+                return [str(value)]
         return value
 
     @field_validator("advanced", mode="before")


### PR DESCRIPTION
… and feed endpoints

### Purpose
News API clients should be able to make feed and search requests matching a comma separated list of product id's, such requests were failing with a http status code 500.

 
### What has changed
product list parameters are now parsed correctly

### Steps to test
Make an API request for multiple products using a tool such as postman or curl

```
curl --location 'http://localhost:5400/api/v1/news/feed?products=682a88a47fa16b095c2712eb%2C693764868f1f2583c485002e' \
--header 'Authorization: Bearer TOKEN'

```

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-753
