### PR TITLE
Fix: applying download permissions to feature media

### DIFF
--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -306,7 +306,7 @@ def _get_associations_to_remove_or_disable(
             continue
 
         # This item has display enabled. Check to see if we need to disable the download from browser action
-        elif content_type in {"audio", "video"} and not company.is_permissioned_for_embed(
+        elif content_type in {"audio", "video", "picture"} and not company.is_permissioned_for_embed(
             embed_type, EmbedPermissionUserAction.DOWNLOAD
         ):
             disable_download.add(key)


### PR DESCRIPTION
### Purpose
The download permission for featuremedia was not being applied.

### What has changed
The download checkbox will need to be checked for a user to be able to download the feature image in the package downloads.


### Steps to test
Define a company that has "Superdesk Products" enabled.
Check "FeatureMedia" "Content Type"  but leave the corresponding "Allow Download" unchecked.
Download an Article using the "HTML with Embedded media" formatter and observe  the result does not have the Feature Media embedded. 
Check the "Allow Download" and repeat the download and observe the Feature Media item is embedded.

<img width="457" height="335" alt="image" src="https://github.com/user-attachments/assets/80c2d48f-058b-47ea-97fb-31b9fae82658" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
