### PR TITLE
SDAN-767 Apply the download permissions to the embedded images

### DIFF
--- a/assets/companies/components/CompanyContentPermissions.tsx
+++ b/assets/companies/components/CompanyContentPermissions.tsx
@@ -24,7 +24,7 @@ const embedPermissions: Array<IEmbedPermissionOptions> = [
     {
         contentType: 'picture',
         label: gettext('Images'),
-        separateDownloadPermission: false,
+        separateDownloadPermission: true,
     },
     {
         contentType: 'video',

--- a/newsroom/companies/views.py
+++ b/newsroom/companies/views.py
@@ -115,7 +115,7 @@ def get_company_updates(data, original=None):
                 "video": [EmbedPermissionUserAction.DISPLAY, EmbedPermissionUserAction.DOWNLOAD],
                 "audio": [EmbedPermissionUserAction.DISPLAY, EmbedPermissionUserAction.DOWNLOAD],
                 "embed_code": [EmbedPermissionUserAction.DISPLAY],
-                "picture": [EmbedPermissionUserAction.DISPLAY],
+                "picture": [EmbedPermissionUserAction.DISPLAY, EmbedPermissionUserAction.DOWNLOAD],
                 "sd_product": [],
             }
         ),


### PR DESCRIPTION
### Purpose
Apply the Superdesk Products download permission to embedded images in the same way as applied to feature images.

### What has changed
Add the checkbox to the company permission view.


### Screenshots
<img width="422" height="258" alt="image" src="https://github.com/user-attachments/assets/d45ec038-40ae-4d4f-af6a-772a008c5196" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-767
