### PR TITLE
SDAN-762 Fix planning item/coverage display duplicated in agenda preview

### DIFF
--- a/assets/agenda/components/AgendaPreviewPlanning.tsx
+++ b/assets/agenda/components/AgendaPreviewPlanning.tsx
@@ -104,6 +104,9 @@ class AgendaPreviewPlanningComponent extends React.Component<IProps, IState> {
         const plan = planningItems.find((p) => p.guid === planningId);
         const otherPlanningItems = planningItems.filter((p) => p.guid !== planningId);
         const relatedPlanningItems = getFilteredItems(item.planning_ids || [], this.props.items);
+        // Ensure the planningItems are not in the relatedPlanningItems
+        const planningItemIds = new Set(planningItems.map((p) => p._id));
+        const cleanedRelatedItems = relatedPlanningItems.filter((p) => !planningItemIds.has(p.guid));
 
         if (isPlanningItem(item) || restrictCoverageInfo) {
             return (
@@ -171,10 +174,10 @@ class AgendaPreviewPlanningComponent extends React.Component<IProps, IState> {
                         </span>
                         {loading ? (
                             <div className="spinner-border text-success" />
-                        ) : relatedPlanningItems.length === 0 ? (
+                        ) : cleanedRelatedItems.length === 0 ? (
                             <div>{gettext('No Related Planning Items')}</div>
                         ) : (
-                            relatedPlanningItems.map((planningItem: any) => {
+                            cleanedRelatedItems.map((planningItem: any) => {
                                 const isExpanded = expandedPlanningItems[planningItem._id] || false;
                                 return (
                                     <div


### PR DESCRIPTION
### Purpose
Planning item display is duplicated in the agenda preview.

This may be due to the version of Superdesk AAP is running, but this change should not have negative effects on other instances.

### What has changed
Items in the relatedplanning list are removed and not displayed if they exist in the planning items.

### Steps to test
To replicate :-

Create and publish an event in Superdesk

In Superdesk create a planning item from the event with a single coverage and publish that.

Note the display in Newsroom Agenda with no “Events & Coverages” Selected similar to above.


### Screenshots
<img width="1024" height="505" alt="image" src="https://github.com/user-attachments/assets/15254c07-4c47-4c7c-a117-677954408ae5" />

TEST 1 has only one planning item!!! but it is being displayed twice.


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-762
