### PR TITLE
[SDAN-761] Log video/audio downloads

### DIFF
--- a/assets/server.ts
+++ b/assets/server.ts
@@ -149,6 +149,17 @@ class Server {
             })
         ).then(checkStatus);
     }
+
+    /**
+     * Make HEAD request to url
+     *
+     * @param {String} url
+     * @return {Promise}
+    */
+    head(url: string) {
+        return fetch(url, options({method: 'HEAD'}))
+            .then(checkStatus);
+    }
 }
 
 export default new Server();

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -1,6 +1,8 @@
 import {isEmpty} from 'lodash';
 import classNames from 'classnames';
 import videojs from 'video.js';
+import server from '../server';
+import {notify, gettext} from '../utils';
 
 type VjsPlayer = ReturnType<typeof videojs>;
 const isNotEmpty = (x: any) => !isEmpty(x);
@@ -8,9 +10,9 @@ const isNotEmpty = (x: any) => !isEmpty(x);
 /**
  * Get bem classes
  *
- * @param {String} block 
- * @param {String} element 
- * @param {Object} modifier 
+ * @param {String} block
+ * @param {String} element
+ * @param {Object} modifier
  * @return {String}
  */
 export function bem(block: any, element: any, modifier: any) {
@@ -39,7 +41,10 @@ function initPlayer(
 
     function attempt(remainingTries: number): void {
         if (cancelled) return;
-        if (!document.body.contains(el)) { onReady(null); return; }
+        if (!document.body.contains(el)) {
+            onReady(null);
+            return;
+        }
         const isAudio = el instanceof HTMLAudioElement;
 
         if (typeof videojs === 'function') {
@@ -49,6 +54,10 @@ function initPlayer(
                     preload: 'auto',
                     fluid: true,
                     audioOnlyMode: isAudio,
+                    controlBar: {
+                        pictureInPictureToggle: false,
+                        fullscreenToggle: false
+                    },
                 });
                 el.setAttribute('data-vjs-initialized', 'true');
                 onReady(player);
@@ -83,34 +92,85 @@ export function setupMediaPlayers(root: HTMLElement) {
     elements.forEach((element) => {
         if (element.getAttribute('data-vjs-initialized')) return;
 
-        const disable = element.getAttribute('data-disable-download') === 'true';
+        const disableDownload = element.getAttribute('data-disable-download') === 'true';
 
-        if (disable) {
-            // Remove native controls everywhere on all major browsers
-            element.removeAttribute('controls');
-            // Additional override for browsers that support controlsList
-            element.setAttribute('controlsList', 'nodownload');
-            // Disable right-click context menu on all browsers
-            element.addEventListener('contextmenu', (e) => e.preventDefault());
-
-            if (element instanceof HTMLVideoElement) {
-                element.classList.add('video-js', 'vjs-big-play-centered');
-            } else if (element instanceof HTMLAudioElement) {
-                element.classList.add('video-js');
-            }
-
-            const cancel = initPlayer(element, 3, 100, (player: VjsPlayer | null) => {
-                if (player) players.push(player);
-            });
-            timeoutCancels.push(cancel);
-        } else {
-            // Enable all native controls
-            element.setAttribute('controls', '');
+        element.classList.add('video-js');
+        // Convince the player to show the ControlBar
+        if (element instanceof HTMLVideoElement) {
+            element.classList.add('vjs-has-started');
         }
+
+        // Remove native controls everywhere on all major browsers
+        element.removeAttribute('controls');
+        // Additional override for browsers that support controlsList
+        element.setAttribute('controlsList', 'nodownload');
+        // Disable right-click context menu on all browsers
+        element.addEventListener('contextmenu', (e) => e.preventDefault());
+
+        const cancel = initPlayer(element, 3, 100, (player: VjsPlayer | null) => {
+            if (!player) return;
+
+            if (player) players.push(player);
+
+            if (!disableDownload) {
+                const VjsButton = videojs.getComponent('Button');
+                const downloadBtn = new VjsButton(player, {
+                    controlText: 'Download',
+                    className: 'vjs-control vjs-download-button vjs-icon-file-download'
+                });
+                player.getChild('ControlBar')?.addChild(downloadBtn);
+
+                downloadBtn.handleClick = async () => {
+                    const item_id = element.getAttribute('data-item-id') || '';
+                    const altText= element.getAttribute('alt') || 'download';
+                    const filename = sanitizeFilename(altText);
+
+                    const source = player.currentSrc() + '/download';
+
+                    const downloadUrl = new URL(source);
+                    downloadUrl.searchParams.set('item_id', item_id);
+
+                    try {
+                        // Make a head request to ensure that the user has download rights
+                        await server.head(downloadUrl.toString());
+
+                        const link = document.createElement('a');
+                        downloadUrl.searchParams.set('filename', filename);
+                        link.href = downloadUrl.toString();
+                        link.setAttribute('download', '');
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                    } catch (error: any) {
+                        if (error.status === 403) {
+                            notify.warning(gettext('Permission Denied'));
+                        } else if (error.status === 404) {
+                            notify.error(gettext('File not found.'));
+                        } else {
+                            notify.error(gettext('An error occurred while checking download permissions.'));
+                        }
+                    }
+                };
+
+            }
+        });
+
+        timeoutCancels.push(cancel);
     });
 
     return () => {
         timeoutCancels.forEach((c) => c());
         players.forEach((p) => p?.dispose?.());
     };
+}
+
+function sanitizeFilename(name: string): string {
+    if (!name) return 'download';
+
+    return name
+        .replace(/[\x00-\x1f\x80-\x9f]/g, '')
+        .replace(/[\\/:*?"<>|%]/g, '')
+        .replace(/[\s_]+/g, '_')
+        .replace(/[\.\s]+$/, '')
+        .substring(0, 255); // Max filename length for most OS
 }

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -115,14 +115,13 @@ export function setupMediaPlayers(root: HTMLElement) {
             if (!disableDownload) {
                 const VjsButton = videojs.getComponent('Button');
                 const downloadBtn = new VjsButton(player, {
-                    controlText: 'Download',
                     className: 'vjs-control vjs-download-button vjs-icon-file-download'
                 });
-                player.getChild('ControlBar')?.addChild(downloadBtn);
+                (downloadBtn as any).controlText('Download');
 
-                downloadBtn.handleClick = async () => {
+                (downloadBtn as any).handleClick = async () => {
                     const item_id = element.getAttribute('data-item-id') || '';
-                    const altText= element.getAttribute('alt') || 'download';
+                    const altText = element.getAttribute('alt') || 'download';
                     const filename = sanitizeFilename(altText);
 
                     const source = player.currentSrc() + '/download';
@@ -147,11 +146,14 @@ export function setupMediaPlayers(root: HTMLElement) {
                         } else if (error.status === 404) {
                             notify.error(gettext('File not found.'));
                         } else {
-                            notify.error(gettext('An error occurred while checking download permissions.'));
+                            notify.error(gettext('An error occurred while checking permissions.'));
                         }
                     }
                 };
-
+                const controlBar = player.getChild('ControlBar');
+                if (controlBar) {
+                    controlBar.addChild(downloadBtn);
+                }
             }
         });
 
@@ -168,9 +170,10 @@ function sanitizeFilename(name: string): string {
     if (!name) return 'download';
 
     return name
+        // eslint-disable-next-line no-control-regex
         .replace(/[\x00-\x1f\x80-\x9f]/g, '')
         .replace(/[\\/:*?"<>|%]/g, '')
         .replace(/[\s_]+/g, '_')
-        .replace(/[\.\s]+$/, '')
+        .replace(/[.\s]+$/, '')
         .substring(0, 255); // Max filename length for most OS
 }

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -90,7 +90,10 @@ export function setupMediaPlayers(root: HTMLElement) {
     const elements = root.querySelectorAll<HTMLVideoElement | HTMLAudioElement>('video, audio');
 
     elements.forEach((element) => {
-        if (element.getAttribute('data-vjs-initialized')) return;
+        // Nothing to do if already initialised, or we have now download logging requirement.
+        if (element.hasAttribute('data-vjs-initialized') || !element.hasAttribute('data-disable-download')) {
+            return;
+        }
 
         const disableDownload = element.getAttribute('data-disable-download') === 'true';
 
@@ -113,6 +116,7 @@ export function setupMediaPlayers(root: HTMLElement) {
             if (player) players.push(player);
 
             if (!disableDownload) {
+                // Add the download button referencing the logging download endpoint
                 const VjsButton = videojs.getComponent('Button');
                 const downloadBtn = new VjsButton(player, {
                     className: 'vjs-control vjs-download-button vjs-icon-file-download'

--- a/newsroom/assets/views.py
+++ b/newsroom/assets/views.py
@@ -1,4 +1,6 @@
+from flask import abort
 from pydantic import BaseModel
+import logging
 
 from superdesk.core import get_app_config, get_current_async_app
 from superdesk.core.types import Response, Request
@@ -7,6 +9,12 @@ from superdesk.storage.superdesk_file import get_file_request_range, generate_re
 
 from .module import assets_endpoints
 from .utils import get_media_file, get_content_disposition
+from newsroom.history_async import HistoryService
+from newsroom.types import WireItem, SectionEnum
+from newsroom.auth.utils import get_user_or_none_from_request
+from newsroom.products.utils import get_products_for_request_user_and_company
+
+logger = logging.getLogger(__name__)
 
 
 class RouteArguments(BaseModel):
@@ -15,6 +23,11 @@ class RouteArguments(BaseModel):
 
 class UrlParams(BaseModel):
     filename: str | None = None
+
+
+class DownloadUrlParams(BaseModel):
+    filename: str | None = None
+    item_id: str | None = None
 
 
 async def get_upload(media_id: str, filename: str | None = None):
@@ -38,3 +51,68 @@ async def download_file(args: RouteArguments, params: UrlParams, request: Reques
 
     response = await get_upload(args.media_id, params.filename)
     return response if response else await request.abort(404)
+
+
+@assets_endpoints.endpoint("/assets/<path:media_id>/download", methods=["GET", "HEAD"])
+async def download_file_logged(args: RouteArguments, params: DownloadUrlParams, request: Request) -> Response:
+    """
+    Download and log the download. Accepts a HEAD request that will validate that the user has the rights to download
+    the asset.
+    @param args: The item_id is the identifier for the item the asset belongs to. The filename is the suggeted name for
+    the download file.
+    @param params: The media identifier
+    @param request:
+    @return:
+    """
+    if params.item_id:
+        item: WireItem = await WireItem.get_service().find_by_id(params.item_id)
+        if not item:
+            logger.warning(f"Failed find item for media download for {params.item_id} with media id {args.media_id}")
+            abort(404)
+
+        name, association = _find_association(item, args.media_id)
+
+        sdesk_products: set[str] = {
+            product.sd_product_id
+            for product in await get_products_for_request_user_and_company(SectionEnum.WIRE)
+            if product.sd_product_id and product.is_enabled
+        }
+
+        association_products = {a.get("code") for a in association.get("products", {})}
+
+        if not (sdesk_products & association_products):
+            abort(403)
+
+        if request.method == "GET":
+            user = get_user_or_none_from_request(request)
+            action = f"download {association.get('type')}"
+            if user:
+                await HistoryService().create_media_history_record(item.to_dict(), name, action, user)
+            else:
+                abort(404)
+    else:
+        abort(404)
+
+    if request.method == "HEAD":
+        return Response("", 204)
+
+    response = await get_upload(args.media_id, params.filename)
+    if not response:
+        abort(404)
+
+    return response
+
+
+def _find_association(item, media_id):
+    """
+    Find the matching media association in the item
+    :param item: item object
+    :param media_id: ID of the media
+    :return: tuple (name, association) or a 404
+    """
+    for name, association in (item.associations or {}).items():
+        renditions = association.get("renditions", {})
+        for rend_key, rend_data in renditions.items():
+            if rend_data.get("media") == media_id:
+                return name, association
+    abort(404)

--- a/newsroom/assets/views.py
+++ b/newsroom/assets/views.py
@@ -1,4 +1,4 @@
-from flask import abort
+from superdesk.flask import abort
 from pydantic import BaseModel
 import logging
 
@@ -58,16 +58,17 @@ async def download_file_logged(args: RouteArguments, params: DownloadUrlParams, 
     """
     Download and log the download. Accepts a HEAD request that will validate that the user has the rights to download
     the asset.
-    @param args: The item_id is the identifier for the item the asset belongs to. The filename is the suggeted name for
-    the download file.
-    @param params: The media identifier
-    @param request:
-    @return:
+    @param args: Contains the media_id, the unique identifier for the asset.
+    @param params: item_id The of the parent item.
+                   and the suggested filename for the attachment.
+    @param request: The incoming HTTP request object.
+    @return: A Response object containing the file stream (GET) or a success
+             status (HEAD) if the item is allowed to be downloaded , otherwise aborts with 403 or 404.
     """
     if params.item_id:
         item: WireItem = await WireItem.get_service().find_by_id(params.item_id)
         if not item:
-            logger.warning(f"Failed find item for media download for {params.item_id} with media id {args.media_id}")
+            logger.warning(f"Failed to find item for media download for {params.item_id} with media id {args.media_id}")
             abort(404)
 
         name, association = _find_association(item, args.media_id)
@@ -78,7 +79,10 @@ async def download_file_logged(args: RouteArguments, params: DownloadUrlParams, 
             if product.sd_product_id and product.is_enabled
         }
 
-        association_products = {a.get("code") for a in association.get("products", {})}
+        products = association.get("products", [])
+        if not isinstance(products, list):
+            products = []
+        association_products = {a.get("code") for a in products if isinstance(a, dict) and a.get("code")}
 
         if not (sdesk_products & association_products):
             abort(403)

--- a/newsroom/history_async.py
+++ b/newsroom/history_async.py
@@ -86,7 +86,12 @@ class HistoryService(NewshubAsyncResourceService[HistoryResourceModel]):
         return {"_items": docs, "hits": cursor.hits}
 
     async def create_media_history_record(
-        self, item: dict[str, Any], association_name: str, action: str | None, user: UserResourceModel, section: str
+        self,
+        item: dict[str, Any],
+        association_name: str,
+        action: str | None,
+        user: UserResourceModel,
+        section: str = "wire",
     ):
         """
         Log the download of an association belonging to an item

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -12,7 +12,7 @@ from superdesk.etree import to_string
 
 from newsroom.types import SectionEnum, CompanyResource, EmbedPermissionUserAction
 from newsroom.settings import get_setting
-from newsroom.auth.utils import get_user_or_none_from_request, get_company_from_request
+from newsroom.auth.utils import get_company_from_request
 from newsroom.products import get_products_for_request_user_and_company
 
 __all__ = [
@@ -47,12 +47,7 @@ async def apply_company_permissions_to_embeds(
     if not len(items) or not get_app_config("WIRE_EMBED_PERMISSIONS", True):
         return
 
-    user = get_user_or_none_from_request(None)
     company = get_company_from_request(None)
-
-    if (user and user.is_admin()) or not company:
-        # If the current user is an admin, then there are no permissions to be applied
-        return
 
     sdesk_products: set[str] = {
         product.sd_product_id
@@ -61,7 +56,8 @@ async def apply_company_permissions_to_embeds(
     }
 
     for doc in items:
-        _remove_or_disable_item_media(doc, company, sdesk_products, use_download_as_view_permission)
+        if company is not None:
+            _remove_or_disable_item_media(doc, company, sdesk_products, use_download_as_view_permission)
 
 
 def _get_html_from_string(html_string: bytes | str | None) -> HtmlElement:
@@ -327,9 +323,6 @@ def _remove_or_disable_item_media(
         disable_display |= disable_download
     disable_embed_codes = not company.is_permissioned_for_embed("embed_code", EmbedPermissionUserAction.DISPLAY)
 
-    if not disable_download and not disable_display and not disable_embed_codes:
-        return
-
     for key in disable_display:
         (item.get("associations") or {}).pop(key, None)
 
@@ -363,6 +356,9 @@ def _remove_or_disable_item_media(
                 if elem.tag in ["video", "audio"]:
                     if editor_id in disable_download:
                         elem.attrib["data-disable-download"] = "true"
+                    else:
+                        elem.attrib["data-disable-download"] = "false"
+                        elem.attrib["data-item-id"] = item.get("_id")
                 if elem.text and " EMBED END " in elem.text:
                     break
             html_updated = True

--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -44,10 +44,10 @@ def iterate_embeds(
 async def apply_company_permissions_to_embeds(
     items: list[dict], section: SectionEnum, use_download_as_view_permission: bool = False
 ) -> None:
-    if not len(items) or not get_app_config("WIRE_EMBED_PERMISSIONS", True):
-        return
-
     company = get_company_from_request(None)
+
+    if not len(items) or not company or not get_app_config("WIRE_EMBED_PERMISSIONS", True):
+        return
 
     sdesk_products: set[str] = {
         product.sd_product_id


### PR DESCRIPTION
### Purpose
Tracking is required for video and audio downloads, which must be restricted to authorized users only.

### What has changed
A separate endpoint for logged downloads of assets has been created. This endpoint responds to both GET and HEAD requests, The HEAD request is used to verify that the asset is allowed for the user before the client application make the GET request if allowed.

The "look" of the player has changed, such that the download button is visible when the article page is rendered, rather than just the big play button. 

Administrator users will be subject to the permissioned access to media.
A tentative file name is also provided (based on the alt text for the media)


### Screenshots
No download
<img width="490" height="480" alt="image" src="https://github.com/user-attachments/assets/f59143ab-af7e-4bcd-a390-f12b2287efa8" />

With download

<img width="642" height="570" alt="image" src="https://github.com/user-attachments/assets/eca2c030-8a19-461e-aaaf-4bfecc5c76e6" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[SDAN-761]


[SDAN-761]: https://sofab.atlassian.net/browse/SDAN-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ