### PR TITLE
SDAN-759 Scheduled updates not being displayed

### DIFF
--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -494,7 +494,7 @@ export const getNextPendingScheduledUpdate = (coverage?: IFullCoverage) => {
     const scheduledUpdates = coverage.scheduled_updates || [];
     const deliveries = coverage.deliveries || [];
 
-    if (coverage.scheduled == null) {
+    if (coverage.scheduled === null) {
         // Not privileged to see coverage details
         return null;
     } else if (

--- a/assets/agenda/utils.ts
+++ b/assets/agenda/utils.ts
@@ -494,7 +494,7 @@ export const getNextPendingScheduledUpdate = (coverage?: IFullCoverage) => {
     const scheduledUpdates = coverage.scheduled_updates || [];
     const deliveries = coverage.deliveries || [];
 
-    if (coverage.scheduled === null) {
+    if (coverage.planning?.scheduled == null) {
         // Not privileged to see coverage details
         return null;
     } else if (


### PR DESCRIPTION
### Purpose
When a planning item is published to Newsroom with a scheduled update this is not reflected in Newsroom


### What has changed
The time of the scheduled update will be displayed.



### Steps to test

- Create a planning item with a text coverage, and also schedule an update.
- Fulfill the text coverage and publish it.
- Find the agenda item in newsroom agenda and select it, note that the string "Update expected @" an the time of the update is displayed in the coverage preview.

Should be something like
<img width="464" height="160" alt="image" src="https://github.com/user-attachments/assets/81be2ec9-2e89-4de1-94f9-8e3d631da4a9" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-759
