### PR TITLE
SDAN-766 Items opened from the homepage do not respect the embedded i…

### DIFF
--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -23,6 +23,7 @@ __all__ = [
     "remove_all_embeds",
     "remove_internal_renditions",
     "set_association_links",
+    "apply_company_permissions_to_cards",
 ]
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,37 @@ def iterate_embeds(
 
         # if we've found an Embed Start comment, yield it now
         yield comment, f"editor_{m.group(1)}"
+
+
+async def apply_company_permissions_to_cards(card_items: list[dict]):
+    """
+    Applies company permissions to the items displayed on the home page/cards.
+    It will leave the featuremedia association untouched as this may be displayed.
+
+    @param card_items: List of item dictionaries to process
+    """
+    company = get_company_from_request(None)
+    if not len(card_items) or not company or not get_app_config("WIRE_EMBED_PERMISSIONS", True):
+        return
+
+    saved_featuremedia = {}
+    for card_item in card_items:
+        item_id = card_item.get("_id")
+        associations = card_item.get("associations") or {}
+        featuremedia = associations.get("featuremedia")
+
+        if item_id and featuremedia:
+            saved_featuremedia[item_id] = dict(featuremedia)
+
+    await apply_company_permissions_to_embeds(card_items, SectionEnum.WIRE)
+
+    # Restore the featuremedia
+    for card_item in card_items:
+        item_id = card_item.get("_id")
+        if item_id in saved_featuremedia:
+            if not card_item.get("associations"):
+                card_item["associations"] = {}
+            card_item["associations"]["featuremedia"] = saved_featuremedia[item_id]
 
 
 async def apply_company_permissions_to_embeds(

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -74,7 +74,7 @@ from newsroom.wire.formatters.utils import add_media
 from .items import get_items_for_dashboard
 from .service import WireSearchServiceAsync
 from .formatters.picture import PictureFormatter
-from .embeds import apply_company_permissions_to_embeds
+from .embeds import apply_company_permissions_to_embeds, apply_company_permissions_to_cards
 
 HOME_ITEMS_CACHE_KEY = "home_items"
 HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
@@ -131,9 +131,7 @@ async def set_permissions_on_cards(items_by_card):
                 item_dict["_access"] = True
         return
 
-    card_item_ids = []
-    for _c, card_items in items_by_card.items():
-        card_item_ids.extend([itm.get("_id") for itm in card_items if itm.get("_id")])
+    card_item_ids = [itm.get("_id") for card_items in items_by_card.values() for itm in card_items if itm.get("_id")]
     service = WireSearchServiceAsync()
     try:
         cursor = await service.get_items_by_id(
@@ -145,7 +143,8 @@ async def set_permissions_on_cards(items_by_card):
         # Exception thrown if no wire items are allowed
         allowed_ids_set = set()
 
-    for card, card_items in items_by_card.items():
+    for card_items in items_by_card.values():
+        await apply_company_permissions_to_cards(card_items)
         for i, card_item in enumerate(card_items):
             wire_item = WireItem.from_dict(card_item)
 


### PR DESCRIPTION
…tems permissions mechanism

### Purpose
Currently, the homepage layout breaks or looks incomplete when a company lacks permissions to view images. This PR ensures that homepage images remain visible to all users, regardless of company-level permissions, to maintain a consistent user experience.

### What has changed
Updated the permission logic to exclude featured images on the homepage. Permissions will continue to be strictly applied to individual card items as required.

### Steps to test
Permission a company for "Superdesk Products" without the FeatureMedia checked, view the home page and observe that the images on the home page can be seen.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-766
