### PR TITLE
SDAN-763 Sort the prodcuts for the admin pages

### DIFF
--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -39,9 +39,9 @@ async def get_settings_data():
 
     ui_config_service = UiConfigResourceService()
     return {
-        "companies": await CompanyService().get_all_raw_as_list(),
+        "companies": sorted(await CompanyService().get_all_raw_as_list(), key=lambda x: x.get("name", "").lower()),
         "services": get_app_config("SERVICES"),
-        "products": await ProductsService().get_all_raw_as_list(),
+        "products": sorted(await ProductsService().get_all_raw_as_list(), key=lambda x: x.get("name", "").lower()),
         "sections": get_current_app().as_any().sections,
         "company_types": get_company_types_options(),
         "api_enabled": get_app_config("NEWS_API_ENABLED", False),
@@ -67,6 +67,7 @@ async def search_companies(args: None, params: CompanySearchArgs, request: Reque
         lookup = {"name": regex}
     cursor = await CompanyService().search(lookup)
     companies = await cursor.to_list_raw()
+    companies.sort(key=lambda x: x.get("name", "").lower())
     return Response(companies)
 
 

--- a/newsroom/navigations/views.py
+++ b/newsroom/navigations/views.py
@@ -24,6 +24,7 @@ navigations_endpoints = EndpointGroup("navigations", __name__)
 
 async def get_settings_data():
     all_navigations = await get_navigations_as_list()
+    all_navigations.sort(key=lambda x: x.get("name", "").lower())
 
     return {
         "products": list(query_resource("products")),
@@ -65,6 +66,7 @@ async def search(_a, params: SearchParams, _q):
         lookup = {"name": regex}
     cursor = await NavigationsService().search(lookup)
     navigations = await cursor.to_list_raw()
+    navigations.sort(key=lambda x: x.get("name", "").lower())
     return Response(navigations)
 
 

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -22,8 +22,9 @@ products_endpoints = EndpointGroup("products_views", __name__)
 
 async def get_settings_data():
     app = get_current_wsgi_app()
+
     return {
-        "products": await ProductsService().get_all_raw_as_list(),
+        "products": sorted(await ProductsService().get_all_raw_as_list(), key=lambda x: x.get("name", "").lower()),
         "navigations": await get_navigations_as_list(),
         "companies": await CompanyService().get_all_raw_as_list(),
         "sections": [s for s in app.sections if s.get("_id") != "monitoring"],  # monitoring has no products
@@ -49,6 +50,7 @@ class ProductsArgs(BaseModel):
 @products_endpoints.endpoint("/products", methods=["GET"], auth=[auth_rules.admin_only])
 async def index():
     products = await ProductsService().get_all_raw_as_list()
+    products.sort(key=lambda x: x.get("name", "").lower())
     return Response(products)
 
 
@@ -63,7 +65,7 @@ async def search(_a: None, params: SearchParams, _r: None):
 
     search_cursor = await ProductsService().search(lookup)
     products = await search_cursor.to_list_raw()
-
+    products.sort(key=lambda x: x.get("name", "").lower())
     return Response(products)
 
 


### PR DESCRIPTION
### Purpose
Show the products and companies sorted by name for the admin pages.

### What has changed
Product and company lists are sorted in the back end before being returned to the client.

### Steps to test
As an Administrative user got to the Settings/Products page and observe that the products are shown in alphabetic order, rather than being ordered by id as in the past.

Also go to Company Management, select a company then view the permissions tab the Products are ordered alphabetically.

In Global Topics admin select a topic and the products tab and note that the products are sorted alphabetically by name.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-763
