### PR TITLE
fix flaky monitoring test

### DIFF
--- a/tests/core/test_monitoring.py
+++ b/tests/core/test_monitoring.py
@@ -16,10 +16,11 @@ from newsroom.monitoring import MonitoringProfileService
 
 company_id = "5c3eb6975f627db90c84093c"
 even_now = utcnow().replace(hour=4, minute=0)
+fixed_mock_now = utcnow().replace(minute=0, second=0, microsecond=0)
 
 
 def mock_utcnow():
-    return utcnow().replace(minute=0)
+    return fixed_mock_now
 
 
 def get_fixture_path(fixture):

--- a/tests/core/test_monitoring.py
+++ b/tests/core/test_monitoring.py
@@ -855,6 +855,7 @@ async def test_last_run_time_always_updated_with_matching_content_scheduled(clie
         assert w["last_run_time"] > (last_run_time - timedelta(minutes=5))
 
 
+@mock.patch("newsroom.monitoring.email_alerts.utcnow", mock_utcnow)
 @mock.patch("newsroom.email.send_email", mock_send_email)
 async def test_last_run_time_does_not_update_with_no_matching_content_immediate(client, app):
     await create_entries_for(
@@ -874,7 +875,7 @@ async def test_last_run_time_does_not_update_with_no_matching_content_immediate(
         w = await find_one_by_id("monitoring", "5db11ec55f627d8aa0b545fb")
         assert w is not None
         assert w.get("last_run_time") is not None
-        assert w["last_run_time"] > (mock_utcnow() - timedelta(minutes=5))
+        assert w["last_run_time"] > (mock_utcnow() - timedelta(minutes=15))
 
 
 @mock.patch("newsroom.email.send_email", mock_send_email)


### PR DESCRIPTION
freeze the time and increase the offset when testing next run time

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
