### PR TITLE
SDAN-766 Items opened from the homepage do not respect the embedded items permissions mechanism

### DIFF
--- a/newsroom/wire/embeds.py
+++ b/newsroom/wire/embeds.py
@@ -45,9 +45,10 @@ def iterate_embeds(
 async def apply_company_permissions_to_cards(card_items: list[dict]):
     """
     Applies company permissions to the items displayed on the home page/cards.
-    It will leave the featuremedia association untouched as this may be displayed.
+    Leaves the ``featuremedia`` association untouched so it can still be displayed.
 
-    @param card_items: List of item dictionaries to process
+    :param card_items: List of item dictionaries to process.
+    :return
     """
     company = get_company_from_request(None)
     if not len(card_items) or not company or not get_app_config("WIRE_EMBED_PERMISSIONS", True):

--- a/newsroom/wire/service.py
+++ b/newsroom/wire/service.py
@@ -38,8 +38,7 @@ from .filters import (
     apply_time_limit_filter,
     apply_highlights,
 )
-from .embeds import apply_company_permissions_to_embeds
-
+from .embeds import apply_company_permissions_to_embeds, apply_company_permissions_to_cards
 
 logger = logging.getLogger(__name__)
 
@@ -347,7 +346,7 @@ class WireSearchServiceAsync(BaseWebSearchService[WireSearchRequestArgs, WireIte
         )
         items = await cursor.to_list_raw()
         if get_app_config("USE_EMBED_PERMISSIONS_IN_DASHBOARD", True):
-            await apply_company_permissions_to_embeds(items, self.section)
+            await apply_company_permissions_to_cards(items)
         return items
 
     async def get_matching_item_bookmarks(

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -74,7 +74,7 @@ from newsroom.wire.formatters.utils import add_media
 from .items import get_items_for_dashboard
 from .service import WireSearchServiceAsync
 from .formatters.picture import PictureFormatter
-from .embeds import apply_company_permissions_to_embeds, apply_company_permissions_to_cards
+from .embeds import apply_company_permissions_to_embeds
 
 HOME_ITEMS_CACHE_KEY = "home_items"
 HOME_EXTERNAL_ITEMS_CACHE_KEY = "home_external_items"
@@ -144,7 +144,6 @@ async def set_permissions_on_cards(items_by_card):
         allowed_ids_set = set()
 
     for card_items in items_by_card.values():
-        await apply_company_permissions_to_cards(card_items)
         for i, card_item in enumerate(card_items):
             wire_item = WireItem.from_dict(card_item)
 


### PR DESCRIPTION
### Purpose
Currently, the homepage layout breaks or looks incomplete when a company lacks permissions to view images. This PR ensures that homepage images remain visible to all users, regardless of company-level permissions, to maintain a consistent user experience.

### What has changed
Updated the permission logic to exclude featured images on the homepage. Permissions will continue to be strictly applied to individual card items as required.

### Steps to test
Permission a company for "Superdesk Products" without the FeatureMedia checked, view the home page and observe that the images on the home page can be seen.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-766