### PR TITLE
fix data updates to allow app based updates

### DIFF
--- a/newsroom/commands/data_updates.py
+++ b/newsroom/commands/data_updates.py
@@ -22,7 +22,6 @@ async def data_generate_update(resource):
     "--id",
     "data_update_id",
     required=False,
-    type=click.Choice(get_data_updates_files(strip_file_extension=True)),
     help="Data update id to run last",
 )
 @click.option(

--- a/newsroom/data_updates.py
+++ b/newsroom/data_updates.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import getpass
+import click
 import superdesk
 
 from string import Template
@@ -102,11 +103,9 @@ class DataUpdateCommand:
     async def run(self, data_update_id=None, fake=False, dry=False):
         # TODO-ASYNC: revisit when `data_updates` module is migrated to async
         if data_update_id and data_update_id not in get_data_updates_files(strip_file_extension=True):
-            print(
-                "Error argument --id/-i: invalid choice: '{}'"
-                " (choose from  {})".format(data_update_id, get_data_updates_files(strip_file_extension=True))
-            )
-            return
+            error_message = f"'{data_update_id}' (choose from  {get_data_updates_files(strip_file_extension=True)})"
+            raise click.BadParameter(error_message, param_hint="--id/-i")
+
         self.data_updates_service = superdesk.get_resource_service("data_updates")
         self.data_updates_files = get_data_updates_files(strip_file_extension=True)
 

--- a/newsroom/data_updates.py
+++ b/newsroom/data_updates.py
@@ -101,6 +101,12 @@ class DataUpdateCommand:
 
     async def run(self, data_update_id=None, fake=False, dry=False):
         # TODO-ASYNC: revisit when `data_updates` module is migrated to async
+        if data_update_id and data_update_id not in get_data_updates_files(strip_file_extension=True):
+            print(
+                "Error argument --id/-i: invalid choice: '{}'"
+                " (choose from  {})".format(data_update_id, get_data_updates_files(strip_file_extension=True))
+            )
+            return
         self.data_updates_service = superdesk.get_resource_service("data_updates")
         self.data_updates_files = get_data_updates_files(strip_file_extension=True)
 


### PR DESCRIPTION
### Purpose
The parameter validation would not allow data_upates from the application repos's to be run individualy.

### What has changed
The validation that ensures any update script specified to the update command exists has been moved to the run function as by then the script folder for the application based updates has been added.

### Steps to test
Run an update script from the application

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
