### PR TITLE
fix the newsapi cache_url setting

### DIFF
--- a/newsroom/news_api/default_settings.py
+++ b/newsroom/news_api/default_settings.py
@@ -9,12 +9,16 @@ from newsroom.web.default_settings import (  # noqa
     CLIENT_URL,
     AUTH_PROVIDERS,  # Required otherwise NewsAPI behave tests fail on ``company.validate_auth_provider``
     LOG_CONFIG_FILE,
+    CACHE_REDIS_URL,
 )
 
 SITE_NAME = env("SITE_NAME", "NEWSHUB")
 NEWSAPI_URL = env("NEWSAPI_URL", "http://localhost:5400")
 server_url = urlparse(NEWSAPI_URL)
 URL_PREFIX = env("NEWSAPI_URL_PREFIX", server_url.path.strip("/")) or "api/v1"
+
+# fix superdesk cache config
+CACHE_URL = CACHE_REDIS_URL
 
 QUERY_MAX_PAGE_SIZE = 100
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"


### PR DESCRIPTION
### Purpose
Allow the newsapi to set the required value for CACHE_URL

### What has changed
Set the config value

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
