### PR TITLE
fix validation error in notifications

### DIFF
--- a/newsroom/email.py
+++ b/newsroom/email.py
@@ -268,9 +268,8 @@ async def send_user_email(
     """Send an email to Newsroom user, respecting user's email preferences."""
     user_dict: User = user.to_dict() if isinstance(user, ResourceModel) else user
 
-    if not user_dict.get("receive_email") and not ignore_preferences:
-        # If this is a user in the system, and has emails disabled
-        # then skip this recipient
+    if (not user_dict.get("receive_email") and not ignore_preferences) or (not user_dict.get("is_enabled")):
+        # skip user if has emails disabled or the user is not enabled
         return
 
     language = user_dict.get("locale") or get_app_config("DEFAULT_LANGUAGE")

--- a/newsroom/push/notifications.py
+++ b/newsroom/push/notifications.py
@@ -146,7 +146,6 @@ class NotificationManager:
                         continue
                     else:
                         with elasticapm.capture_span("notify_user"):
-                            users_with_realtime_subscription.add(user.id)
                             if topic.topic_type == SectionEnum.WIRE:
                                 wire_service = WireSearchServiceAsync()
                                 query = await wire_service.get_topic_items_query(
@@ -160,7 +159,7 @@ class NotificationManager:
                                     ),
                                     include_updated=True,
                                 )
-                                if not query:
+                                if query is None:
                                     continue
                                 cursor = await wire_service.service.find(SearchRequest(elastic=query))
                                 items = await cursor.to_list_raw()
@@ -176,6 +175,8 @@ class NotificationManager:
                                         es_highlight=True,
                                     ),
                                 )
+                                if query is None:
+                                    continue
                                 cursor = await agenda_service.service.find(SearchRequest(elastic=query))
                                 items = await cursor.to_list_raw()
                             highlighted_item = item
@@ -189,6 +190,7 @@ class NotificationManager:
                                 item=highlighted_item,
                                 section=section.value,
                             )
+                            users_with_realtime_subscription.add(user.id)
                 except Exception as e:
                     logger.exception(e)
                     # when there is an error for specific topic/subscriber continue

--- a/newsroom/push/notifications.py
+++ b/newsroom/push/notifications.py
@@ -285,7 +285,7 @@ class NotificationManager:
     async def send_user_notification_emails(
         self, item: dict[str, Any], user_matches: set[ObjectId], users: dict[ObjectId, UserResourceModel], section: str
     ):
-        logger.info("Sending topic notifications for item %s", item["_id"])
+        logger.info("Sending history match notification for item %s", item["_id"])
         for user_id in user_matches:
             user = users.get(user_id)
             if not user:

--- a/newsroom/push/notifications.py
+++ b/newsroom/push/notifications.py
@@ -105,6 +105,8 @@ class NotificationManager:
         users_with_realtime_subscription: set[ObjectId] = set()
         notification_queue_service = NotificationQueueService()
 
+        logger.info("Sending topic notifications for item %s", item["_id"])
+
         for topic in topics:
             if topic.id not in topic_matches:
                 continue
@@ -158,6 +160,8 @@ class NotificationManager:
                                     ),
                                     include_updated=True,
                                 )
+                                if not query:
+                                    continue
                                 cursor = await wire_service.service.find(SearchRequest(elastic=query))
                                 items = await cursor.to_list_raw()
                             else:

--- a/tests/core/test_emails.py
+++ b/tests/core/test_emails.py
@@ -23,7 +23,7 @@ from tests.core.utils import create_entries_for
 
 
 async def test_item_notification_template(client, app, mocker):
-    user = {"email": "foo@example.com", "receive_email": True}
+    user = {"email": "foo@example.com", "receive_email": True, "is_enabled": True}
     item = {
         "_id": "tag:localhost:2018:bcc9fd45",
         "guid": "tag:localhost:2018:bcc9fd45",
@@ -99,6 +99,7 @@ MOCK_USERS = [
         "last_name": "Test",
         "receive_email": True,
         "receive_app_notifications": True,
+        "is_enabled": True,
     },
     {
         "email": EMAILS[1],
@@ -107,6 +108,7 @@ MOCK_USERS = [
         "locale": "fr_CA",
         "receive_email": True,
         "receive_app_notifications": True,
+        "is_enabled": True,
     },
     {
         "email": EMAILS[2],
@@ -115,6 +117,7 @@ MOCK_USERS = [
         "locale": "fi",
         "receive_email": True,
         "receive_app_notifications": True,
+        "is_enabled": True,
     },
 ]
 
@@ -227,6 +230,7 @@ async def test_send_user_email(app):
         notification_schedule={"timezone": "Europe/Helsinki"},
         user_type="user",
         receive_email=True,
+        is_enabled=True,
     )
     date = datetime(2024, 4, 9, 11, 0, 0)
     template_kwargs = dict(date=date, topic_match_table={"wire": [], "agenda": []}, entries={})
@@ -257,6 +261,7 @@ async def test_item_killed_notification_email(app):
         last_name="Bar",
         email="foo@example.com",
         user_type=UserRole.PUBLIC,
+        is_enabled=True,
     )
 
     item = {
@@ -291,6 +296,7 @@ async def test_send_user_email_on_locale_changed():
         notification_schedule={"timezone": "Asia/Calcutta"},
         user_type="user",
         receive_email=True,
+        is_enabled=True,
     )
 
     event_item["coverages"][0]["coverage_status"] = "coverage intended"


### PR DESCRIPTION
when item doesn't match a query there is `None` returned which will raise ValidationError when constructing SearchRequest

