### PR TITLE
fix featured service

### DIFF
--- a/newsroom/agenda/featured_service.py
+++ b/newsroom/agenda/featured_service.py
@@ -1,5 +1,6 @@
 from typing import Any
 from datetime import datetime
+import logging
 
 from superdesk.core.types import ESQuery, RestGetResponse, RestResponseMeta
 from superdesk.core.resources import AsyncResourceService
@@ -14,12 +15,15 @@ from .filters import (
     apply_item_state_filter,
     apply_section_filter,
     apply_agenda_filters,
+    apply_item_type_filter,
     planning_items_query_string,
     nested_query,
     aggregations,
     AgendaSearchRequestArgs,
 )
 from .agenda_search import AgendaSearchServiceAsync
+
+logger = logging.getLogger(__name__)
 
 
 class FeaturedService(AsyncResourceService[FeaturedResourceModel]):
@@ -114,6 +118,7 @@ class FeaturedService(AsyncResourceService[FeaturedResourceModel]):
                 apply_section_filter,
                 apply_agenda_filters,
                 apply_featured_filters,
+                apply_item_type_filter,
             ],
         )
 
@@ -137,6 +142,8 @@ class FeaturedService(AsyncResourceService[FeaturedResourceModel]):
             if agenda_item and agenda_item.get("_id") not in agenda_ids:
                 docs.append(agenda_item)
                 agenda_ids.add(agenda_item.get("_id"))
+            else:
+                logger.warning(f"No featured agenda found for {agenda_id}")
 
         response = RestGetResponse(
             _items=docs,

--- a/newsroom/push/views.py
+++ b/newsroom/push/views.py
@@ -72,7 +72,7 @@ async def handle_publish_planning_featured(item):
     orig = await service.find_by_id(item["_id"])
 
     if orig:
-        await service.update(orig["_id"], {"items": item.get("items") or []})
+        await service.update(item["_id"], {"items": item.get("items") or []})
     else:
         # Assert `tz` and `items` in initial push only
         assert item.get("tz"), {"tz": 1}


### PR DESCRIPTION
### Purpose
Fixes Exception thrown on push of updated to the featured list and fixes missing items in the featured list when changed

### What has changed
In the processing of updates to the features list an exception was being thrown when accessing the id from the (orig) model!
The query for the planning items would return both the events and planning items, the test for unique planning items would cause some entries to be excluded!

### Steps to test
Publish a featured list of planning items to news room

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
