### PR TITLE
fix wire refresh button not using user products

### DIFF
--- a/assets/wire/actions.ts
+++ b/assets/wire/actions.ts
@@ -34,7 +34,7 @@ import {getFoldersUrl} from 'user-profile/actions';
 const NEW_ITEMS_FETCH_THROTTLE_MS = 2000;
 
 const throttledFetchNewItems = throttle(
-    (dispatch: any) => dispatch(fetchNewItems()).catch(errorHandler),
+    (dispatch: any) => dispatch(fetchNewItems()).catch((error: any) => errorHandler(error, dispatch)),
     NEW_ITEMS_FETCH_THROTTLE_MS,
     {leading: true, trailing: true}
 );

--- a/assets/wire/actions.ts
+++ b/assets/wire/actions.ts
@@ -1,4 +1,5 @@
 import {get, isEmpty} from 'lodash';
+import throttle from 'lodash/throttle';
 
 import {IArticle} from 'interfaces';
 import server from 'server';
@@ -29,6 +30,22 @@ import {
     loadMyTopic,
 } from 'search/actions';
 import {getFoldersUrl} from 'user-profile/actions';
+
+const NEW_ITEMS_FETCH_THROTTLE_MS = 2000;
+
+const throttledFetchNewItems = throttle(
+    (dispatch: any) => dispatch(fetchNewItems()).catch(errorHandler),
+    NEW_ITEMS_FETCH_THROTTLE_MS,
+    {leading: true, trailing: true}
+);
+
+export function resetFetchNewItemsThrottleForTests() {
+    throttledFetchNewItems.cancel();
+}
+
+export function fetchNewItemsThrottled() {
+    return (dispatch: any) => throttledFetchNewItems(dispatch) || Promise.resolve();
+}
 
 export const SET_STATE = 'SET_STATE';
 export function setState(state: any) {
@@ -488,7 +505,7 @@ export function pushNotification(push: any): any {
             return dispatch(setNewItemByTopic(push.extra));
 
         case 'new_item':
-            return dispatch(setNewItems(push.extra));
+            return dispatch(fetchNewItemsThrottled());
 
         case `topics:${user}`:
             return dispatch(reloadMyTopics());

--- a/assets/wire/tests/actions.spec.ts
+++ b/assets/wire/tests/actions.spec.ts
@@ -122,6 +122,17 @@ describe('wire actions', () => {
             });
     });
 
+    it('sets an error message when throttled new item fetch gets a 403', () => {
+        spyOn(server, 'get').and.returnValue(Promise.reject({status: 403, statusText: 'Forbidden'} as Response));
+
+        return store.dispatch(actions.pushNotification({event: 'new_item', extra: {_items: [ {'_id': 'foo', 'type': 'text'} ]}}))
+            .then(() => {
+                expect(store.getState().errorMessage).toBe(
+                    'There is no product associated with your user. Please reach out to your Company Admin'
+                );
+            });
+    });
+
     it('throttles new item update fetches during bursts', () => {
         const searchSpy = spyOn(server, 'get').and.callThrough();
         jasmine.clock().install();

--- a/assets/wire/tests/actions.spec.ts
+++ b/assets/wire/tests/actions.spec.ts
@@ -36,10 +36,11 @@ describe('wire actions', () => {
     let store: any;
     const response: any = {
         _meta: {total: 2},
-        _items: [{_id: 'foo'}],
+        _items: [{_id: 'foo', type: 'text'}],
     };
 
     beforeEach(() => {
+        actions.resetFetchNewItemsThrottleForTests();
         (spyOn(utils.now, 'utcOffset') as any).and.returnValue('');
         fetchMock.get('/wire/search', response, {
             name: 'wire_search:from_0',
@@ -49,6 +50,7 @@ describe('wire actions', () => {
     });
 
     afterEach(() => {
+        actions.resetFetchNewItemsThrottleForTests();
         fetchMock.restore();
     });
 
@@ -110,10 +112,33 @@ describe('wire actions', () => {
     });
 
     it('can populate new items on update', () => {
+        const searchSpy = spyOn(server, 'get').and.callThrough();
+
         expect(store.getState().newItems).toEqual([]);
         return store.dispatch(actions.pushNotification({event: 'new_item', extra: {_items: [ {'_id': 'foo', 'type': 'text'} ]}}))
             .then(() => {
                 expect(store.getState().newItems).toEqual(['foo']);
+                expect(searchSpy).toHaveBeenCalled();
+            });
+    });
+
+    it('throttles new item update fetches during bursts', () => {
+        const searchSpy = spyOn(server, 'get').and.callThrough();
+        jasmine.clock().install();
+        jasmine.clock().mockDate();
+
+        return store.dispatch(actions.pushNotification({event: 'new_item', extra: {_items: [ {'_id': 'foo', 'type': 'text'} ]}}))
+            .then(() => {
+                store.dispatch(actions.pushNotification({event: 'new_item', extra: {_items: [ {'_id': 'bar', 'type': 'text'} ]}}));
+
+                expect(searchSpy.calls.count()).toBe(1);
+
+                jasmine.clock().tick(2000);
+
+                expect(searchSpy.calls.count()).toBe(2);
+            })
+            .finally(() => {
+                jasmine.clock().uninstall();
             });
     });
 


### PR DESCRIPTION
there was refresh button with count visible even
if user couldn't see the new items.

STT-1659

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
