### PR TITLE
Fix date filter search for factcheck, marketplace, media releases and monitoring

### DIFF
--- a/newsroom/factcheck/views.py
+++ b/newsroom/factcheck/views.py
@@ -1,11 +1,10 @@
 import logging
-from eve.render import send_response
-from eve.methods.get import get_internal
+from superdesk.core import get_app_config
 
 from superdesk.flask import render_template, jsonify, request
 
 from newsroom.types import SectionEnum
-from newsroom.auth.utils import get_user_from_request, get_company_from_request
+from newsroom.auth.utils import get_user_from_request, get_company_from_request, get_current_request
 from newsroom.formatters import get_formatters_id_and_names
 from newsroom.factcheck import blueprint
 from newsroom.decorator import login_required, section
@@ -35,6 +34,7 @@ async def get_view_data():
         "saved_items": await FactCheckSearchServiceAsync().get_current_user_bookmarks_count(),
         "context": "factcheck",
         "ui_config": await ui_config_service.get_section_config("factcheck"),
+        "date_filters": get_app_config("WIRE_TIME_FILTERS", []),
     }
 
 
@@ -50,8 +50,9 @@ async def index():
 @login_required
 @section("factcheck")
 async def search():
-    response = await get_internal("factcheck_search")
-    return await send_response("factcheck_search", response)
+    rq = get_current_request()
+    response = await FactCheckSearchServiceAsync().process_web_request(request=rq)
+    return response.body, response.status_code, response.headers
 
 
 @blueprint.route("/bookmarks_factcheck")

--- a/newsroom/market_place/views.py
+++ b/newsroom/market_place/views.py
@@ -1,10 +1,8 @@
-from eve.render import send_response
-from eve.methods.get import get_internal
-
+from superdesk.core import get_app_config
 from superdesk.flask import render_template, jsonify, request
 
 from newsroom.types import Navigation, CompanyResource, UserResourceModel, SectionEnum
-from newsroom.auth.utils import get_user_from_request, get_company_from_request
+from newsroom.auth.utils import get_user_from_request, get_company_from_request, get_current_request
 from newsroom.formatters import get_formatters_id_and_names
 from newsroom.market_place import blueprint, SECTION_ID, SECTION_NAME
 from newsroom.decorator import login_required, section
@@ -53,6 +51,7 @@ async def get_view_data():
         "ui_config": await ui_config_service.get_section_config(SECTION_ID),
         "home_page": False,
         "title": SECTION_NAME,
+        "date_filters": get_app_config("WIRE_TIME_FILTERS", []),
     }
 
 
@@ -102,8 +101,9 @@ async def home():
 @blueprint.route("/{}/search".format(SECTION_ID))
 @login_required
 async def search():
-    response = await get_internal(search_endpoint_name)
-    return await send_response(search_endpoint_name, response)
+    rq = get_current_request()
+    response = await MarketPlaceSearchServiceAsync().process_web_request(request=rq)
+    return response.body, response.status_code, response.headers
 
 
 @blueprint.route("/bookmarks_{}".format(SECTION_ID))

--- a/newsroom/media_releases/views.py
+++ b/newsroom/media_releases/views.py
@@ -1,11 +1,10 @@
 import logging
-from eve.render import send_response
-from eve.methods.get import get_internal
+from superdesk.core import get_app_config
 
 from superdesk.flask import render_template, jsonify, request
 
 from newsroom.types import SectionEnum
-from newsroom.auth.utils import get_user_from_request, get_company_from_request
+from newsroom.auth.utils import get_user_from_request, get_company_from_request, get_current_request
 from newsroom.formatters import get_formatters_id_and_names
 from newsroom.media_releases import blueprint
 from newsroom.decorator import login_required, section
@@ -35,6 +34,7 @@ async def get_view_data():
         "saved_items": await MediaReleasesSearchServiceAsync().get_current_user_bookmarks_count(),
         "context": "media_releases",
         "ui_config": await ui_config_service.get_section_config("media_releases"),
+        "date_filters": get_app_config("WIRE_TIME_FILTERS", []),
     }
 
 
@@ -50,8 +50,9 @@ async def index():
 @login_required
 @section("media_releases")
 async def search():
-    response = await get_internal("media_releases_search")
-    return await send_response("media_releases_search", response)
+    rq = get_current_request()
+    response = await MediaReleasesSearchServiceAsync().process_web_request(request=rq)
+    return response.body, response.status_code, response.headers
 
 
 @blueprint.route("/bookmarks_media_releases")

--- a/newsroom/monitoring/views.py
+++ b/newsroom/monitoring/views.py
@@ -53,6 +53,7 @@ async def get_view_data():
         "saved_items": await MonitoringSearchService().get_current_user_bookmarks_count(),
         "formats": get_formatters_id_and_names(SectionEnum.MONITORING),
         "secondary_formats": [{"format": f[0], "name": f[1]} for f in alert_types],
+        "date_filters": get_app_config("WIRE_TIME_FILTERS", []),
     }
 
 
@@ -77,9 +78,8 @@ def process_form_request(updates, request_updates, form):
         updates["keywords"] = request_updates["keywords"]
 
     if "email" in request_updates:
-        updates["email"] = request_updates.get("email").replace(" ", "")
-        if updates["email"] == "":
-            updates["email"] = None
+        email_val = (request_updates.get("email") or "").replace(" ", "")
+        updates["email"] = email_val if email_val else None
 
 
 async def get_monitoring_for_company(user: UserResourceModel | None):


### PR DESCRIPTION


### Purpose
The date filter was not working for the factcheck, market place, media releases and monitoring views

### What has changed
Uses proces_web_request for the search endpoints as it applies the date filter

### Steps to test
Execute a date filter search against those views 
<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
