### PR TITLE
SDAN-764 Stop always displaying More Hidden in Agenda view

### DIFF
--- a/assets/agenda/components/AgendaListGroupHeader.tsx
+++ b/assets/agenda/components/AgendaListGroupHeader.tsx
@@ -58,18 +58,25 @@ export function AgendaListGroupHeader({group, itemIds, itemsById, itemsShown, to
             <span className="badge rounded-pill badge--neutral">{itemIds.length}</span>
             {coverageTypes.length === 0 ? (
                 <div className="list-group-header__title">
-                    {gettext('More hidden')}
+                    {itemsShown
+                        ? gettext('Extra shown')
+                        : gettext('More hidden')
+                    }
                 </div>
             ) : (
                 <React.Fragment>
                     <div className="list-group-header__title">
-                        {gettext('More hidden')}
+                        {itemsShown
+                            ? gettext('Extra shown')
+                            : gettext('More hidden')
+                        }
                     </div>
                     <div className="list-group-header__coverage-group">
                         {coverageTypes.map((coverageType) => (
                             <div key={coverageType} className="list-group-header__coverage-item">
-                                <span className="wire-articles__item__icon" title="Some title">
-                                    <i className={`icon--coverage-${getCoverageIcon(coverageType)}`} />
+                                <span className="wire-articles__item__icon"
+                                    title={gettext('{{ coverageType }} coverage', {coverageType})}>
+                                    <i className={`icon--coverage-${getCoverageIcon(coverageType)}`}/>
                                 </span>
                                 <span className="list-group-header__coverage-number">
                                     {coverageTypeCount[coverageType]}


### PR DESCRIPTION
### Purpose
In the Agenda View if it has items for a particular day that are hidden, a show all button is displayed along with a count of the hidden items is shown

In the Agenda View, if items for a particular day are hidden, a 'Show all' button is displayed along with a count of the hidden items.

<img width="1612" height="148" alt="image" src="https://github.com/user-attachments/assets/c3f3ded3-44f0-471a-8683-7dc11568e240" />

When you click the "Show Hidden" the result is :-

<img width="1116" height="143" alt="image" src="https://github.com/user-attachments/assets/a9c2de80-6455-40ce-b78d-56aab3b01596" />

Still showing the "More hidden" text which is now misleading.

### What has changed

When showing the hidden items the text is change to "Extra shown" along with the hide button.
<img width="1444" height="565" alt="image" src="https://github.com/user-attachments/assets/83e879b9-3e58-49db-abb5-792bde057c5e" />

<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-764