### PR TITLE
SDAN-757 fix permissions for cards when no wire products defined

### DIFF
--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -135,11 +135,15 @@ async def set_permissions_on_cards(items_by_card):
     for _c, card_items in items_by_card.items():
         card_item_ids.extend([itm.get("_id") for itm in card_items if itm.get("_id")])
     service = WireSearchServiceAsync()
-    cursor = await service.get_items_by_id(
-        card_item_ids, WireSearchRequestArgs(ignore_latest=False), apply_permissions=True
-    )
-    allowed_ids_list = await cursor.to_list()
-    allowed_ids_set = {itm.id for itm in allowed_ids_list if itm.id}
+    try:
+        cursor = await service.get_items_by_id(
+            card_item_ids, WireSearchRequestArgs(ignore_latest=False), apply_permissions=True
+        )
+        allowed_ids_list = await cursor.to_list()
+        allowed_ids_set = {itm.id for itm in allowed_ids_list if itm.id}
+    except AuthorizationError:
+        # Exception thrown if no wire items are allowed
+        allowed_ids_set = set()
 
     for card, card_items in items_by_card.items():
         for i, card_item in enumerate(card_items):


### PR DESCRIPTION
### Purpose
Companies that have events only permissions would just have spinning wheels displayed on the home page when the PERMISSION_DASHBOARD_CARDS feature was enabled.

### What has changed
The cards will now be displayed but clicking on them will result in a message that the item is not part of the users/companies subscription.

### Steps to test
Permission a User/Company for events only and have the PERMISSION_DASHBOARD_CARDS feature enabled an view the behavior of the home page.


### Screenshots
<img width="393" height="831" alt="image" src="https://github.com/user-attachments/assets/28f6ca6f-b10c-47e3-af04-934567a051e2" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-757]


[SDAN-757]: https://sofab.atlassian.net/browse/SDAN-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ