### PR TITLE
Fix make public pages accessible to public

### DIFF
--- a/newsroom/public/views.py
+++ b/newsroom/public/views.py
@@ -60,7 +60,7 @@ class PageArgs(BaseModel):
     template: str
 
 
-@public_endpoints.endpoint("/page/<path:template>")
+@public_endpoints.endpoint("/page/<path:template>", auth=False)
 async def page(args: PageArgs, _p: None, _r: None):
     template = secure_filename(args.template)
     return await render_template(f"page-{template}.html")


### PR DESCRIPTION
### Purpose
AAP has a copyright page linked in the footer, this page should be visible if the user logged in or not. the page endpoint was redirecting to the login page if the copyright page was clicked by an unauthenticated user.

### What has changed
The public page endpoint has been set to not require authentication.

### Steps to test
On the AAP instance click on the copyright link at the bottom of the login page and ensure the page is displayed.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
