### PR TITLE
Validate map url for agenda printing

### DIFF
--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -1,3 +1,5 @@
+import logging
+import urllib
 from typing import Annotated, Any, cast
 from asyncio import gather
 
@@ -52,6 +54,30 @@ from .agenda_service import AgendaItemService
 from .agenda_search import AgendaSearchServiceAsync
 from .filters import AgendaSearchRequestArgs
 
+logger = logging.getLogger(__name__)
+
+# see https://developers.google.com/maps/documentation/maps-static/start
+ALLOWED_GOOGLE_PARAMS = {
+    "center",
+    "zoom",
+    "size",
+    "scale",
+    "format",
+    "maptype",
+    "language",
+    "region",
+    "map_id",
+    "markers",
+    "path",
+    "visible",
+    "style",
+    "key",
+    "signature",
+}
+
+# See assets/maps/utils.ts for the frontend equivalent
+MAP_URL_PREFIX = "https://maps.googleapis.com/maps/api/staticmap"
+
 
 @agenda_endpoints.endpoint("/agenda", auth=[auth_rules.section_required("agenda")])
 async def index() -> str:
@@ -80,6 +106,43 @@ class AgendaItemParams(BaseModel):
     def parse_print(cls, value: str | bool | None) -> bool | str | None:
         # Support this URL param as a toggle, if `print` is provided in the URL then it is `True`
         return True if value == "" else value
+
+    @field_validator("map", mode="before")
+    def validate_map_url(cls, value: str | None) -> str | None:
+        """
+        Attempt to ensure the map parameter is a legitimate google static map api url
+        If not remove it and log the reason
+        :param value:
+        :return:
+        """
+        if not value or not value.strip():
+            return None
+
+        map_url = value.strip()
+
+        bad_characters = ("<", ">", '"', "'", "`", "javascript:", "data:")
+        if any(signal in map_url.lower() for signal in bad_characters):
+            logger.warning("map_url validation rejected character sequence")
+            return None
+        try:
+            if map_url.startswith(MAP_URL_PREFIX):
+                _, _, map_params = map_url.partition("?")
+            else:
+                logger.warning("unexpected prefix to map url")
+                return None
+            parsed_query = urllib.parse.parse_qsl(map_params, strict_parsing=True)
+            clean_pairs = []
+            for key, val in parsed_query:
+                if key.lower() not in ALLOWED_GOOGLE_PARAMS:
+                    logger.warning(f"Disallowed query parameter in map url: {key}")
+                    return None
+                clean_pairs.append((key, val))
+
+            return f"{MAP_URL_PREFIX}?{urllib.parse.urlencode(clean_pairs)}"
+
+        except Exception as ex:
+            logger.warning(f"Malformed map query format: {str(ex)}")
+            return None
 
 
 @agenda_endpoints.endpoint("/agenda/<_id>")

--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -134,14 +134,14 @@ class AgendaItemParams(BaseModel):
             clean_pairs = []
             for key, val in parsed_query:
                 if key.lower() not in ALLOWED_GOOGLE_PARAMS:
-                    logger.warning(f"Disallowed query parameter in map url: {key}")
+                    logger.warning("Disallowed query parameter in map url: %s", key)
                     return None
                 clean_pairs.append((key, val))
 
             return f"{MAP_URL_PREFIX}?{urllib.parse.urlencode(clean_pairs)}"
 
-        except Exception as ex:
-            logger.warning(f"Malformed map query format: {str(ex)}")
+        except ValueError as ex:
+            logger.warning("Malformed map query format: %s", ex)
             return None
 
 

--- a/newsroom/templates/agenda_item_print.html
+++ b/newsroom/templates/agenda_item_print.html
@@ -21,7 +21,7 @@
     {% if map and map != '' %}
         <div class="mt-4 mb-4">
             <img style="height: auto!important; max-width: 700px!important; width: 100%!important"
-                 src={{ map | safe }} >
+               src="{{ map }}" >
         </div>
     {% endif %}
 

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -715,7 +715,7 @@ async def test_filter_events_only(client):
     assert "coverages" not in data["_items"][0]
 
 
-async def test_item_print(client, caplog):
+async def test_item_print(client):
     MAP_URL_PREFIX = "https://maps.googleapis.com/maps/api/staticmap"
     payload = (
         f"{MAP_URL_PREFIX}%3Fmarkers%3D-35.3066572,149.1235713%26size%3D600x306%26key%3DKEY%26"

--- a/tests/core/test_agenda.py
+++ b/tests/core/test_agenda.py
@@ -1,3 +1,4 @@
+import logging
 import pytz
 from quart import json
 from datetime import datetime
@@ -5,6 +6,7 @@ from unittest import mock
 from pytest import fixture
 
 import newsroom.auth  # noqa - Fix cyclic import when running single test file
+from newsroom.agenda.views import AgendaItemParams
 from newsroom.utils import (
     get_location_string,
     get_agenda_dates,
@@ -711,3 +713,47 @@ async def test_filter_events_only(client):
     assert "urn:conference" == data["_items"][0]["_id"]
     assert "planning_items" not in data["_items"][0]
     assert "coverages" not in data["_items"][0]
+
+
+async def test_item_print(client, caplog):
+    MAP_URL_PREFIX = "https://maps.googleapis.com/maps/api/staticmap"
+    payload = (
+        f"{MAP_URL_PREFIX}%3Fmarkers%3D-35.3066572,149.1235713%26size%3D600x306%26key%3DKEY%26"
+        f"scale%3D2%26style%3Dfeature%3Apoi.business%7Celement%3Alabels%7Cvisibility%3Aoff%26"
+        f"style%3Dfeature%3Apoi.attraction%7Celement%3Alabels%7Cvisibility%3Aoff%26zoom%3D15"
+    )
+    resp = await client.get(f"/agenda/urn:conference?print&map={payload}")
+    assert resp.status_code == 200
+    data = (await resp.get_data()).decode()
+    assert "https://maps.googleapis.com/maps/api/staticmap?markers=-35.3066572%2C149.1235713" in data
+
+
+def test_map_validator_rejects_bad_prefix(caplog):
+    with caplog.at_level(logging.WARNING):
+        model = AgendaItemParams(map="https://evil-attacker.com/maps")
+
+        assert model.map is None
+        assert any("unexpected prefix to map url" in record.message for record in caplog.records)
+
+
+def test_map_validator_rejects_bad_characters(caplog):
+    MAP_URL_PREFIX = "https://maps.googleapis.com/maps/api/staticmap"
+    payload = f"{MAP_URL_PREFIX}?center=40.7,-74.0&size=600x300&key=123<script>"
+
+    with caplog.at_level(logging.WARNING):
+        model = AgendaItemParams(map=payload)
+        assert model.map is None
+        assert any("map_url validation rejected character sequence" in record.message for record in caplog.records)
+
+
+def test_map_validator_rejects_disallowed_parameters(caplog):
+    MAP_URL_PREFIX = "https://maps.googleapis.com/maps/api/staticmap"
+    payload = f"{MAP_URL_PREFIX}?center=40.7,-74.0&size=600x300&malicious_param=hack"
+
+    with caplog.at_level(logging.WARNING):
+        model = AgendaItemParams(map=payload)
+
+        assert model.map is None
+        assert any(
+            "Disallowed query parameter in map url: malicious_param" in record.message for record in caplog.records
+        )


### PR DESCRIPTION
### Purpose
Validates the map URL passed on printing to prevent XSS vulnerability

### What has changed
Addition of a Validation function on the passed map parameter, also remove the "safe" from the jinja template variable usage.

### Steps to test
Ensure that the printed event include a map if enabled.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #SDAN-769
