### PR TITLE
[NHUB-632] Share single websocket connection per browser tab

### DIFF
--- a/assets/globals.d.ts
+++ b/assets/globals.d.ts
@@ -71,6 +71,7 @@ interface IClientConfig {
 }
 
 interface Window {
+    __newsroomWebSocketManager?: INewsroomWebSocketManager;
     sectionNames: {
         home: string;
         wire: string;
@@ -112,6 +113,21 @@ interface Window {
 
     __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: any;
     sitename: string;
+}
+
+interface IWebSocketListener {
+    store: any;
+    action: any;
+}
+
+interface INewsroomWebSocketManager {
+    firstConnection: boolean;
+    wsConnection: WebSocket | null;
+    connectInterval: ReturnType<typeof setInterval> | null;
+    listeners: IWebSocketListener[];
+    shuttingDown: boolean;
+    unloadHandlerAttached: boolean;
+    unloadHandler: (() => void) | null;
 }
 
 type Dictionary<T> = {[key: string]: T};

--- a/assets/websocket.spec.ts
+++ b/assets/websocket.spec.ts
@@ -1,0 +1,191 @@
+import {initWebSocket} from 'websocket';
+import {notify} from 'utils';
+
+describe('websocket', () => {
+    const originalWebSocket = window.WebSocket;
+    const originalWebsocketUrl = window.newsroom.websocket;
+    const originalProfileData = window.profileData;
+    const createdSockets: Array<any> = [];
+
+    class FakeWebSocket {
+        static CLOSED = 3;
+
+        readyState = 0;
+        onerror: any;
+        onopen: any;
+        onclose: any;
+        onmessage: any;
+        url: string;
+        close = jasmine.createSpy('close').and.callFake(() => {
+            this.readyState = FakeWebSocket.CLOSED;
+            if (this.onclose) {
+                this.onclose({});
+            }
+        });
+
+        constructor(url: string) {
+            this.url = url;
+            createdSockets.push(this);
+        }
+    }
+
+    beforeEach(() => {
+        createdSockets.length = 0;
+        window.__newsroomWebSocketManager = undefined;
+        window.WebSocket = FakeWebSocket as any;
+        window.newsroom.websocket = 'ws://example.test';
+        window.profileData = {
+            user: {_id: 'user-1'},
+            company: 'None',
+        };
+        spyOn(notify, 'success').and.stub();
+        spyOn(notify, 'error').and.stub();
+    });
+
+    afterEach(() => {
+        try {
+            jasmine.clock().uninstall();
+        } catch (e) {
+            // clock may not have been installed
+        }
+
+        const manager = window.__newsroomWebSocketManager;
+
+        if (manager && manager.unloadHandler) {
+            window.removeEventListener('beforeunload', manager.unloadHandler);
+        }
+
+        if (manager && manager.connectInterval != null) {
+            clearInterval(manager.connectInterval);
+        }
+
+        window.WebSocket = originalWebSocket;
+        window.newsroom.websocket = originalWebsocketUrl;
+        window.profileData = originalProfileData;
+        window.__newsroomWebSocketManager = undefined;
+    });
+
+    it('shares a single websocket connection across multiple consumers', () => {
+        const storeA = {dispatch: jasmine.createSpy('dispatchA')};
+        const storeB = {dispatch: jasmine.createSpy('dispatchB')};
+
+        initWebSocket(storeA, (data: any) => ({type: 'A', data}));
+        initWebSocket(storeB, (data: any) => ({type: 'B', data}));
+
+        expect(createdSockets.length).toBe(1);
+        expect(window.__newsroomWebSocketManager?.listeners.length).toBe(2);
+    });
+
+    it('dispatches incoming messages to every consumer', () => {
+        const storeA = {dispatch: jasmine.createSpy('dispatchA')};
+        const storeB = {dispatch: jasmine.createSpy('dispatchB')};
+        const actionA = jasmine.createSpy('actionA').and.callFake((data: any) => ({type: 'A', data}));
+        const actionB = jasmine.createSpy('actionB').and.callFake((data: any) => ({type: 'B', data}));
+
+        initWebSocket(storeA, actionA);
+        initWebSocket(storeB, actionB);
+
+        const socket = createdSockets[0] as any;
+        const payload = {event: 'new_notifications', extra: {counts: {'user-1': 1}}};
+
+        socket.onmessage({data: JSON.stringify(payload)});
+
+        expect(storeA.dispatch).toHaveBeenCalledWith({type: 'A', data: payload});
+        expect(storeB.dispatch).toHaveBeenCalledWith({type: 'B', data: payload});
+    });
+
+    it('dispatches websocket lifecycle events', () => {
+        const store = {dispatch: jasmine.createSpy('dispatch')};
+        const dispatchSpy = spyOn(window, 'dispatchEvent').and.callThrough();
+
+        initWebSocket(store, (data: any) => ({type: 'A', data}));
+
+        const socket = createdSockets[0] as any;
+
+        socket.onopen();
+        socket.close();
+
+        expect(dispatchSpy.calls.all().some((call) => call.args[0].type === 'websocket:connected')).toBe(true);
+        expect(dispatchSpy.calls.all().some((call) => call.args[0].type === 'websocket:disconnected')).toBe(true);
+    });
+
+    it('reconnects after a disconnect and shows the reconnect toast', () => {
+        jasmine.clock().install();
+
+        const store = {dispatch: jasmine.createSpy('dispatch')};
+        const dispatchSpy = spyOn(window, 'dispatchEvent').and.callThrough();
+
+        initWebSocket(store, (data: any) => ({type: 'A', data}));
+
+        const socket1 = createdSockets[0] as any;
+
+        socket1.onopen();
+        expect(notify.success).not.toHaveBeenCalled();
+
+        socket1.close();
+
+        const manager = window.__newsroomWebSocketManager!;
+        expect(manager.connectInterval).not.toBeNull();
+        expect(dispatchSpy.calls.all().some((call) => call.args[0].type === 'websocket:disconnected')).toBe(true);
+
+        jasmine.clock().tick(5000);
+
+        expect(createdSockets.length).toBe(2);
+        const socket2 = createdSockets[1] as any;
+
+        socket2.onopen();
+
+        expect(notify.success).toHaveBeenCalled();
+        expect(dispatchSpy.calls.all().some((call) => call.args[0].type === 'websocket:connected')).toBe(true);
+    });
+
+    it('adds late subscribers without creating a new socket', () => {
+        const storeA = {dispatch: jasmine.createSpy('dispatchA')};
+        const storeB = {dispatch: jasmine.createSpy('dispatchB')};
+
+        initWebSocket(storeA, (data: any) => ({type: 'A', data}));
+
+        const socket = createdSockets[0] as any;
+        socket.onopen();
+
+        initWebSocket(storeB, (data: any) => ({type: 'B', data}));
+
+        expect(createdSockets.length).toBe(1);
+
+        const payload = {event: 'new_notifications', extra: {counts: {'user-1': 1}}};
+        socket.onmessage({data: JSON.stringify(payload)});
+
+        expect(storeA.dispatch).toHaveBeenCalledWith({type: 'A', data: payload});
+        expect(storeB.dispatch).toHaveBeenCalledWith({type: 'B', data: payload});
+    });
+
+    it('closes the shared websocket during unload', () => {
+        const store = {dispatch: jasmine.createSpy('dispatch')};
+
+        initWebSocket(store, (data: any) => ({type: 'A', data}));
+
+        const socket = createdSockets[0] as any;
+        const manager = window.__newsroomWebSocketManager!;
+
+        expect(socket.close).not.toHaveBeenCalled();
+
+        manager.unloadHandler!();
+
+        expect(socket.close).toHaveBeenCalled();
+        expect(manager.shuttingDown).toBe(true);
+    });
+
+    it('does not create a new socket after unload', () => {
+        const store = {dispatch: jasmine.createSpy('dispatch')};
+
+        initWebSocket(store, (data: any) => ({type: 'A', data}));
+
+        const manager = window.__newsroomWebSocketManager!;
+        manager.unloadHandler!();
+
+        initWebSocket({dispatch: jasmine.createSpy('dispatch2')}, (data: any) => ({type: 'B', data}));
+
+        expect(createdSockets.length).toBe(1);
+        expect(manager.shuttingDown).toBe(true);
+    });
+});

--- a/assets/websocket.ts
+++ b/assets/websocket.ts
@@ -4,13 +4,30 @@ import {notify, gettext} from './utils';
 const DEFAULT_WS_URL = 'ws://localhost:5150';
 const RECONNECT_INTERVAL = 5000;
 
-let firstConnection = true;
-let wsConnection: any;
-let connectInterval: any;
-const listeners: any = [];
+function getWebSocketManager(): INewsroomWebSocketManager {
+    if (!window.__newsroomWebSocketManager) {
+        window.__newsroomWebSocketManager = {
+            firstConnection: true,
+            wsConnection: null,
+            connectInterval: null,
+            listeners: [],
+            shuttingDown: false,
+            unloadHandlerAttached: false,
+            unloadHandler: null,
+        };
+    }
+
+    return window.__newsroomWebSocketManager;
+}
 
 function connectToNotificationServer() {
-    if (wsConnection == null || wsConnection.readyState === WebSocket.CLOSED) {
+    const manager = getWebSocketManager();
+
+    if (manager.shuttingDown) {
+        return;
+    }
+
+    if (manager.wsConnection == null || manager.wsConnection.readyState === WebSocket.CLOSED) {
         const baseURL = window.newsroom && window.newsroom.websocket ?
             window.newsroom.websocket :
             DEFAULT_WS_URL;
@@ -23,21 +40,48 @@ function connectToNotificationServer() {
             wsURL.searchParams.append('company', window.profileData.company);
         }
 
-        wsConnection = new WebSocket(wsURL.href);
-        wsConnection.onerror = onWebsocketError;
-        wsConnection.onopen = onWebsocketOpen;
-        wsConnection.onclose = onWebsocketClose;
-        wsConnection.onmessage = onWebsocketMessage;
+        manager.wsConnection = new WebSocket(wsURL.href);
+        manager.wsConnection.onerror = onWebsocketError;
+        manager.wsConnection.onopen = onWebsocketOpen;
+        manager.wsConnection.onclose = onWebsocketClose;
+        manager.wsConnection.onmessage = onWebsocketMessage;
     }
 }
 
-window.addEventListener('beforeunload', () => {
-    wsConnection = null;
-});
+function shutdownNotificationServer() {
+    const manager = getWebSocketManager();
+
+    manager.shuttingDown = true;
+
+    if (manager.connectInterval != null) {
+        clearInterval(manager.connectInterval);
+        manager.connectInterval = null;
+    }
+
+    if (manager.wsConnection != null) {
+        manager.wsConnection.close();
+        manager.wsConnection = null;
+    }
+}
+
+function ensureUnloadHandler() {
+    const manager = getWebSocketManager();
+
+    if (manager.unloadHandlerAttached) {
+        return;
+    }
+
+    manager.unloadHandlerAttached = true;
+    manager.unloadHandler = shutdownNotificationServer;
+    window.addEventListener('beforeunload', manager.unloadHandler);
+}
 
 export function initWebSocket(store: any, action: any) {
+    const manager = getWebSocketManager();
+
+    ensureUnloadHandler();
+    manager.listeners.push({store, action});
     connectToNotificationServer();
-    listeners.push({store, action});
 }
 
 function onWebsocketError(event: any) {
@@ -45,30 +89,48 @@ function onWebsocketError(event: any) {
 }
 
 function onWebsocketOpen() {
-    if (!firstConnection) {
+    const manager = getWebSocketManager();
+
+    if (!manager.firstConnection) {
         // Only show notification if the connection was re-established
         // otherwise a notification will be shown when navigating to each page
         notify.success(gettext('Connected to Notification Server!'));
     }
 
-    firstConnection = false;
-    clearInterval(connectInterval);
-    connectInterval = null;
+    manager.firstConnection = false;
+
+    if (manager.connectInterval != null) {
+        clearInterval(manager.connectInterval);
+        manager.connectInterval = null;
+    }
+
     window.dispatchEvent(new Event('websocket:connected'));
 }
 
 function onWebsocketClose() {
-    if (connectInterval != null || wsConnection == null) {
+    const manager = getWebSocketManager();
+
+    if (manager.shuttingDown) {
+        if (manager.connectInterval != null) {
+            clearInterval(manager.connectInterval);
+            manager.connectInterval = null;
+        }
+
+        manager.wsConnection = null;
+        return;
+    }
+
+    if (manager.connectInterval != null || manager.wsConnection == null) {
         // Already attempting to reconnect to the Notification Server
         // No need to add another interval
         return;
     }
 
-    wsConnection = null;
+    manager.wsConnection = null;
     notify.error(gettext('Disconnected from Notification Server!'));
     window.dispatchEvent(new Event('websocket:disconnected'));
 
-    connectInterval = setInterval(() => {
+    manager.connectInterval = setInterval(() => {
         connectToNotificationServer();
     }, RECONNECT_INTERVAL);
 }
@@ -86,7 +148,9 @@ function onWebsocketMessage(message: any) {
         return;
     }
 
-    listeners.forEach(({store, action}: any) => {
+    const manager = getWebSocketManager();
+
+    manager.listeners.forEach(({store, action}: IWebSocketListener) => {
         store.dispatch(action(data));
     });
 }


### PR DESCRIPTION
### Purpose
Share one websocket connection per browser tab instead of opening duplicates from each app bundle.

### What has changed
- Moved websocket state to a `window`-scoped manager and maintained the existing `initWebSocket(store, action)` API.
- Preserved reconnect handling and connected/disconnected events.
- Added tests for sharing, reconnects, late subscribers, and unload behavior.

### Steps to test
1. Open Newshub and confirm only one websocket per tab in DevTools.
2. Load multiple newsroom app areas in the same tab.
3. Send a realtime event from Superdesk and confirm it still arrives.
4. Open a second tab and confirm it has its own websocket.

### Checklist
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

- Resolves [NHUB-632](https://sofab.atlassian.net/browse/NHUB-632)

[NHUB-632]: https://sofab.atlassian.net/browse/NHUB-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ