### PR TITLE
[SDAN-754] FIX restrict the profiles the monitoring bookmark counts

### DIFF
--- a/newsroom/monitoring/search.py
+++ b/newsroom/monitoring/search.py
@@ -34,7 +34,7 @@ class MonitoringSearchService(WireSearchServiceAsync):
 
         cursor = await self.search(
             NewshubSearchRequest(
-                section= self.section,
+                section=self.section,
                 args=self.search_args_class(bookmarks=[user.id], page_size=0, navigation_ids=navigation_ids),
             )
         )

--- a/newsroom/monitoring/search.py
+++ b/newsroom/monitoring/search.py
@@ -19,11 +19,13 @@ class MonitoringSearchService(WireSearchServiceAsync):
     ]
 
     async def get_current_monitoring_bookmarks_count(self, navigations: list[dict]) -> int:
-        """Returns the number of items that have been bookmarked by the current user
+        """Returns the number of items that have been bookmarked by the current user.
 
-        :param section: The section to search for, defaults to ``SectionEnum.WIRE``
-        :param navigations: The monitoring profiles defined for the Company
+        The count is scoped to items found in enabled monitoring navigations.
+
+        :param navigations: The monitoring profiles defined for the Company.
         :returns: The number of items that have been bookmarked by the current user
+            within the enabled monitoring navigations.
         """
 
         user = get_user_or_none_from_request(None)

--- a/newsroom/monitoring/search.py
+++ b/newsroom/monitoring/search.py
@@ -3,6 +3,8 @@ from newsroom.wire import WireSearchServiceAsync
 
 from newsroom.wire.filters import apply_highlights
 from .filters import MonitoringSearchRequestArgs, default_monitoring_filters, filter_replacements
+from newsroom.auth.utils import get_user_or_none_from_request
+from newsroom.search.types import NewshubSearchRequest
 
 
 class MonitoringSearchService(WireSearchServiceAsync):
@@ -15,3 +17,25 @@ class MonitoringSearchService(WireSearchServiceAsync):
         for filter_function in WireSearchServiceAsync.get_topic_items_query_execute_filters
         if filter_function != apply_highlights
     ]
+
+    async def get_current_monitoring_bookmarks_count(self, navigations: list[dict]) -> int:
+        """Returns the number of items that have been bookmarked by the current user
+
+        :param section: The section to search for, defaults to ``SectionEnum.WIRE``
+        :param navigations: The monitoring profiles defined for the Company
+        :returns: The number of items that have been bookmarked by the current user
+        """
+
+        user = get_user_or_none_from_request(None)
+        if not user:
+            return 0
+
+        navigation_ids = [nav.get("_id") for nav in navigations if nav.get("is_enabled")]
+
+        cursor = await self.search(
+            NewshubSearchRequest(
+                section= self.section,
+                args=self.search_args_class(bookmarks=[user.id], page_size=0, navigation_ids=navigation_ids),
+            )
+        )
+        return await cursor.count()

--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -42,15 +42,16 @@ async def get_view_data():
     user = get_user_from_request(None)
     company = get_company_from_request(None)
     ui_config_service = UiConfigResourceService()
+    navigations = await get_monitoring_for_company(user)
 
     return {
         "user": user.to_dict(),
         "company": str(company.id) if company else None,
-        "navigations": await get_monitoring_for_company(user),
+        "navigations": navigations,
         "context": "monitoring",
         "groups": get_app_config("MONITORING_GROUPS") or get_app_config("WIRE_GROUPS", []),
         "ui_config": await ui_config_service.get_section_config("monitoring"),
-        "saved_items": await MonitoringSearchService().get_current_user_bookmarks_count(),
+        "saved_items": await MonitoringSearchService().get_current_monitoring_bookmarks_count(navigations),
         "formats": get_formatters_id_and_names(SectionEnum.MONITORING),
         "secondary_formats": [{"format": f[0], "name": f[1]} for f in alert_types],
     }


### PR DESCRIPTION
### Purpose
Fixes a crash when all profiles were being executed against elastic

### What has changed
Stops the crash

### Steps to test
Select the monitoring tab on an instance of Newshub with Monitoring enabled and a significant number of monitoring profiles defined.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-754]


[SDAN-754]: https://sofab.atlassian.net/browse/SDAN-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ