### PR TITLE
fix RuntimeError when sending notifications

### DIFF
--- a/newsroom/push/tasks.py
+++ b/newsroom/push/tasks.py
@@ -1,4 +1,6 @@
 import logging
+from contextlib import contextmanager
+from typing import Iterator
 
 from superdesk.lock import lock, unlock
 
@@ -10,35 +12,45 @@ from .notifications import NotificationManager
 
 logger = logging.getLogger(__name__)
 notifier = NotificationManager()
+LOCK_EXPIRE_SECONDS = 300
 
 
 def get_lock_name(service: str, _id: str) -> str:
     return f"notify-{service}-{_id}"
 
 
+@contextmanager
+def task_lock(service: str, _id: str, expire: int = LOCK_EXPIRE_SECONDS) -> Iterator[bool]:
+    lock_name = get_lock_name(service, _id)
+    acquired = lock(lock_name, expire=expire)
+    if not acquired:
+        logger.debug("Lock conflict on %s", lock_name)
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            unlock(lock_name)
+            logger.debug("Done with %s", lock_name)
+
+
 @celery.task
 async def notify_new_wire_item(_id: str, check_topics=True) -> None:
-    lock_name = get_lock_name("wire", _id)
-    if not lock(lock_name, expire=300):
-        logger.debug("Lock conflict on %s", lock_name)
-        return
-    try:
+    with task_lock("wire", _id) as acquired:
+        if not acquired:
+            return
+
         logger.info("Send notifications for wire item %s", _id)
         item = await WireSearchServiceAsync().service.find_by_id(_id)
         if item:
             await notifier.notify_new_item(item.to_dict(), check_topics=check_topics)
-    finally:
-        unlock(lock_name)
-        logger.debug("Done with %s", lock_name)
 
 
 @celery.task
 async def notify_new_agenda_item(_id: str, check_topics=True, is_new=False) -> None:
-    lock_name = get_lock_name("agenda", _id)
-    if not lock(lock_name, expire=300):
-        logger.debug("Lock conflict on %s", lock_name)
-        return
-    try:
+    with task_lock("agenda", _id) as acquired:
+        if not acquired:
+            return
+
         logger.info("Send notifications for agenda item %s", _id)
         service = AgendaItemService()
         agenda = await service.find_by_id(_id)
@@ -53,6 +65,3 @@ async def notify_new_agenda_item(_id: str, check_topics=True, is_new=False) -> N
         agenda_dict = agenda.to_dict()
         await service.enhance_item(agenda_dict)
         await notifier.notify_new_item(agenda_dict, check_topics=check_topics)
-    finally:
-        unlock(lock_name)
-        logger.debug("Done with %s", lock_name)

--- a/newsroom/push/tasks.py
+++ b/newsroom/push/tasks.py
@@ -1,6 +1,5 @@
 import logging
 
-from contextlib import contextmanager
 from superdesk.lock import lock, unlock
 
 from newsroom.celery_app import celery
@@ -13,33 +12,33 @@ logger = logging.getLogger(__name__)
 notifier = NotificationManager()
 
 
-@contextmanager
-def locked(_id: str, service: str):
-    lock_name = f"notify-{service}-{_id}"
-    if not lock(lock_name, expire=300):
-        logger.debug(f"Lock conflict on {lock_name}")
-        return
+def get_lock_name(service: str, _id: str) -> str:
+    return f"notify-{service}-{_id}"
 
-    logger.debug("Starting task %s", lock_name)
+
+@celery.task
+async def notify_new_wire_item(_id: str, check_topics=True) -> None:
+    lock_name = get_lock_name("wire", _id)
+    if not lock(lock_name, expire=300):
+        logger.debug("Lock conflict on %s", lock_name)
+        return
     try:
-        yield lock_name
+        logger.info("Send notifications for wire item %s", _id)
+        item = await WireSearchServiceAsync().service.find_by_id(_id)
+        if item:
+            await notifier.notify_new_item(item.to_dict(), check_topics=check_topics)
     finally:
         unlock(lock_name)
         logger.debug("Done with %s", lock_name)
 
 
 @celery.task
-async def notify_new_wire_item(_id, check_topics=True):
-    with locked(_id, "wire"):
-        logger.info("Send notifications for wire item %s", _id)
-        item = await WireSearchServiceAsync().service.find_by_id(_id)
-        if item:
-            await notifier.notify_new_item(item.to_dict(), check_topics=check_topics)
-
-
-@celery.task
-async def notify_new_agenda_item(_id, check_topics=True, is_new=False):
-    with locked(_id, "agenda"):
+async def notify_new_agenda_item(_id: str, check_topics=True, is_new=False) -> None:
+    lock_name = get_lock_name("agenda", _id)
+    if not lock(lock_name, expire=300):
+        logger.debug("Lock conflict on %s", lock_name)
+        return
+    try:
         logger.info("Send notifications for agenda item %s", _id)
         service = AgendaItemService()
         agenda = await service.find_by_id(_id)
@@ -52,5 +51,8 @@ async def notify_new_agenda_item(_id, check_topics=True, is_new=False):
             return
 
         agenda_dict = agenda.to_dict()
-        await AgendaItemService().enhance_item(agenda_dict)
+        await service.enhance_item(agenda_dict)
         await notifier.notify_new_item(agenda_dict, check_topics=check_topics)
+    finally:
+        unlock(lock_name)
+        logger.debug("Done with %s", lock_name)

--- a/newsroom/push/tasks.py
+++ b/newsroom/push/tasks.py
@@ -15,13 +15,9 @@ notifier = NotificationManager()
 LOCK_EXPIRE_SECONDS = 300
 
 
-def get_lock_name(service: str, _id: str) -> str:
-    return f"notify-{service}-{_id}"
-
-
 @contextmanager
 def task_lock(service: str, _id: str, expire: int = LOCK_EXPIRE_SECONDS) -> Iterator[bool]:
-    lock_name = get_lock_name(service, _id)
+    lock_name = f"notify-{service}-{_id}"
     acquired = lock(lock_name, expire=expire)
     if not acquired:
         logger.debug("Lock conflict on %s", lock_name)

--- a/tests/core/test_realtime_notifications.py
+++ b/tests/core/test_realtime_notifications.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 import quart
 
@@ -326,24 +325,24 @@ async def test_realtime_notifications_agenda_reccuring_event(app):
         assert notifier.notify_new_item.call_count == 2
 
 
-def test_notify_new_wire_item_lock_conflict_returns_early():
+async def test_notify_new_wire_item_lock_conflict_returns_early():
     with mock.patch("newsroom.push.tasks.lock", return_value=False), mock.patch(
         "newsroom.push.tasks.notifier"
     ) as notifier:
         notifier.notify_new_item = mock.AsyncMock()
 
-        asyncio.run(notify_new_wire_item.run("item1"))
+        await notify_new_wire_item("item1")
 
         notifier.notify_new_item.assert_not_awaited()
 
 
-def test_notify_new_agenda_item_lock_conflict_returns_early():
+async def test_notify_new_agenda_item_lock_conflict_returns_early():
     with mock.patch("newsroom.push.tasks.lock", return_value=False), mock.patch(
         "newsroom.push.tasks.notifier"
     ) as notifier:
         notifier.notify_new_item = mock.AsyncMock()
 
-        asyncio.run(notify_new_agenda_item.run("event_id_1"))
+        await notify_new_agenda_item("event_id_1")
 
         notifier.notify_new_item.assert_not_awaited()
 

--- a/tests/core/test_realtime_notifications.py
+++ b/tests/core/test_realtime_notifications.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import quart
 
@@ -323,6 +324,28 @@ async def test_realtime_notifications_agenda_reccuring_event(app):
 
         await notify_new_agenda_item("event_id_2")
         assert notifier.notify_new_item.call_count == 2
+
+
+def test_notify_new_wire_item_lock_conflict_returns_early():
+    with mock.patch("newsroom.push.tasks.lock", return_value=False), mock.patch(
+        "newsroom.push.tasks.notifier"
+    ) as notifier:
+        notifier.notify_new_item = mock.AsyncMock()
+
+        asyncio.run(notify_new_wire_item.run("item1"))
+
+        notifier.notify_new_item.assert_not_awaited()
+
+
+def test_notify_new_agenda_item_lock_conflict_returns_early():
+    with mock.patch("newsroom.push.tasks.lock", return_value=False), mock.patch(
+        "newsroom.push.tasks.notifier"
+    ) as notifier:
+        notifier.notify_new_item = mock.AsyncMock()
+
+        asyncio.run(notify_new_agenda_item.run("event_id_1"))
+
+        notifier.notify_new_item.assert_not_awaited()
 
 
 # @markers.requires_async_celery


### PR DESCRIPTION
when the lock is already taken there is runtime error:

RuntimeError
generator didn't yield

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
