### PR TITLE
[SDAN-755] FIX Allow for more than 25 notifications

### DIFF
--- a/newsroom/notifications/utils.py
+++ b/newsroom/notifications/utils.py
@@ -4,6 +4,7 @@ from asyncio import gather
 from bson import ObjectId
 from typing import Any
 
+from superdesk.core.resources import AsyncResourceService
 from superdesk.utc import utcnow
 from superdesk.core import get_app_config
 from superdesk.notification import push_notification
@@ -13,6 +14,7 @@ from newsroom.auth.utils import get_user_id_from_request
 from newsroom.types import WireItem, AgendaItem
 from newsroom.topics.topics_async import TopicService
 from .services import NotificationsService
+from superdesk.resource_fields import ID_FIELD
 
 
 def user_notifications_lookup(user_id: ObjectId) -> dict[str, Any]:
@@ -57,6 +59,11 @@ async def get_notifications_with_items() -> dict[str, Any] | None:
     Returns the stories that user has notifications for
     :return: List of stories. None if there is not user session.
     """
+
+    async def get_notification_items(service: AsyncResourceService, ids: list[str]) -> list[dict[str, Any]]:
+        cursor = await service.find({ID_FIELD: {"$in": ids}}, use_mongo=True, max_results=500)
+        return await cursor.to_list_raw()
+
     try:
         user_id = get_user_id_from_request(None)
     except AuthorizationError:
@@ -66,15 +73,19 @@ async def get_notifications_with_items() -> dict[str, Any] | None:
     item_ids = [n["item"] for n in saved_notifications]
 
     wire_items, agenda_items, topic_items = await gather(
-        WireItem.get_service().find_by_ids_raw(item_ids),
-        AgendaItem.get_service().find_by_ids_raw(item_ids),
-        TopicService().find_by_ids_raw(item_ids),
+        get_notification_items(WireItem.get_service(), item_ids),
+        get_notification_items(AgendaItem.get_service(), item_ids),
+        get_notification_items(TopicService(), item_ids),
     )
+
+    all_items = wire_items + agenda_items + topic_items
+    found_item_ids = {str(item["_id"]) for item in all_items}
+    valid_notifications = [n for n in saved_notifications if str(n.get("item")) in found_item_ids]
 
     return {
         "user": str(user_id),
-        "items": wire_items + agenda_items + topic_items,
-        "notifications": saved_notifications,
+        "items": all_items,
+        "notifications": valid_notifications,
     }
 
 

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -1,16 +1,17 @@
 import datetime
 
 from quart import json
-from bson import ObjectId
 from pytest import fixture
 
 from superdesk.utc import utcnow
 
 from newsroom.notifications import get_user_notifications, NotificationsService
+from newsroom.tests.test_utils import create_entries_for
 from ..fixtures import PUBLIC_USER_ID, TEST_USER_ID
 from tests.utils import login_public
 
-TEST_ITEM_ID = ObjectId()
+TEST_ITEM_ID = "item_1111"
+TEST_ITEM_ID_2 = "item_2222"
 TEST_USER = str(PUBLIC_USER_ID)
 TEST_NOTIFICATION = {"item": TEST_ITEM_ID, "user": TEST_USER, "resource": "test-resource", "action": "test-action"}
 USER_NOTIFICATIONS_URL = f"users/{TEST_USER}/notifications"
@@ -73,7 +74,7 @@ async def test_delete_notification_fails_for_different_user(client, service):
 
 async def test_delete_notification(client, service):
     await service.create_or_update([TEST_NOTIFICATION])
-
+    await create_entries_for("items", [{"_id": TEST_ITEM_ID, "pubstatus": "usable", "headline": "test item"}])
     await login_public(client)
     resp = await client.get(USER_NOTIFICATIONS_URL)
     print(await resp.get_data(as_text=True))
@@ -93,13 +94,20 @@ async def test_delete_all_notifications(client, service):
         [
             TEST_NOTIFICATION,
             {
-                "item": ObjectId(),
+                "item": TEST_ITEM_ID_2,
                 "user": TEST_USER,
                 "resource": "test-resources",
                 "action": "test-action",
                 "_created": utcnow() - datetime.timedelta(hours=12),
             },
         ]
+    )
+    await create_entries_for(
+        "items",
+        [
+            {"_id": TEST_ITEM_ID, "pubstatus": "usable", "headline": "test item"},
+            {"_id": TEST_ITEM_ID_2, "pubstatus": "usable", "headline": "another test item"},
+        ],
     )
 
     await login_public(client)


### PR DESCRIPTION
### Purpose
More than 25 outstanding notifications will crash the front end

### What has changed
Limit is now set to 500 and consistent data is returned to the frontend

### Steps to test
Ensure you have more than 25 outstanding notifications showing against the bell icon on the home page.
Click the bell icon, ensure that all notifications are displayed.
Ensure no errors are generated in the browser console



### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-755]


[SDAN-755]: https://sofab.atlassian.net/browse/SDAN-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ