### PR TITLE
Fix newsapi assets endpoints to allow s3 paths

### DIFF
--- a/newsroom/news_api/news/assets/views.py
+++ b/newsroom/news_api/news/assets/views.py
@@ -23,7 +23,7 @@ class RouteArguments(BaseModel):
 
 
 @assets_endpoints.endpoint(
-    "assets/<path:asset_id>/<item_id>",
+    "assets/download/<path:asset_id>/<string:item_id>",
     title="Download Asset (with Wire ID)",
     methods=["GET"],
     auth=[support_auth_token_in_url, support_auth_basic_auth],
@@ -39,7 +39,7 @@ async def download(args: RouteArguments, params: RouteParams, request: Request):
 
 
 @assets_endpoints.endpoint(
-    "assets/<string:asset_id>",
+    "assets/<path:asset_id>",
     title="Download Asset",
     methods=["GET"],
     auth=[support_auth_token_in_url, support_auth_basic_auth],

--- a/tests/news_api/test_news_api.py
+++ b/tests/news_api/test_news_api.py
@@ -21,8 +21,8 @@ async def test_news_api_root_links(client, app):
     assert response.status_code == 200
     data = await response.get_json()
     assert {child["href"]: child["title"] for child in data["_links"]["child"]} == {
-        "assets/<path:asset_id>/<item_id>": "Download Asset (with Wire ID)",
-        "assets/<string:asset_id>": "Download Asset",
+        "assets/download/<path:asset_id>/<string:item_id>": "Download Asset (with Wire ID)",
+        "assets/<path:asset_id>": "Download Asset",
         "atom/<path:token>": "ATOM Feed (URL auth)",
         "atom": "ATOM Feed (Header auth)",
         "rss/<path:token>": "RSS Feed (URL auth)",


### PR DESCRIPTION
### Purpose
Asset paths for bucket storage were not being passed correctly and the endpoint for download is made distinct.

### What has changed
Endpoint definitions have changed

### Steps to test
Ensure Assets can be retrieved using the assets and assets/download endpoints.

The RSS and ATOM requests will return the url's in the body for the media:content and for the embedded images.

Passing the token on the url to the ATOM or RSS endpoints will result in the asset download endpoints being returned, these include the token on the url.

> https://server.aap.com.au/api/v1/assets/download/20260401110424/80fbf636-2a6f-4fbc-9ec3-ad26f44463a5.jpg/urn:newsml:aap.com.au:2026-04-01T09:33:32.392908:596b165b-a9d0-493a-be48-7c3a1baf0204?token=TOKEN


Using the Bearer token header will call the normal asset endpoint.

> https://server.aap.com.au/api/v1/assets/20260401120412/b9c75431-c5e5-4a2a-b0e5-076cb7ec83cd.jpg?item_id=urn:newsml:aap.com.au:2026-04-01T10:35:15.207571:5a3eb887-d3f2-48be-9ef3-41ebefc5bb91


<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
