### PR TITLE
SDAN-760 Make News API responses more consistent with old version

### DIFF
--- a/features/news_api/news_api_feed.feature
+++ b/features/news_api/news_api_feed.feature
@@ -74,8 +74,25 @@ Feature: News API News Feed
         {"_items": [{"_id": "urn:test2"}, {"_id": "urn:test4"}]}
         """
 
-  @skip
   Scenario: Response provides a link to the next page
+    Given "products"
+        """
+        [{
+            "_id": "5e4cade4d69954b6d55ac09a",
+            "name": "A fishy product",
+            "description": "A product for those interested in fish",
+            "companies": ["#companies._id#"],
+            "query": "fish",
+            "product_type": "news_api"
+        }, {
+            "_id": "5e4cade4d69954b6d55ac09b",
+            "name": "An aardvark product",
+            "description": "A product for those interested in aardvarks",
+            "companies": ["#companies._id#"],
+            "query": "aardvark",
+            "product_type": "news_api"
+        }]
+        """
     Given "items"
         """
         [
@@ -97,18 +114,18 @@ Feature: News API News Feed
             }
         ]
         """
-    When we get "news/feed?include_fields=body_html&max_results=2&products=#products._id#"
+    When we get "news/feed?include_fields=body_html&max_results=2&products=5e4cade4d69954b6d55ac09a,5e4cade4d69954b6d55ac09b"
     Then we get list with 5 items
         """
         {
             "_items": [
-                {"_id": "urn:test1", "body_html": "Once upon a time there was a single fish who could swim"},
-                {"_id": "urn:test2", "body_html": "Once upon a time there were 2 fish who could swim"}
+                {"_id": "urn:test1", "body_html": "<p>Once upon a time there was a single fish who could swim</p>"},
+                {"_id": "urn:test2", "body_html": "<p>Once upon a time there were 2 fish who could swim</p>"}
             ],
             "_links": {
                 "next_page": {
                     "title": "News Feed",
-                    "href": "news/feed?exclude_ids=urn:test2&include_fields=body_html&max_results=2&products=#products._id#&start_date=2015-06-02T03:48:39"
+                    "href": "news/feed?include_fields=body_html&max_results=2&products=5e4cade4d69954b6d55ac09a%2C5e4cade4d69954b6d55ac09b&start_date=2015-06-02T03%3A48%3A39&exclude_ids=urn%3Atest2"
                 }
             }
         }
@@ -119,13 +136,13 @@ Feature: News API News Feed
         """
         {
             "_items": [
-                {"_id": "urn:test3", "body_html": "Once upon a time there were 3 fish who could swim"},
-                {"_id": "urn:test4", "body_html": "Once upon a time there were 4 fish who could swim"}
+                {"_id": "urn:test3", "body_html": "<p>Once upon a time there were 3 fish who could swim</p>"},
+                {"_id": "urn:test4", "body_html": "<p>Once upon a time there were 4 fish who could swim</p>"}
             ],
             "_links": {
                 "next_page": {
                     "title": "News Feed",
-                    "href": "news/feed?exclude_ids=urn:test4&include_fields=body_html&max_results=2&products=#products._id#&start_date=2015-06-03T03:48:39"
+                    "href": "news/feed?start_date=2015-06-03T03%3A48%3A39&include_fields=body_html&exclude_ids=urn%3Atest4&max_results=2&products=5e4cade4d69954b6d55ac09a%2C5e4cade4d69954b6d55ac09b"
                 }
             }
         }
@@ -136,12 +153,12 @@ Feature: News API News Feed
         """
         {
             "_items": [
-                {"_id": "urn:test5", "body_html": "Once upon a time there were 5 fish who could swim"}
+                {"_id": "urn:test5", "body_html": "<p>Once upon a time there were 5 fish who could swim</p>"}
             ],
             "_links": {
                 "next_page": {
                     "title": "News Feed",
-                    "href": "news/feed?exclude_ids=urn:test5&include_fields=body_html&max_results=2&products=#products._id#&start_date=2015-06-04T03:48:39"
+                    "href": "news/feed?start_date=2015-06-04T03%3A48%3A39&include_fields=body_html&exclude_ids=urn%3Atest5&max_results=2&products=5e4cade4d69954b6d55ac09a%2C5e4cade4d69954b6d55ac09b"
                 }
             }
         }
@@ -155,7 +172,7 @@ Feature: News API News Feed
             "_links": {
                 "next_page": {
                     "title": "News Feed",
-                    "href": "news/feed?exclude_ids=urn:test5&include_fields=body_html&max_results=2&products=#products._id#&start_date=2015-06-04T03:48:39"
+                    "href": "news/feed?start_date=2015-06-04T03%3A48%3A39&include_fields=body_html&exclude_ids=urn%3Atest5&max_results=2&products=5e4cade4d69954b6d55ac09a%2C5e4cade4d69954b6d55ac09b"
                 }
             }
         }

--- a/features/news_api/news_api_search.feature
+++ b/features/news_api/news_api_search.feature
@@ -711,3 +711,41 @@ Feature: News API News Search
     When we get "news/search?start_date=now-10d&products=222222222222222222222222,111111111111111111111111"
     Then we get OK response
     Then we get list with 1 items
+
+ Scenario: Search pagination with sort in request
+    Given "items"
+        """
+        [
+        {"body_html": "<p>Once upon a time there was a fish who could swim 1</p>"},
+        {"body_html": "<p>Once upon a time there was a fish who could swim 2</p>"},
+        {"body_html": "<p>Once upon a time there was a fish who could swim 3</p>"},
+        {"body_html": "<p>Once upon a time there was a fish who could swim 4</p>"},
+        {"body_html": "<p>Once upon a time there was a fish who could swim 5</p>"}
+        ]
+        """
+    Given "products"
+        """
+        [{"name": "A fishy Product",
+        "description": "a product for those interested in fish",
+        "companies" : [
+          "#companies._id#"
+        ],
+        "query": "fish",
+        "product_type": "news_api"
+        }]
+        """
+    When we get "news/search?q=fish&sort=versioncreated:desc&page_size=1&page=2&include_fields=body_html"
+    Then we get list with 5 items
+     """
+     {"_items": [
+         {"body_html": "<p>Once upon a time there was a fish who could swim 2</p>"}
+     ]}
+     """
+     Then we store NEXT_PAGE from HATEOAS
+     When we get "#NEXT_PAGE#"
+     Then we get list with 5 items
+     """
+     {"_items": [
+         {"body_html": "<p>Once upon a time there was a fish who could swim 3</p>"}
+     ]}
+     """

--- a/newsroom/news_api/news/feed/service.py
+++ b/newsroom/news_api/news/feed/service.py
@@ -77,6 +77,16 @@ class NewsAPIFeedSearchService(NewsApiSearchServiceAsync):
         doc = resp.body
         query_params = search_req.args.to_dict(flatten_lists=True)
 
+        # Page size is not available on the feed endpoint
+        page_size = query_params.pop("page_size", None)
+        if page_size:
+            query_params["max_results"] = page_size
+
+        # Externally documented as products
+        products = query_params.pop("product_ids", None)
+        if products:
+            query_params["products"] = products
+
         if doc["_meta"]["total"] > 0:
             items = list(doc.get("_items") or [])
             last_datetime = items[-1].get("versioncreated")

--- a/newsroom/news_api/news/filters.py
+++ b/newsroom/news_api/news/filters.py
@@ -132,8 +132,6 @@ def apply_projection(request: NewshubSearchRequest[NewsApiSearchRequestArgs]):
         "copyrightholder",
         "versioncreated",
         "evolvedfrom",
-        "original_id",
-        "body_html",
     }
 
     include_fields = default_fields.union(default_allowed_exclude_fields)

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -100,11 +100,15 @@ class NewsApiSearchServiceAsync(BaseNewshubSearchService[NewsApiSearchRequestArg
         search_req = self.get_search_request_instance(request)
         self.build_hateoas(request, response, search_req)
 
+        # If a date format has been configured then apply it to date fields
+        date_format = get_app_config("API_DATE_FORMAT")
+
         for doc in response.body["_items"] or []:
-            if get_app_config("API_DATE_FORMAT"):
+            if date_format:
                 for date_field in ["firstcreated", "versioncreated", "embargoed"]:
-                    if date_field in doc:
-                        doc[date_field] = format_api_date(doc.get(date_field))
+                    date_value = doc.get(date_field)
+                    if isinstance(date_value, str) and date_value:
+                        doc[date_field] = format_api_date(date_value)
 
             self._enhance_internal_item_hateoas(doc)
 

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -19,7 +19,7 @@ from newsroom.wire.embeds import (
 )
 from newsroom.search.types import NewshubSearchRequest, SearchFilterFunction
 from newsroom.search.base_service import BaseNewshubSearchService
-from newsroom.news_api.utils import post_api_audit
+from newsroom.news_api.utils import post_api_audit, format_api_date
 from newsroom.search.filters import apply_company_filter, apply_section_filter, apply_products_filter
 
 from .filters import (
@@ -101,6 +101,11 @@ class NewsApiSearchServiceAsync(BaseNewshubSearchService[NewsApiSearchRequestArg
         self.build_hateoas(request, response, search_req)
 
         for doc in response.body["_items"] or []:
+            if get_app_config("API_DATE_FORMAT"):
+                for date_field in ["firstcreated", "versioncreated", "embargoed"]:
+                    if date_field in doc:
+                        doc[date_field] = format_api_date(doc.get(date_field))
+
             self._enhance_internal_item_hateoas(doc)
 
             if get_app_config("WIRE_EMBED_PERMISSIONS", True):
@@ -116,33 +121,34 @@ class NewsApiSearchServiceAsync(BaseNewshubSearchService[NewsApiSearchRequestArg
 
     def build_hateoas(self, req: Request, resp: Response, search_req: NewshubSearchRequest[NewsApiSearchRequestArgs]):
         base_url = req.path.strip("/").replace(get_app_config("URL_PREFIX"), "")
-        query_params = search_req.args.to_dict(flatten_lists=True)
+        original_args = req.request.args.to_dict()
 
         resp.body.setdefault("_links", {})
         resp.body["_links"]["parent"] = {"title": "Home", "href": "/"}
 
-        # append page and page_size only if they were provided in original request
-        for arg in ["page", "page_size"]:
-            if arg in flask_request.view_args:
-                query_params.update({arg: query_params.get(arg)})
+        resp.body["_links"]["self"] = {
+            "title": "News Search",
+            "href": f"{base_url}?{urlencode(original_args)}" if original_args else base_url,
+        }
 
-        q_args = f"?{urlencode(query_params)}" if query_params else ""
-        resp.body["_links"]["self"] = (
-            {
-                "title": "News Search",
-                "href": f"{base_url}{q_args}",
-            },
-        )
+        total_items = resp.body.get("_meta", {}).get("total", 0)
+        current_page = search_req.args.page
+        page_size = search_req.args.page_size
 
         # add next page if there are more items
-        if (search_req.args.page * search_req.args.page_size) < resp.body["_meta"]["total"]:
-            query_params["page"] = search_req.args.page + 1
-            resp.body["_links"]["next"] = {"title": "next page", "href": f"{base_url}?{urlencode(query_params)}"}
+        if (current_page * page_size) < total_items:
+            next_args = {**original_args, "page": current_page + 1}
+            resp.body["_links"]["next"] = {"title": "next page", "href": f"{base_url}?{urlencode(next_args)}"}
 
         # add prev page if needed
-        if search_req.args.page > 1:
-            query_params["page"] = search_req.args.page - 1
-            resp.body["_links"]["prev"] = {"title": "prev page", "href": f"{base_url}?{urlencode(query_params)}"}
+        if current_page > 1:
+            prev_args = {**original_args, "page": current_page - 1}
+            resp.body["_links"]["prev"] = {"title": "prev page", "href": f"{base_url}?{urlencode(prev_args)}"}
+
+        if total_items > 0:
+            last_page = (total_items + page_size - 1) // page_size
+            last_args = {**original_args, "page": last_page}
+            resp.body["_links"]["last"] = {"title": "last page", "href": f"{base_url}?{urlencode(last_args)}"}
 
     def _enhance_internal_item_hateoas(self, item: dict[str, Any]):
         item.setdefault("_links", {})

--- a/newsroom/news_api/utils.py
+++ b/newsroom/news_api/utils.py
@@ -1,4 +1,8 @@
+import re
+from datetime import datetime
+
 from quart_babel import gettext
+from superdesk import get_app_config
 
 from superdesk.core.types import Request
 from superdesk.core.resources.cursor import ElasticsearchResourceCursorAsync
@@ -6,6 +10,9 @@ from superdesk.flask import request as flask_request
 
 from newsroom.types import NewsApiAuditResourceModel, CompanyResource
 from newsroom.exceptions import AuthorizationError
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 
 async def post_api_audit(request: Request, item_ids: list[str]) -> None:
@@ -54,3 +61,32 @@ def get_company_from_newsapi_request(request: Request) -> CompanyResource:
         raise AuthorizationError(403, gettext("Company not found or not enabled."))
 
     return company
+
+
+def format_api_date(date_string: str) -> str:
+    """
+    Converts an Elasticsearch 7.1+ high-precision date string
+    to a legacy format.
+    @param date_string:
+    @return: formatted date string
+    """
+
+    if not date_string:
+        return ""
+
+    target_format = get_app_config("API_DATE_FORMAT")
+    if target_format is None:
+        return date_string
+
+    # Standardize the timezone offset
+    # ES 7.1 often uses +00:00, but Python's %z and older ES expect +0000
+    # This regex removes the colon in the last 5 characters if it exists
+    clean_date = re.sub(r"(\+\d{2}):(\d{2})$", r"\1\2", date_string)
+
+    try:
+        dt = datetime.strptime(clean_date, "%Y-%m-%dT%H:%M:%S%z")
+        return dt.strftime(target_format)
+    except ValueError as e:
+        # Fallback if the string is weirdly formatted
+        logger.warning(f"Error parsing date {date_string}: {e}")
+        return date_string

--- a/newsroom/tests/news_api/steps.py
+++ b/newsroom/tests/news_api/steps.py
@@ -43,7 +43,9 @@ def step_assert_response_header(context):
 @async_run_until_complete
 async def step_store_next_page_from_response(context):
     data = await get_json_data(context.response)
-    href = ((data.get("_links") or {}).get("next_page") or {}).get("href")
+    links = data.get("_links", {})
+    next_link = links.get("next") or links.get("next_page")
+    href = next_link.get("href") if next_link else None
     assert href, data
     set_placeholder(context, "NEXT_PAGE", href)
 

--- a/newsroom/wire/formatters/ninjs.py
+++ b/newsroom/wire/formatters/ninjs.py
@@ -59,12 +59,18 @@ class NINJSFormatter(BaseWireFormatter):
 
         date_format = get_app_config("API_DATE_FORMAT")
         if date_format:
-            for k, v in ninjs.items():
-                if isinstance(v, datetime):
-                    # Update the dictionary with the formatted string
-                    ninjs[k] = v.strftime(date_format)
+            ninjs = self._recursive_date_formatter(ninjs, date_format)
 
         return str.encode(json.dumps(ninjs, default=json_serialize_datetime_objectId), "utf-8")
+
+    def _recursive_date_formatter(self, data: Any, date_format: str) -> Any:
+        if isinstance(data, dict):
+            return {k: self._recursive_date_formatter(v, date_format) for k, v in data.items()}
+        elif isinstance(data, list):
+            return [self._recursive_date_formatter(i, date_format) for i in data]
+        elif isinstance(data, datetime):
+            return data.strftime(date_format)
+        return data
 
     async def _transform_to_ninjs(self, item: dict[str, Any]) -> dict[str, Any]:
         ninjs = {

--- a/newsroom/wire/formatters/ninjs.py
+++ b/newsroom/wire/formatters/ninjs.py
@@ -1,6 +1,8 @@
 from typing import Any
 import json
+from datetime import datetime
 from quart_babel import lazy_gettext
+from superdesk import get_app_config
 
 from superdesk.utils import json_serialize_datetime_objectId
 
@@ -54,6 +56,13 @@ class NINJSFormatter(BaseWireFormatter):
     async def format_item(self, item: dict[str, Any], item_type: str | None = "items") -> bytes:
         item = item.copy()
         ninjs = await self._transform_to_ninjs(item)
+
+        date_format = get_app_config("API_DATE_FORMAT")
+        if date_format:
+            for k, v in ninjs.items():
+                if isinstance(v, datetime):
+                    # Update the dictionary with the formatted string
+                    ninjs[k] = v.strftime(date_format)
 
         return str.encode(json.dumps(ninjs, default=json_serialize_datetime_objectId), "utf-8")
 


### PR DESCRIPTION
### Purpose
AAP have a number of clients using the News API, we would like to make the transition to the new Newsroom version as painless as possible and hopefully transparent. This PR makes the API responses more consistent between versions.

### What has changed
The format of the date times should match the old version based on the existence of the config value API_DATE_FORMAT being defined an containing a date format string of the required output format. It seems the change in elasticsearch version changed the stored date format. 

The pagination of the search endpoint was wrong.

passing a sort value to the search endpoint resulted in invalid self, next and prev references as the parameters in the returned response were those from the internal search.

The body_html and original_id have been removed from the default fields. I couldn't see any reason they had been added!! AAP tends to discourage the use of the body html field in the search and feed endpoints as we don't have visibility of the "use" of the story.

### Steps to test
Compare News API responses between Newsroom 1.22 and Newsroom 3

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
