### PR TITLE
[STT-1651] improve: Use cache in background thread

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,18 +8,18 @@ aioboto3==14.3.0
     # via superdesk-core
 aiobotocore[boto3]==2.22.0
     # via aioboto3
-aiofiles==24.1.0
+aiofiles==25.1.0
     # via
     #   aioboto3
     #   quart
     #   quart-uploads
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.15
+aiohttp==3.13.5
     # via
     #   aiobotocore
     #   elasticsearch
-aioitertools==0.12.0
+aioitertools==0.13.0
     # via aiobotocore
 aiosignal==1.4.0
     # via aiohttp
@@ -33,7 +33,7 @@ arrow==1.3.0
     # via
     #   eve-elastic
     #   superdesk-core
-asgiref==3.9.1
+asgiref==3.11.1
     # via superdesk-core
 asn1crypto==1.5.1
     # via
@@ -44,17 +44,17 @@ async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
-attrs==25.3.0
+attrs==26.1.0
     # via aiohttp
 authlib==1.4.1
     # via superdesk-core
-babel==2.17.0
+babel==2.18.0
     # via quart-babel
 bcrypt==4.2.1
     # via superdesk-core
 behave==1.2.6
     # via wooper
-billiard==4.2.1
+billiard==4.2.4
     # via celery
 black==23.12.1
     # via -r black-requirements.txt
@@ -81,13 +81,13 @@ cachetools==5.5.2
     # via
     #   flask-oidc-ex
     #   google-auth
-celery[redis]==5.4.0
+celery[redis]==5.6.3
     # via superdesk-core
-cerberus==1.3.7
+cerberus==1.3.8
     # via
     #   eve
     #   superdesk-core
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   elastic-apm
     #   elasticsearch
@@ -97,7 +97,7 @@ cffi==2.0.0
     # via cryptography
 chardet==5.2.0
     # via superdesk-core
-charset-normalizer==3.4.3
+charset-normalizer==3.4.7
     # via
     #   reportlab
     #   requests
@@ -119,19 +119,19 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-coverage[toml]==7.10.6
+coverage[toml]==7.13.5
     # via pytest-cov
 croniter==6.0.0
     # via superdesk-core
-cryptography==45.0.7
+cryptography==46.0.7
     # via
     #   authlib
     #   jwcrypto
     #   pyhanko
     #   pyhanko-certvalidator
-cssselect2==0.8.0
+cssselect2==0.9.0
     # via svglib
-deepdiff==8.6.1
+deepdiff==9.0.0
     # via superdesk-planning
 defusedxml==0.7.1
     # via pyhanko
@@ -141,11 +141,11 @@ dnspython==2.8.0
     #   pymongo
 draftjs-exporter[lxml]==2.1.0
     # via superdesk-core
-ecs-logging==2.2.0
+ecs-logging==2.3.0
     # via elastic-apm
-elastic-apm[flask]==6.24.0
+elastic-apm[flask]==6.25.0
     # via superdesk-core
-elasticsearch[async]==7.17.12
+elasticsearch[async]==7.17.13
     # via
     #   eve-elastic
     #   superdesk-core
@@ -155,8 +155,9 @@ eve @ git+https://github.com/superdesk/eve@async
     # via superdesk-core
 eve-elastic @ git+https://github.com/superdesk/eve-elastic@async
     # via superdesk-core
-exceptiongroup==1.3.0
+exceptiongroup==1.3.1
     # via
+    #   celery
     #   hypercorn
     #   pytest
     #   taskgroup
@@ -164,14 +165,14 @@ feedparser==6.0.12
     # via superdesk-core
 flake8==7.3.0
     # via -r dev-requirements.in
-flask==3.1.2
+flask==3.1.3
     # via
     #   flask-caching
     #   flask-mail
     #   flask-oidc-ex
     #   flask-webpack
     #   quart
-flask-caching==2.3.1
+flask-caching==2.4.0
     # via -r requirements.txt
 flask-mail==0.10.0
     # via superdesk-core
@@ -179,7 +180,7 @@ flask-oidc-ex==0.6.2
     # via superdesk-core
 flask-webpack==0.1.0
     # via -r requirements.txt
-frozenlist==1.7.0
+frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
@@ -205,7 +206,7 @@ html5lib==1.1
     # via xhtml2pdf
 httmock==1.4.0
     # via -r dev-requirements.in
-httplib2==0.31.0
+httplib2==0.31.2
     # via oauth2client
 hypercorn==0.18.0
     # via
@@ -213,14 +214,14 @@ hypercorn==0.18.0
     #   quart
 hyperframe==6.1.0
     # via h2
-icalendar==5.0.13
+icalendar==5.0.14
     # via superdesk-planning
-idna==3.10
+idna==3.11
     # via
     #   email-validator
     #   requests
     #   yarl
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
 isodate==0.7.2
     # via python3-saml
@@ -233,19 +234,17 @@ jinja2==3.1.6
     # via
     #   flask
     #   quart
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   aiobotocore
     #   boto3
     #   botocore
-jwcrypto==1.5.6
+jwcrypto==1.5.7
     # via
     #   flask-oidc-ex
     #   python-jwt
-kombu==5.4.2
-    # via
-    #   celery
-    #   superdesk-core
+kombu[redis]==5.6.2
+    # via celery
 ldap3==2.9.1
     # via superdesk-core
 lxml==5.3.2
@@ -256,9 +255,9 @@ lxml==5.3.2
     #   superdesk-core
     #   svglib
     #   xmlsec
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.4
     # via superdesk-core
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   flask
     #   jinja2
@@ -270,7 +269,7 @@ mccabe==0.7.0
     # via flake8
 motor==3.7.1
     # via superdesk-core
-multidict==6.6.4
+multidict==6.7.1
     # via
     #   aiobotocore
     #   aiohttp
@@ -289,24 +288,25 @@ orderly-set==5.5.0
     # via deepdiff
 oscrypto==1.3.0
     # via pyhanko-certvalidator
-packaging==25.0
+packaging==26.1
     # via
     #   black
+    #   kombu
     #   pytest
-parse==1.20.2
+parse==1.21.1
     # via
     #   behave
     #   parse-type
 parse-type==0.6.6
     # via behave
-pathspec==0.12.1
+pathspec==1.0.4
     # via black
 pillow==11.1.0
     # via
     #   reportlab
     #   superdesk-core
     #   xhtml2pdf
-platformdirs==4.4.0
+platformdirs==4.9.6
     # via black
 pluggy==1.6.0
     # via
@@ -316,11 +316,11 @@ priority==2.0.0
     # via hypercorn
 prompt-toolkit==3.0.52
     # via click-repl
-propcache==0.3.2
+propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-pyasn1==0.6.1
+pyasn1==0.6.3
     # via
     #   ldap3
     #   oauth2client
@@ -332,7 +332,7 @@ pyasn1-modules==0.4.2
     #   oauth2client
 pycodestyle==2.14.0
     # via flake8
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pydantic==2.12.5
     # via
@@ -342,7 +342,7 @@ pydantic-core==2.41.5
     # via pydantic
 pyflakes==3.4.0
     # via flake8
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pyhanko==0.28.0
     # via xhtml2pdf
@@ -359,11 +359,11 @@ pymongo==4.9.2
     #   eve
     #   motor
     #   superdesk-core
-pyparsing==3.2.3
+pyparsing==3.3.2
     # via
     #   httplib2
     #   pyrtf3
-pypdf==6.4.0
+pypdf==6.10.2
     # via xhtml2pdf
 pyrtf3==0.47.5
     # via -r requirements.txt
@@ -375,7 +375,7 @@ pytest==8.4.2
     #   pytest-mock
 pytest-asyncio==0.26.0
     # via -r dev-requirements.in
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r dev-requirements.in
 pytest-mock==3.15.1
     # via -r dev-requirements.in
@@ -400,14 +400,14 @@ python-twitter==3.5
     # via superdesk-core
 python3-saml==1.16.0
     # via -r requirements.txt
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   croniter
     #   eve-elastic
     #   icalendar
     #   quart-babel
     #   superdesk-core
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   pyhanko
     #   responses
@@ -434,18 +434,16 @@ quart-uploads==0.0.4
     # via quart-wtforms
 quart-wtforms==1.0.3
     # via -r requirements.txt
-redis==5.2.1
-    # via
-    #   celery
-    #   superdesk-core
+redis==6.4.0
+    # via kombu
 regex==2024.11.6
     # via superdesk-core
-reportlab==4.4.3
+reportlab==4.4.10
     # via
     #   superdesk-core
     #   svglib
     #   xhtml2pdf
-requests==2.32.5
+requests==2.33.1
     # via
     #   httmock
     #   pyhanko
@@ -465,11 +463,11 @@ rsa==4.9.1
     #   oauth2client
 s3transfer==0.11.3
     # via boto3
-sentry-sdk[quart]==2.37.1
+sentry-sdk[quart]==2.58.0
     # via superdesk-core
 sgmllib3k==1.0.0
     # via feedparser
-simplejson==3.20.1
+simplejson==3.20.2
     # via eve
 six==1.17.0
     # via
@@ -488,18 +486,18 @@ svglib==1.5.1
     # via xhtml2pdf
 taskgroup==0.2.2
     # via hypercorn
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via
     #   cssselect2
     #   svglib
-tomli==2.2.1
+tomli==2.4.1
     # via
     #   black
     #   coverage
     #   hypercorn
     #   mypy
     #   pytest
-types-aiofiles==24.1.0.20250822
+types-aiofiles==25.1.0.20260409
     # via quart-uploads
 types-click==7.1.8
     # via types-flask
@@ -511,13 +509,13 @@ types-jinja2==2.11.9
     #   types-flask
 types-markupsafe==1.1.10
     # via types-jinja2
-types-protobuf==6.32.1.20251105
+types-protobuf==7.34.1.20260408
     # via -r mypy-requirements.txt
-types-python-dateutil==2.9.0.20251115
+types-python-dateutil==2.9.0.20260408
     # via
     #   -r mypy-requirements.txt
     #   arrow
-types-pytz==2025.2.0.20251108
+types-pytz==2026.1.1.20260408
     # via
     #   -r mypy-requirements.txt
     #   quart-babel
@@ -538,6 +536,7 @@ typing-extensions==4.15.0
     #   aiosignal
     #   asgiref
     #   black
+    #   cryptography
     #   exceptiongroup
     #   hypercorn
     #   jwcrypto
@@ -550,19 +549,18 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.2
-    # via
-    #   celery
-    #   kombu
+tzdata==2026.1
+    # via kombu
 tzlocal==5.3.1
     # via
+    #   celery
     #   pyhanko
     #   superdesk-core
 unidecode==1.3.8
     # via superdesk-core
-uritools==5.0.0
+uritools==6.0.1
     # via pyhanko-certvalidator
-urllib3==1.26.20
+urllib3==2.6.3
     # via
     #   botocore
     #   elastic-apm
@@ -576,16 +574,16 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via prompt-toolkit
 webencodings==0.5.1
     # via
     #   cssselect2
     #   html5lib
     #   tinycss2
-websockets==13.1
+websockets==16.0
     # via superdesk-core
-werkzeug==3.1.4
+werkzeug==3.1.8
     # via
     #   flask
     #   quart
@@ -595,7 +593,7 @@ wrapt==1.17.3
     # via
     #   aiobotocore
     #   elastic-apm
-wsproto==1.2.0
+wsproto==1.3.2
     # via hypercorn
 wtforms[email]==3.2.1
     # via
@@ -608,7 +606,7 @@ xmlsec==1.3.14
     # via
     #   python3-saml
     #   superdesk-core
-yarl==1.20.1
+yarl==1.23.0
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/newsroom/auth/session_auth.py
+++ b/newsroom/auth/session_auth.py
@@ -6,13 +6,14 @@ from bson import ObjectId
 from bson.errors import InvalidId
 from quart_babel import gettext
 
-from superdesk.core import get_current_app, get_app_config
+from superdesk.core import get_app_config
 from superdesk.core.types import Request
 from superdesk.core.auth.user_auth import UserAuthProtocol
 from superdesk.flask import url_for
 from superdesk.utc import utcnow
 
 from newsroom.types import CompanyResource, UserResourceModel, UserRole
+from newsroom.core import get_current_wsgi_app
 from newsroom.flask import flash
 from newsroom.companies import CompanyServiceAsync
 from newsroom.users.service import UsersService
@@ -123,7 +124,7 @@ class NewshubSessionAuth(UserAuthProtocol):
             await UsersService().system_update(user.id, updates)
             user.last_active = current_time
             user.is_validated = True
-            get_current_app().as_any().cache.set(str(user.id), user.to_json())
+            get_current_wsgi_app().cache.set_in_background(str(user.id), user.to_json())
 
     async def stop_session(self, request: "Request") -> None:
         await super().stop_session(request)

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -114,7 +114,7 @@ def email_has_exceeded_max_login_attempts(email):
         return True
 
     # TODO: What do we do if connection to Redis is lost???
-    #       As this raises a security issue, Redis is down, account never get's disabled
+    #       As this raises a security issue, Redis is down, account never gets disabled
     #       Do we use MongoDB, $set and $inc on the collection itself?
     app = get_current_app().as_any()
     login_attempt = app.cache.get(email)

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -65,7 +65,7 @@ async def login(req: Request):
         auth = get_current_auth()
         await auth.stop_session(req)
 
-        if email_has_exceeded_max_login_attempts(form.email.data):
+        if await email_has_exceeded_max_login_attempts(form.email.data):
             return await render_template("account_locked.html", form=form)
 
         user = await UsersAuthService().get_by_email(form.email.data)
@@ -93,7 +93,7 @@ async def login(req: Request):
                 # Password login is not enabled for this user's company, and the user is not an admin
                 await flash(gettext(f"Invalid login type, please login using '{auth_provider.name}'"), "danger")
             else:
-                if not _is_password_valid(form.password.data.encode("UTF-8"), user):
+                if not await _is_password_valid(form.password.data.encode("UTF-8"), user):
                     await flash(gettext("Invalid username or password."), "danger")
                 else:
                     await auth.start_session(req, user, permanent=form.remember_me.data)
@@ -102,7 +102,7 @@ async def login(req: Request):
     return await render_template("login.html", form=form, firebase=get_app_config("FIREBASE_ENABLED"))
 
 
-def email_has_exceeded_max_login_attempts(email):
+async def email_has_exceeded_max_login_attempts(email) -> bool:
     """
     Checks if the user with given email has exceeded maximum number of
     allowed attempts before the successful login.
@@ -116,15 +116,15 @@ def email_has_exceeded_max_login_attempts(email):
     # TODO: What do we do if connection to Redis is lost???
     #       As this raises a security issue, Redis is down, account never gets disabled
     #       Do we use MongoDB, $set and $inc on the collection itself?
-    app = get_current_app().as_any()
-    login_attempt = app.cache.get(email)
+    app = get_current_wsgi_app()
+    login_attempt = await app.cache.get_in_background(email)
 
     if not login_attempt or "attempt_count" not in login_attempt:
-        app.cache.set(email, {"attempt_count": 0})
+        app.cache.set_in_background(email, {"attempt_count": 0})
         return False
 
     login_attempt["attempt_count"] += 1
-    app.cache.set(email, login_attempt)
+    app.cache.set_in_background(email, login_attempt)
     max_attempt_allowed = get_app_config("MAXIMUM_FAILED_LOGIN_ATTEMPTS")
 
     if login_attempt["attempt_count"] >= max_attempt_allowed:
@@ -137,7 +137,7 @@ def email_has_exceeded_max_login_attempts(email):
     return login_attempt["attempt_count"] >= max_attempt_allowed
 
 
-def _is_password_valid(password: bytes, user: UserAuthResourceModel):
+async def _is_password_valid(password: bytes, user: UserAuthResourceModel) -> bool:
     """
     Checks the password of the user
     """
@@ -146,9 +146,9 @@ def _is_password_valid(password: bytes, user: UserAuthResourceModel):
         return False
 
     app = get_current_wsgi_app()
-    previous_login_attempt = app.cache.get(user.email) or {}
+    previous_login_attempt = (await app.cache.get_in_background(user.email)) or {}
     previous_login_attempt["user_id"] = user.id
-    app.cache.set(user.email, previous_login_attempt)
+    app.cache.set_in_background(user.email, previous_login_attempt)
 
     try:
         hashed = user.password.encode("UTF-8")
@@ -176,12 +176,12 @@ async def get_login_token(req: Request):
     if not email or not password:
         return await req.abort(400)
 
-    if email_has_exceeded_max_login_attempts(email):
+    if await email_has_exceeded_max_login_attempts(email):
         return await req.abort(401, gettext("Exceeded number of allowed login attempts"))
 
     user_auth = await UsersAuthService().get_by_email(email)
 
-    if user_auth is not None and _is_password_valid(password.encode("UTF-8"), user_auth):
+    if user_auth is not None and await _is_password_valid(password.encode("UTF-8"), user_auth):
         user = await UsersService().find_by_id(user_auth.id)
         company = await user.get_company()
 
@@ -444,7 +444,7 @@ async def change_password(req: Request):
             user_auth = await UsersAuthService().get_by_email(user.email)
             if user_auth is None:
                 await flash(gettext("Invalid username or password."), "danger")
-            elif not _is_password_valid(form.old_password.data.encode("UTF-8"), user_auth):
+            elif not await _is_password_valid(form.old_password.data.encode("UTF-8"), user_auth):
                 await flash(gettext("Invalid username or password."), "danger")
             else:
                 updates = {"password": form.new_password.data}

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -21,6 +21,7 @@ from superdesk.utc import utcnow
 
 from newsroom.flask import flash
 from newsroom.types import AuthProviderType, UserAuthResourceModel, User, UserRole, Company
+from newsroom.core import get_current_wsgi_app
 from newsroom.auth.forms import SignupForm, LoginForm, TokenForm, ResetPasswordForm
 from newsroom.auth.utils import (
     redirect_to_next_url,
@@ -112,6 +113,9 @@ def email_has_exceeded_max_login_attempts(email):
     if not email:
         return True
 
+    # TODO: What do we do if connection to Redis is lost???
+    #       As this raises a security issue, Redis is down, account never get's disabled
+    #       Do we use MongoDB, $set and $inc on the collection itself?
     app = get_current_app().as_any()
     login_attempt = app.cache.get(email)
 
@@ -141,7 +145,7 @@ def _is_password_valid(password: bytes, user: UserAuthResourceModel):
     if not user.password:
         return False
 
-    app = get_current_app().as_any()
+    app = get_current_wsgi_app()
     previous_login_attempt = app.cache.get(user.email) or {}
     previous_login_attempt["user_id"] = user.id
     app.cache.set(user.email, previous_login_attempt)
@@ -154,7 +158,7 @@ def _is_password_valid(password: bytes, user: UserAuthResourceModel):
     try:
         if bcrypt.checkpw(password, hashed):
             # login successful so remove the login attempt check record
-            app.cache.delete(user.email)
+            app.cache.delete_in_thread(user.email)
             return True
     except (TypeError, ValueError):
         return False
@@ -344,7 +348,7 @@ async def reset_password(args: LoginTokenRouteArgs, params: None, req: Request) 
 
         return req.redirect(url_for("auth.login"))
 
-    get_current_app().as_any().cache.delete(user.email)
+    get_current_wsgi_app().cache.delete_in_thread(user.email)
     return await render_template("reset_password.html", form=form, token=args.token)
 
 

--- a/newsroom/auth/views.py
+++ b/newsroom/auth/views.py
@@ -158,7 +158,7 @@ def _is_password_valid(password: bytes, user: UserAuthResourceModel):
     try:
         if bcrypt.checkpw(password, hashed):
             # login successful so remove the login attempt check record
-            app.cache.delete_in_thread(user.email)
+            app.cache.delete_in_background(user.email)
             return True
     except (TypeError, ValueError):
         return False
@@ -348,7 +348,7 @@ async def reset_password(args: LoginTokenRouteArgs, params: None, req: Request) 
 
         return req.redirect(url_for("auth.login"))
 
-    get_current_wsgi_app().cache.delete_in_thread(user.email)
+    get_current_wsgi_app().cache.delete_in_background(user.email)
     return await render_template("reset_password.html", form=form, token=args.token)
 
 

--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -120,7 +120,7 @@ class CompaniesService(newsroom.Service):
             ]
 
     def on_updated(self, updates, original):
-        get_current_wsgi_app().cache.delete_in_thread(str(original["_id"]))
+        get_current_wsgi_app().cache.delete_in_background(str(original["_id"]))
 
         updated = original.copy()
         updated.update(updates)
@@ -152,7 +152,7 @@ class CompaniesService(newsroom.Service):
                 user_service.patch(user[ID_FIELD], updates=user_updates)
 
     def on_deleted(self, doc):
-        get_current_wsgi_app().cache.delete_in_thread(str(doc["_id"]))
+        get_current_wsgi_app().cache.delete_in_background(str(doc["_id"]))
 
     def validate_auth_provider(self, company):
         supported_provider_ids = [provider["_id"] for provider in get_app_config("AUTH_PROVIDERS")]

--- a/newsroom/companies/companies.py
+++ b/newsroom/companies/companies.py
@@ -1,13 +1,14 @@
 from quart_babel import gettext
 from content_api import MONGO_PREFIX
 
-from superdesk.core import get_current_app, get_app_config
+from superdesk.core import get_app_config
 from superdesk.flask import abort
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service
 import newsroom
 
 from newsroom.types import SectionEnum
+from newsroom.core import get_current_wsgi_app
 
 from .utils import get_company_section_names, get_company_product_ids
 
@@ -119,7 +120,7 @@ class CompaniesService(newsroom.Service):
             ]
 
     def on_updated(self, updates, original):
-        get_current_app().as_any().cache.delete(str(original["_id"]))
+        get_current_wsgi_app().cache.delete_in_thread(str(original["_id"]))
 
         updated = original.copy()
         updated.update(updates)
@@ -151,7 +152,7 @@ class CompaniesService(newsroom.Service):
                 user_service.patch(user[ID_FIELD], updates=user_updates)
 
     def on_deleted(self, doc):
-        get_current_app().as_any().cache.delete(str(doc["_id"]))
+        get_current_wsgi_app().cache.delete_in_thread(str(doc["_id"]))
 
     def validate_auth_provider(self, company):
         supported_provider_ids = [provider["_id"] for provider in get_app_config("AUTH_PROVIDERS")]

--- a/newsroom/companies/companies_async/service.py
+++ b/newsroom/companies/companies_async/service.py
@@ -12,6 +12,7 @@ from ..utils import get_company_section_names, get_company_product_ids, get_user
 
 class CompanyService(NewshubAsyncResourceService[CompanyResource]):
     resource_name = "companies"
+    add_item_to_cache_on_create = True
     clear_item_cache_on_update = True
 
     async def on_create(self, docs: List[CompanyResource]) -> None:

--- a/newsroom/core/resources/service.py
+++ b/newsroom/core/resources/service.py
@@ -34,7 +34,7 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
     async def on_created(self, docs: list[NewshubResourceModelType]) -> None:
         await super().on_created(docs)
         if self.add_item_to_cache_on_create and docs:
-            get_current_wsgi_app().cache.set_many_in_thread({str(doc.id): doc.to_dict() for doc in docs})
+            get_current_wsgi_app().cache.set_many_in_background({str(doc.id): doc.to_dict() for doc in docs})
 
     async def on_update(self, updates: dict[str, Any], original: NewshubResourceModelType) -> None:
         from newsroom.auth.utils import get_user_or_none_from_request
@@ -55,7 +55,7 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
             self.delete_item_from_cache(doc)
 
     def delete_item_from_cache(self, doc: NewshubResourceModelType) -> None:
-        get_current_wsgi_app().cache.delete_in_thread(str(doc.id))
+        get_current_wsgi_app().cache.delete_in_background(str(doc.id))
 
     async def find_items_by_ids(self, ids: list[str] | list[ObjectId]) -> list[NewshubResourceModelType]:
         """

--- a/newsroom/core/resources/service.py
+++ b/newsroom/core/resources/service.py
@@ -18,6 +18,7 @@ NewshubResourceModelType = TypeVar("NewshubResourceModelType", bound=NewshubReso
 
 
 class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceModelType]]):
+    add_item_to_cache_on_create: ClassVar[bool] = False
     clear_item_cache_on_update: ClassVar[bool] = False
 
     async def on_create(self, docs: list[NewshubResourceModelType]) -> None:
@@ -30,6 +31,10 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
                 doc.original_creator = current_user.id
                 doc.version_creator = current_user.id
 
+    async def on_created(self, docs: list[NewshubResourceModelType]) -> None:
+        if self.add_item_to_cache_on_create and docs:
+            get_current_wsgi_app().cache.set_many_in_thread({str(doc.id): doc.to_dict() for doc in docs})
+
     async def on_update(self, updates: dict[str, Any], original: NewshubResourceModelType) -> None:
         from newsroom.auth.utils import get_user_or_none_from_request
 
@@ -41,14 +46,15 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
     async def on_updated(self, updates: dict[str, Any], original: NewshubResourceModelType) -> None:
         await super().on_updated(updates, original)
         if self.clear_item_cache_on_update:
-            app = get_current_wsgi_app()
-            app.cache.delete(str(original.id))
+            self.delete_item_from_cache(original)
 
     async def on_deleted(self, doc: NewshubResourceModelType):
         await super().on_deleted(doc)
         if self.clear_item_cache_on_update:
-            app = get_current_wsgi_app()
-            app.cache.delete(str(doc.id))
+            self.delete_item_from_cache(doc)
+
+    def delete_item_from_cache(self, doc: NewshubResourceModelType) -> None:
+        get_current_wsgi_app().cache.delete_in_thread(str(doc.id))
 
     async def find_items_by_ids(self, ids: list[str] | list[ObjectId]) -> list[NewshubResourceModelType]:
         """

--- a/newsroom/core/resources/service.py
+++ b/newsroom/core/resources/service.py
@@ -32,6 +32,7 @@ class NewshubAsyncResourceService(AsyncResourceService[Generic[NewshubResourceMo
                 doc.version_creator = current_user.id
 
     async def on_created(self, docs: list[NewshubResourceModelType]) -> None:
+        await super().on_created(docs)
         if self.add_item_to_cache_on_create and docs:
             get_current_wsgi_app().cache.set_many_in_thread({str(doc.id): doc.to_dict() for doc in docs})
 

--- a/newsroom/factory/app.py
+++ b/newsroom/factory/app.py
@@ -11,7 +11,6 @@ import pathlib
 import importlib
 
 from flask_mail import Mail
-from flask_caching import Cache
 from elasticapm.contrib.flask import ElasticAPM
 from pydantic import ValidationError
 from eve.io.mongo import ensure_mongo_indexes
@@ -32,6 +31,8 @@ from newsroom.exceptions import AuthorizationError
 from newsroom.utils import is_json_request, parse_validation_error
 from newsroom.gettext import setup_babel
 
+from .cache import NewshubCache
+
 
 NEWSROOM_DIR = pathlib.Path(__file__).resolve().parent.parent
 
@@ -43,6 +44,7 @@ class BaseNewsroomApp(SuperdeskEve):
     DATALAYER = SuperdeskDataLayer
     AUTH_SERVICE = SessionAuth
     INSTANCE_CONFIG = None
+    cache: NewshubCache
 
     def __init__(self, import_name=__package__, config=None, testing=False, **kwargs):
         """Override __init__ to do Newsroom specific config and still be able
@@ -171,7 +173,7 @@ class BaseNewsroomApp(SuperdeskEve):
 
     def setup_cache(self):
         cache_backend.init_app(self)
-        self.cache = Cache(self)
+        self.cache = NewshubCache(self)
 
     def setup_error_handlers(self):
         def assertion_error(err):

--- a/newsroom/factory/cache.py
+++ b/newsroom/factory/cache.py
@@ -28,7 +28,7 @@ class NewshubCache(Cache):
 
         super().init_app(app, config)  # type: ignore[arg-type]
 
-    def set_in_thread(self, key: str, value: Any, timeout: int | None = None):
+    def set_in_background(self, key: str, value: Any, timeout: int | None = None):
         """
         Add/update a key/value pair in the cache, in a background thread.
 
@@ -41,7 +41,7 @@ class NewshubCache(Cache):
 
         get_current_wsgi_app().add_background_task(self.set, key, value, timeout=timeout)
 
-    def set_many_in_thread(self, mapping: dict, timeout: int | None = None) -> None:
+    def set_many_in_background(self, mapping: dict, timeout: int | None = None) -> None:
         """
         Set multiple keys and values from a mapping, in a background thread.
 
@@ -53,7 +53,7 @@ class NewshubCache(Cache):
 
         get_current_wsgi_app().add_background_task(self.set_many, mapping, timeout=timeout)
 
-    def delete_in_thread(self, key: str) -> None:
+    def delete_in_background(self, key: str) -> None:
         """
         Delete a key from the cache, in a background thread.
 
@@ -62,7 +62,7 @@ class NewshubCache(Cache):
 
         get_current_wsgi_app().add_background_task(self.delete, key)
 
-    def delete_many_in_thread(self, keys: list[str]):
+    def delete_many_in_background(self, keys: list[str]):
         """
         Delete multiple keys from the cache, in a background thread.
 
@@ -71,7 +71,7 @@ class NewshubCache(Cache):
 
         get_current_wsgi_app().add_background_task(self.delete_many, *keys)
 
-    async def get_in_thread(self, key: str, async_timeout: int = 2) -> Any:
+    async def get_in_background(self, key: str, async_timeout: int = 2) -> Any:
         """
         Look up key in the cache in a background thread, await until it's finished and return the result.
 
@@ -86,7 +86,7 @@ class NewshubCache(Cache):
         except asyncio.TimeoutError:
             return None
 
-    async def get_dict_in_thread(self, keys: list[str], async_timeout: int = 2) -> dict[str, Any] | None:
+    async def get_dict_in_background(self, keys: list[str], async_timeout: int = 2) -> dict[str, Any] | None:
         """
         Return a dictionary of key/value pairs for the given keys.
 

--- a/newsroom/factory/cache.py
+++ b/newsroom/factory/cache.py
@@ -4,6 +4,7 @@ from quart import Quart
 
 from flask_caching import Cache
 
+from superdesk.core import get_config
 from newsroom.core import get_current_wsgi_app
 
 
@@ -71,16 +72,20 @@ class NewshubCache(Cache):
 
         get_current_wsgi_app().add_background_task(self.delete_many, *keys)
 
-    async def get_in_background(self, key: str, async_timeout: int = 2) -> Any:
+    async def get_in_background(self, key: str, async_timeout: int | None = None) -> Any:
         """
         Look up key in the cache in a background thread, await until it's finished and return the result.
 
         :param key: The key to look up
         :param async_timeout: If the cache does not respond within this time, return None.
+                              (Defaults to the ``CACHE_REDIS_TIMEOUT`` setting)
         :return: The value for the key, or None if the key is not found.
         """
 
         try:
+            if async_timeout is None:
+                async_timeout = get_config(int, "CACHE_REDIS_TIMEOUT")
+
             loop = asyncio.get_running_loop()
             return await asyncio.wait_for(loop.run_in_executor(None, self.get, key), timeout=async_timeout)
         except asyncio.TimeoutError:

--- a/newsroom/factory/cache.py
+++ b/newsroom/factory/cache.py
@@ -1,0 +1,102 @@
+from typing import Any
+import asyncio
+from quart import Quart
+
+from flask_caching import Cache
+
+from newsroom.core import get_current_wsgi_app
+
+
+class NewshubCache(Cache):
+    def __init__(self, app: Quart, *args, **kwargs):
+        super().__init__(app, *args, **kwargs)  # type: ignore[arg-type]
+
+    def init_app(self, app: Quart, config: dict | None = None) -> None:  # type: ignore[override]
+        if app.config.get("CACHE_TYPE") == "redis":
+            if config is None:
+                config = {}
+
+            config.setdefault("CACHE_OPTIONS", {})
+            # Timeout for read/write operations (seconds)
+            config["CACHE_OPTIONS"].setdefault("socket_timeout", app.config.get("CACHE_REDIS_TIMEOUT", 10))
+            # Timeout for initial connection
+            config["CACHE_OPTIONS"].setdefault(
+                "socket_connect_timeout", app.config.get("CACHE_REDIS_CONNECT_TIMEOUT", 2)
+            )
+            # Optionally retry once after a timeout
+            config["CACHE_OPTIONS"]["retry_on_timeout"] = True
+
+        super().init_app(app, config)  # type: ignore[arg-type]
+
+    def set_in_thread(self, key: str, value: Any, timeout: int | None = None):
+        """
+        Add/update a key/value pair in the cache, in a background thread.
+
+        :param key: The key to set
+        :param value: The value for the key
+        :param timeout: The cache timeout for the key in seconds (if not
+                        specified, it uses the default timeout). A timeout of
+                        0 indicates that the cache never expires.
+        """
+
+        get_current_wsgi_app().add_background_task(self.set, key, value, timeout=timeout)
+
+    def set_many_in_thread(self, mapping: dict, timeout: int | None = None) -> None:
+        """
+        Set multiple keys and values from a mapping, in a background thread.
+
+        :param mapping: A mapping with the keys/values to set.
+        :param timeout: The cache timeout for the key in seconds (if not
+                        specified, it uses the default timeout). A timeout of
+                        0 indicates that the cache never expires.
+        """
+
+        get_current_wsgi_app().add_background_task(self.set_many, mapping, timeout=timeout)
+
+    def delete_in_thread(self, key: str) -> None:
+        """
+        Delete a key from the cache, in a background thread.
+
+        :param key: The key to delete
+        """
+
+        get_current_wsgi_app().add_background_task(self.delete, key)
+
+    def delete_many_in_thread(self, keys: list[str]):
+        """
+        Delete multiple keys from the cache, in a background thread.
+
+        :param keys: The keys to delete
+        """
+
+        get_current_wsgi_app().add_background_task(self.delete_many, *keys)
+
+    async def get_in_thread(self, key: str, async_timeout: int = 2) -> Any:
+        """
+        Look up key in the cache in a background thread, await until it's finished and return the result.
+
+        :param key: The key to look up
+        :param async_timeout: If the cache does not respond within this time, return None.
+        :return: The value for the key, or None if the key is not found.
+        """
+
+        try:
+            loop = asyncio.get_running_loop()
+            return await asyncio.wait_for(loop.run_in_executor(None, self.get, key), timeout=async_timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def get_dict_in_thread(self, keys: list[str], async_timeout: int = 2) -> dict[str, Any] | None:
+        """
+        Return a dictionary of key/value pairs for the given keys.
+
+        :param keys: The keys to look up
+        :param async_timeout: If the cache does not respond within this time, return None.
+        :return: A dictionary of key/value pairs, or None if the cache does not respond within the timeout.
+        """
+
+        try:
+            loop = asyncio.get_running_loop()
+            return await asyncio.wait_for(loop.run_in_executor(None, self.get_dict, *keys), timeout=async_timeout)
+        except asyncio.TimeoutError:
+            return None

--- a/newsroom/mgmt_api/companies.py
+++ b/newsroom/mgmt_api/companies.py
@@ -1,17 +1,14 @@
-from typing import List, Dict, Any
-
 from superdesk.core.module import Module
 from superdesk.core.resources import MongoResourceConfig, ResourceConfig, RestEndpointConfig
 
 from newsroom import MONGO_PREFIX
 from newsroom.types import CompanyResource
 from newsroom.companies.companies_async import CompanyService
-from newsroom.core import get_current_wsgi_app
 from .utils import validate_product_refs
 
 
 class CPCompaniesService(CompanyService):
-    async def on_create(self, docs: List[CompanyResource]):
+    async def on_create(self, docs: list[CompanyResource]):
         for doc in docs:
             if doc.products:
                 doc.products = await validate_product_refs(doc.products)
@@ -19,23 +16,10 @@ class CPCompaniesService(CompanyService):
                 doc.country = "CAN"
         await super().on_create(docs)
 
-    async def on_created(self, docs: List[CompanyResource]):
-        await super().on_created(docs)
-        app = get_current_wsgi_app()
-        for doc in docs:
-            app.cache.set(str(doc.id), doc)
-
-    async def on_update(self, updates: Dict[str, Any], original: CompanyResource):
+    async def on_update(self, updates: dict, original: CompanyResource):
         if updates.get("products"):
             updates["products"] = await validate_product_refs(updates["products"])
         await super().on_update(updates, original)
-        app = get_current_wsgi_app()
-        app.cache.delete(str(original.id))
-
-    async def on_delete(self, doc: CompanyResource):
-        await super().on_deleted(doc)
-        app = get_current_wsgi_app()
-        app.cache.delete(str(doc.id))
 
 
 company_resource_config = ResourceConfig(

--- a/newsroom/mgmt_api/topics.py
+++ b/newsroom/mgmt_api/topics.py
@@ -1,18 +1,18 @@
-from newsroom import MONGO_PREFIX
-from newsroom.core import get_current_wsgi_app
-from newsroom.types import TopicFolderResourceModel
-from newsroom.topics_folders.folders import FolderResourceService
-from newsroom.topics.topics_async import TopicResourceModel, TopicService
-
 from superdesk.core.module import Module
 from superdesk.errors import SuperdeskApiError
 from superdesk.core.resources import MongoResourceConfig, ResourceConfig, RestEndpointConfig
 
-from typing import Any, Dict, List
+from newsroom import MONGO_PREFIX
+from newsroom.types import TopicFolderResourceModel
+from newsroom.topics_folders.folders import FolderResourceService
+from newsroom.topics.topics_async import TopicResourceModel, TopicService
 
 
 class GlobalTopicsService(TopicService):
-    async def on_create(self, docs: List[TopicResourceModel]) -> None:
+    add_item_to_cache_on_create = True
+    clear_item_cache_on_update = True
+
+    async def on_create(self, docs: list[TopicResourceModel]) -> None:
         await super().on_create(docs)
         for doc in docs:
             user = doc.user
@@ -22,17 +22,6 @@ class GlobalTopicsService(TopicService):
             elif not doc.is_global:
                 message = "Please set is_global True, or provide user in the body."
                 raise SuperdeskApiError.badRequestError(message=message, payload=message)
-
-    async def on_created(self, docs: List[TopicResourceModel]) -> None:
-        await super().on_created(docs)
-        app = get_current_wsgi_app()
-        for doc in docs:
-            app.cache.set(str(doc.id), doc)
-
-    async def on_update(self, updates: Dict[str, Any], original: TopicResourceModel) -> None:
-        await super().on_update(updates, original)
-        app = get_current_wsgi_app()
-        app.cache.delete(str(original.id))
 
 
 topics_resource_config = ResourceConfig(

--- a/newsroom/mgmt_api/users.py
+++ b/newsroom/mgmt_api/users.py
@@ -45,7 +45,7 @@ class CPUsersService(UsersService):
 
     @override
     async def on_delete(self, doc: UserResourceModel) -> None:
-        # Skipping UsersService.on_updated as its validations are not needed for this API.
+        # Skipping UsersService.on_delete so delete-specific validations/side effects are bypassed for this API.
         await super(UsersService, self).on_delete(doc)
 
 

--- a/newsroom/mgmt_api/users.py
+++ b/newsroom/mgmt_api/users.py
@@ -3,7 +3,6 @@ from typing_extensions import override
 from bson.objectid import ObjectId
 
 from newsroom import MONGO_PREFIX
-from newsroom.core import get_current_wsgi_app
 from newsroom.mgmt_api.utils import validate_product_refs
 from newsroom.users.service import UsersService
 from newsroom.types import UserResourceModel
@@ -46,7 +45,8 @@ class CPUsersService(UsersService):
 
     @override
     async def on_delete(self, doc: UserResourceModel) -> None:
-        get_current_wsgi_app().cache.delete(str(doc.id))
+        # Skipping UsersService.on_updated as its validations are not needed for this API.
+        await super(UsersService, self).on_delete(doc)
 
 
 class UsersRestEndpoints(ResourceRestEndpoints):

--- a/newsroom/navigations/views.py
+++ b/newsroom/navigations/views.py
@@ -151,4 +151,4 @@ async def add_remove_products_for_navigation(nav_id: ObjectId, product_ids: list
         else:
             db.update_one({"_id": product["_id"]}, {"$pull": {"navigations": nav_id}})
 
-    cache.clean(["products"])
+    cache.clean_in_thread(["products"])

--- a/newsroom/public/views.py
+++ b/newsroom/public/views.py
@@ -5,10 +5,11 @@ from werkzeug.utils import secure_filename
 
 from superdesk.flask import render_template
 from superdesk.core.web import EndpointGroup
-from superdesk.core import get_current_app, get_app_config
+from superdesk.core import get_app_config
 
 from newsroom.auth.utils import is_valid_session
 from newsroom.types import Article, CardResourceModel
+from newsroom.core import get_current_wsgi_app
 from newsroom.wire.items import get_items_for_dashboard
 from newsroom.ui_config_async import UiConfigResourceService
 from newsroom.cards import CardsResourceService
@@ -21,37 +22,40 @@ public_endpoints = EndpointGroup("public", __name__)
 
 
 async def get_public_dashboard_config():
-    app = get_current_app().as_any()
-    if app.cache.get(PUBLIC_DASHBOARD_CONFIG_CACHE_KEY):
-        return app.cache.get(PUBLIC_DASHBOARD_CONFIG_CACHE_KEY)
-    ui_config_service = UiConfigResourceService()
+    app = get_current_wsgi_app()
 
+    if cached_data := await app.cache.get_in_background(PUBLIC_DASHBOARD_CONFIG_CACHE_KEY):
+        return cached_data
+
+    ui_config_service = UiConfigResourceService()
     config = await ui_config_service.get_section_config("home")
-    app.cache.set(
+    app.cache.set_in_background(
         PUBLIC_DASHBOARD_CONFIG_CACHE_KEY, config, timeout=get_app_config("PUBLIC_CONTENT_CACHE_TIMEOUT", 240)
     )
     return config
 
 
 async def get_public_items_by_cards() -> Dict[str, List[Article]]:
-    app = get_current_app().as_any()
-    if app.cache.get(PUBLIC_DASHBOARD_ITEMS_CACHE_KEY):
-        return app.cache.get(PUBLIC_DASHBOARD_ITEMS_CACHE_KEY)
+    app = get_current_wsgi_app()
+    if cached_data := await app.cache.get_in_background(PUBLIC_DASHBOARD_ITEMS_CACHE_KEY):
+        return cached_data
 
     items_by_card = await get_items_for_dashboard(await get_public_cards(), True, True)
-    app.cache.set(
+    app.cache.set_in_background(
         PUBLIC_DASHBOARD_ITEMS_CACHE_KEY, items_by_card, timeout=get_app_config("PUBLIC_CONTENT_CACHE_TIMEOUT", 240)
     )
     return items_by_card
 
 
 async def get_public_cards() -> List[CardResourceModel]:
-    app = get_current_app().as_any()
-    if app.cache.get(PUBLIC_DASHBOARD_CARDS_CACHE_KEY):
-        return app.cache.get(PUBLIC_DASHBOARD_CARDS_CACHE_KEY)
+    app = get_current_wsgi_app()
+    if cached_data := await app.cache.get_in_background(PUBLIC_DASHBOARD_CARDS_CACHE_KEY):
+        return cached_data
 
     cards = await (await CardsResourceService().find({"dashboard": "newsroom"})).to_list()
-    app.cache.set(PUBLIC_DASHBOARD_CARDS_CACHE_KEY, cards, timeout=get_app_config("PUBLIC_CONTENT_CACHE_TIMEOUT", 240))
+    app.cache.set_in_background(
+        PUBLIC_DASHBOARD_CARDS_CACHE_KEY, cards, timeout=get_app_config("PUBLIC_CONTENT_CACHE_TIMEOUT", 240)
+    )
 
     return cards
 

--- a/newsroom/users/service.py
+++ b/newsroom/users/service.py
@@ -36,6 +36,7 @@ from .users import COMPANY_ADMIN_ALLOWED_PRODUCT_UPDATES, COMPANY_ADMIN_ALLOWED_
 
 class UsersService(NewshubAsyncResourceService[UserResourceModel]):
     resource_name = "users"
+    clear_item_cache_on_update = True
 
     async def authorize(self, request: Request):
         current_user = get_user_or_none_from_request(request)
@@ -77,11 +78,9 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
             updates["sections"] = get_updated_sections(updates, original, company)
             updates["products"] = get_updated_products(updates, original, company)
 
-        app = get_current_wsgi_app()
-        app.cache.delete(str(original.id))
-        app.cache.delete(original.email)
-
     async def on_updated(self, updates: dict[str, Any], original: UserResourceModel):
+        await super().on_updated(updates, original)
+
         if is_from_request():
             # If this is from a request, test to see if we need to update the
             # current user cached in request storage
@@ -100,7 +99,7 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
         await user_updated.send(updated, updates)
 
     async def on_deleted(self, doc):
-        get_current_wsgi_app().cache.delete(str(doc.id))
+        await super().on_deleted(doc)
         await user_deleted.send(doc)
 
     async def on_delete(self, doc):
@@ -110,6 +109,9 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
         user = await self.find_by_id(doc.id)
         await self.check_permissions(user, None, "DELETE")
         await super().on_delete(doc)
+
+    def delete_item_from_cache(self, doc: UserResourceModel) -> None:
+        get_current_wsgi_app().cache.delete_many_in_thread([str(doc.id), doc.email])
 
     async def check_permissions(self, user: UserResourceModel, updates: dict | None, method: HTTP_METHOD):
         """Check if current user has permissions to edit user."""
@@ -172,10 +174,7 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
         notification_schedule = deepcopy(user.notification_schedule)
         notification_schedule.last_run_time = run_time
         await self.update(user.id, {"notification_schedule": notification_schedule})
-
-        app = self.app.wsgi
-        app.cache.delete(str(user.id))
-        app.cache.delete(user.email)
+        self.delete_item_from_cache(user)
 
     @staticmethod
     def user_has_paused_notifications(user: User) -> bool:
@@ -212,16 +211,13 @@ class UsersAuthService(NewshubAsyncResourceService[UserAuthResourceModel]):
         if "password" in updates:
             updates["password"] = self._get_password_hash(updates["password"])
 
-        app = get_current_wsgi_app()
-        app.cache.delete(str(original.id))
-        app.cache.delete(original.email)
-
     async def on_updated(self, updates: dict[str, Any], original: UserAuthResourceModel):
+        await super().on_updated(updates, original)
         updated = original.model_copy(update=updates)
         await user_updated.send(updated, updates)
 
     async def on_deleted(self, doc):
-        get_current_wsgi_app().cache.delete(str(doc.id))
+        await super().on_deleted(doc)
         await user_deleted.send(doc)
 
     def _get_password_hash(self, password):

--- a/newsroom/users/service.py
+++ b/newsroom/users/service.py
@@ -111,7 +111,7 @@ class UsersService(NewshubAsyncResourceService[UserResourceModel]):
         await super().on_delete(doc)
 
     def delete_item_from_cache(self, doc: UserResourceModel) -> None:
-        get_current_wsgi_app().cache.delete_many_in_thread([str(doc.id), doc.email])
+        get_current_wsgi_app().cache.delete_many_in_background([str(doc.id), doc.email])
 
     async def check_permissions(self, user: UserResourceModel, updates: dict | None, method: HTTP_METHOD):
         """Check if current user has permissions to edit user."""

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -389,40 +389,6 @@ async def get_company_dict_async(use_globals: bool = True) -> Dict[ObjectId, Com
     return companies_dict
 
 
-def get_cached_resource_by_id(resource, _id, black_list_keys=None):
-    """If the document exist in cache then return the document form cache
-    else fetch the document from the database store in the cache and return the document.
-
-
-    :param str resource: Name of the resource
-    :param _id: id
-    :param set black_list_keys: black list of keys to exclude from the document.
-    """
-    app = get_current_app().as_any()
-    item = app.cache.get(str(_id))
-    if item:
-        return loads(item)
-    try:
-        # item is not stored in cache
-        item = superdesk.get_resource_service(resource).find_one(req=None, _id=_id)
-    except KeyError:
-        item = None
-    if item:
-        if not black_list_keys:
-            black_list_keys = {
-                "password",
-                "token",
-                "token_expiry",
-                "_id",
-                "_updated",
-                "_etag",
-            }
-        item = {key: item[key] for key in item.keys() if key not in black_list_keys}
-        app.cache.set(str(_id), json.dumps(item, default=json_serialize_datetime_objectId))
-        return item
-    return None
-
-
 def get_items_by_id(ids, resource):
     try:
         return list(superdesk.get_resource_service(resource).find(where={"_id": {"$in": ids}}))

--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -54,6 +54,8 @@ from superdesk.default_settings import (  # noqa
     SENTRY_TRACES_SAMPLE_RATE,
     SENTRY_PROFILES_SAMPLE_RATE,
     CACHE_URL,
+    CACHE_REDIS_TIMEOUT,
+    CACHE_REDIS_CONNECT_TIMEOUT,
 )
 
 from newsroom.types import AuthProviderConfig, AuthProviderType

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -10,7 +10,7 @@ from werkzeug.utils import secure_filename
 from quart_babel import gettext
 
 from superdesk.core.types import Request, Response
-from superdesk.core import get_app_config, get_current_app
+from superdesk.core import get_app_config
 from superdesk.flask import render_template, send_file
 from superdesk.utc import utcnow
 
@@ -147,12 +147,12 @@ async def get_view_data() -> dict:
 
 async def get_items_by_card(cards: list[CardResourceModel], company_id: ObjectId | None) -> dict[str, list[dict]]:
     cache_key = "{}{}".format(HOME_ITEMS_CACHE_KEY, company_id or "")
-    app = get_current_app().as_any()
-    if app.cache.get(cache_key):
-        return app.cache.get(cache_key)
+    app = get_current_wsgi_app()
+    if cached_items := await app.cache.get_in_background(cache_key):
+        return cached_items
 
     items_by_card = await get_items_for_dashboard(cards)
-    app.cache.set(cache_key, items_by_card, timeout=get_app_config("DASHBOARD_CACHE_TIMEOUT", 300))
+    app.cache.set_in_background(cache_key, items_by_card, timeout=get_app_config("DASHBOARD_CACHE_TIMEOUT", 300))
     return items_by_card
 
 
@@ -287,16 +287,16 @@ class MediaCardRouteArguments(BaseModel):
 @wire_endpoints.endpoint("/media_card_external/<card_id>")
 async def get_media_card_external(args: MediaCardRouteArguments, params: None, request: Request) -> Response:
     cache_id = "{}_{}".format(HOME_EXTERNAL_ITEMS_CACHE_KEY, args.card_id)
-    app = get_current_app().as_any()
+    app = get_current_wsgi_app()
 
-    if app.cache.get(cache_id):
-        card_items = app.cache.get(cache_id)
+    if cached_items := await app.cache.get_in_background(cache_id):
+        card_items = cached_items
     else:
         card = await CardsResourceService().find_by_id_raw(args.card_id)
         if not card:
             await request.abort(404)
         card_items = app.get_media_cards_external(card)
-        app.cache.set(cache_id, card_items, timeout=get_app_config("DASHBOARD_CACHE_TIMEOUT", 300))
+        app.cache.set_in_background(cache_id, card_items, timeout=get_app_config("DASHBOARD_CACHE_TIMEOUT", 300))
 
     return Response({"_items": card_items})
 

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -171,7 +171,7 @@ def delete_dashboard_caches():
         PUBLIC_DASHBOARD_CARDS_CACHE_KEY,
         PUBLIC_DASHBOARD_ITEMS_CACHE_KEY,
     ] + [f"{HOME_ITEMS_CACHE_KEY}{company['_id']}" for company in query_resource("companies")]
-    get_current_wsgi_app().cache.delete_many_in_thread(keys)
+    get_current_wsgi_app().cache.delete_many_in_background(keys)
 
 
 class DashboardTopicData(TypedDict):

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -24,6 +24,7 @@ from newsroom.types import (
     WireItem,
     DashboardCardType,
 )
+from newsroom.core import get_current_wsgi_app
 from newsroom.exceptions import AuthorizationError
 from newsroom.search.types import NewshubSearchRequest
 from newsroom.auth.utils import (
@@ -156,13 +157,21 @@ async def get_items_by_card(cards: list[CardResourceModel], company_id: ObjectId
 
 
 def delete_dashboard_caches():
-    app = get_current_app().as_any()
-    app.cache.delete(HOME_ITEMS_CACHE_KEY)
-    app.cache.delete(PUBLIC_DASHBOARD_CONFIG_CACHE_KEY)
-    app.cache.delete(PUBLIC_DASHBOARD_CARDS_CACHE_KEY)
-    app.cache.delete(PUBLIC_DASHBOARD_ITEMS_CACHE_KEY)
-    for company in query_resource("companies"):
-        app.cache.delete(f"{HOME_ITEMS_CACHE_KEY}{company['_id']}")
+    """Delete system caches used for the dashboard
+
+    .. note::
+        If the system has many companies, this would send many commands which could affect its performance.
+        Consider disabling ``DELETE_DASHBOARD_CACHE_ON_PUSH`` config, and modify ``DASHBOARD_CACHE_TIMEOUT``
+        to reflect desired homepage update rate.
+    """
+
+    keys = [
+        HOME_ITEMS_CACHE_KEY,
+        PUBLIC_DASHBOARD_CONFIG_CACHE_KEY,
+        PUBLIC_DASHBOARD_CARDS_CACHE_KEY,
+        PUBLIC_DASHBOARD_ITEMS_CACHE_KEY,
+    ] + [f"{HOME_ITEMS_CACHE_KEY}{company['_id']}" for company in query_resource("companies")]
+    get_current_wsgi_app().cache.delete_many_in_thread(*keys)
 
 
 class DashboardTopicData(TypedDict):

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -171,7 +171,7 @@ def delete_dashboard_caches():
         PUBLIC_DASHBOARD_CARDS_CACHE_KEY,
         PUBLIC_DASHBOARD_ITEMS_CACHE_KEY,
     ] + [f"{HOME_ITEMS_CACHE_KEY}{company['_id']}" for company in query_resource("companies")]
-    get_current_wsgi_app().cache.delete_many_in_thread(*keys)
+    get_current_wsgi_app().cache.delete_many_in_thread(keys)
 
 
 class DashboardTopicData(TypedDict):

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -387,13 +387,13 @@ async def test_is_user_valid_empty_password():
     password_str = "plaintextpassword"
     password = password_str.encode("utf-8")
     user_auth = UserAuthResourceModel(id=ObjectId(), email="foo@example.com", first_name="foo", last_name="bar")
-    assert not _is_password_valid(password, user_auth)
+    assert not await _is_password_valid(password, user_auth)
     user_auth.password = None
-    assert not _is_password_valid(password, user_auth)
+    assert not await _is_password_valid(password, user_auth)
     user_auth.password = password_str
-    assert not _is_password_valid(password, user_auth)
+    assert not await _is_password_valid(password, user_auth)
     user_auth.password = get_hash(password_str, 10)
-    assert _is_password_valid(password, user_auth)
+    assert await _is_password_valid(password, user_auth)
 
 
 async def test_login_for_public_user_if_company_not_assigned(client, app):

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -47,7 +47,7 @@ async def test_cache_many(app) -> None:
     for i in range(number_of_docs):
         docs[f"key{i}"] = f"value{i}"
     async with app.test_app():
-        app.cache.set_many_in_thread(docs)
+        app.cache.set_many_in_background(docs)
 
     results = await app.cache.get_dict_in_background(docs.keys())
     for i in range(number_of_docs):

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from quart import Quart, Config
+
+from newsroom.factory.cache import NewshubCache
+
+
+def test_cache_redis_args() -> None:
+    app = Quart(__name__)
+    app.config = Config(".")
+    app.config.from_object("newsroom.web.default_settings")
+
+    with patch("flask_caching.backends.redis") as mock_redis_backend:
+        NewshubCache(app)
+        args, kwargs = mock_redis_backend.call_args
+        assert args[3] == {
+            "default_timeout": 3600,
+            "retry_on_timeout": True,
+            "socket_connect_timeout": 2.0,
+            "socket_timeout": 10.0,
+        }
+
+    app.config.update({"CACHE_REDIS_TIMEOUT": 60, "CACHE_REDIS_CONNECT_TIMEOUT": 5})
+    with patch("flask_caching.backends.redis") as mock_redis_backend:
+        NewshubCache(app)
+        args, kwargs = mock_redis_backend.call_args
+        assert args[3] == {
+            "default_timeout": 3600,
+            "retry_on_timeout": True,
+            "socket_connect_timeout": 5,
+            "socket_timeout": 60,
+        }
+
+
+async def test_cache_get_set(app) -> None:
+    # Use ``test_app`` here to make sure background task is finished before proceeding
+    async with app.test_app():
+        app.cache.set_in_thread("foo", "bar")
+
+    foo = await app.cache.get_in_thread("foo")
+    assert foo == "bar"
+
+
+async def test_cache_many(app) -> None:
+    number_of_docs = 100
+    docs = {}
+    for i in range(number_of_docs):
+        docs[f"key{i}"] = f"value{i}"
+    async with app.test_app():
+        app.cache.set_many_in_thread(docs)
+
+    results = await app.cache.get_dict_in_thread(docs.keys())
+    for i in range(number_of_docs):
+        assert results[f"key{i}"] == f"value{i}"

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -35,9 +35,9 @@ def test_cache_redis_args() -> None:
 async def test_cache_get_set(app) -> None:
     # Use ``test_app`` here to make sure background task is finished before proceeding
     async with app.test_app():
-        app.cache.set_in_thread("foo", "bar")
+        app.cache.set_in_background("foo", "bar")
 
-    foo = await app.cache.get_in_thread("foo")
+    foo = await app.cache.get_in_background("foo")
     assert foo == "bar"
 
 
@@ -49,6 +49,6 @@ async def test_cache_many(app) -> None:
     async with app.test_app():
         app.cache.set_many_in_thread(docs)
 
-    results = await app.cache.get_dict_in_thread(docs.keys())
+    results = await app.cache.get_dict_in_background(docs.keys())
     for i in range(number_of_docs):
         assert results[f"key{i}"] == f"value{i}"

--- a/tests/core/test_navigations.py
+++ b/tests/core/test_navigations.py
@@ -281,7 +281,8 @@ async def test_get_products_by_navigation_caching(app):
     async with app.app_context():
         assert 1 == len(get_products_by_navigation([nav_id], "wire"))
 
-    await add_remove_products_for_navigation(nav_id, [])
+    async with app.test_app():
+        await add_remove_products_for_navigation(nav_id, [])
 
     async with app.app_context():
         assert 0 == len(get_products_by_navigation([nav_id], "wire"))


### PR DESCRIPTION
### Purpose
When modifying resources, sometimes the cache for that resource is cleared. If an exception is raised during clearing of this cache, the parent request will also fail.

### What has changed
* Use `CACHE_REDIS_` to set default Redis client timeout settings
* Added new `in_thread` methods to the Flask Caching extension we're using (for `app.cache`)
* Used the new cache in thread commands across the codebase
* Add tests

**Note:** There is a `TODO` comment in this PR that needs further discussion, and fix in a separate task.

Resolves: STT-1651