### PR TITLE
[STT-1718] - the in app notifications disappear on click

### DIFF
--- a/assets/components/ErrorBoundary.tsx
+++ b/assets/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface IProps {
+    fallback?: React.ReactNode;
+    label?: string;
+}
+
+interface IState {
+    error: boolean;
+}
+
+/**
+ * Contains a render error, so it doesn't unmount everything around it.
+ */
+export class ErrorBoundary extends React.Component<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+        this.state = {error: false};
+    }
+
+    static getDerivedStateFromError(): IState {
+        return {error: true};
+    }
+
+    componentDidCatch(error: any, info: any) {
+        console.error(`Error in ${this.props.label || 'component'}`, error, info);
+    }
+
+    render() {
+        if (this.state.error) {
+            return this.props.fallback ?? null;
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/assets/components/NotificationList.tsx
+++ b/assets/components/NotificationList.tsx
@@ -4,6 +4,7 @@ import {Tooltip} from 'bootstrap';
 import {gettext} from 'utils';
 import {isTouchDevice} from '../utils';
 import {NotificationPopup, IProps as INotificationPopupProps} from './NotificationPopup';
+import {ErrorBoundary} from './ErrorBoundary';
 
 interface IState {
     displayItems: boolean;
@@ -97,17 +98,19 @@ class NotificationList extends React.Component<IProps, IState> {
                 </span>
 
                 {this.state.displayItems === true && (
-                    <NotificationPopup
-                        fullUser={this.props.fullUser}
-                        items={this.props.items}
-                        count={this.props.count}
-                        notifications={this.props.notifications}
-                        loading={this.props.loading}
-                        clearNotification={this.props.clearNotification}
-                        clearAll={this.props.clearAll}
-                        loadNotifications={this.props.loadNotifications}
-                        resumeNotifications={this.props.resumeNotifications}
-                    />
+                    <ErrorBoundary label="notification popup">
+                        <NotificationPopup
+                            fullUser={this.props.fullUser}
+                            items={this.props.items}
+                            count={this.props.count}
+                            notifications={this.props.notifications}
+                            loading={this.props.loading}
+                            clearNotification={this.props.clearNotification}
+                            clearAll={this.props.clearAll}
+                            loadNotifications={this.props.loadNotifications}
+                            resumeNotifications={this.props.resumeNotifications}
+                        />
+                    </ErrorBoundary>
                 )}
             </div>
         );

--- a/assets/components/NotificationListItem.tsx
+++ b/assets/components/NotificationListItem.tsx
@@ -1,29 +1,24 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+
+import {IArticle} from 'interfaces';
+import {INotification} from 'interfaces/notification';
 
 import CloseModalButton from './CloseModalButton';
 import {renderNotificationComponent} from 'notifications/components/notificationItems';
 
-function NotificationListItem({notification, item, clearNotification}: any) {
-    if (item == null) {
-        // rendering without an item throws and takes the whole notification list down
-        console.warn('Skipping notification without an item', notification);
+interface IProps {
+    notification: INotification;
+    item: IArticle;
+    clearNotification(id: string): void;
+}
 
-        return null;
-    }
-
+function NotificationListItem({notification, item, clearNotification}: IProps) {
     return (
         <div className='notif__list__item'>
             <CloseModalButton onClick={() => clearNotification(notification.item)}/>
             {renderNotificationComponent(notification, item)}
-        </div>);
-
+        </div>
+    );
 }
-
-NotificationListItem.propTypes = {
-    notification: PropTypes.object,
-    item: PropTypes.object,
-    clearNotification: PropTypes.func,
-};
 
 export default NotificationListItem;

--- a/assets/components/NotificationListItem.tsx
+++ b/assets/components/NotificationListItem.tsx
@@ -5,9 +5,16 @@ import CloseModalButton from './CloseModalButton';
 import {renderNotificationComponent} from 'notifications/components/notificationItems';
 
 function NotificationListItem({notification, item, clearNotification}: any) {
+    if (item == null) {
+        // rendering without an item throws and takes the whole notification list down
+        console.warn('Skipping notification without an item', notification);
+
+        return null;
+    }
+
     return (
-        <div key={item._id} className='notif__list__item'>
-            <CloseModalButton onClick={() => clearNotification(item._id)}/>
+        <div className='notif__list__item'>
+            <CloseModalButton onClick={() => clearNotification(notification.item)}/>
             {renderNotificationComponent(notification, item)}
         </div>);
 

--- a/assets/components/NotificationPopup.tsx
+++ b/assets/components/NotificationPopup.tsx
@@ -86,14 +86,21 @@ export const NotificationPopup = (props: IProps) => {
                             {gettext('Loading...')}
                         </div>
                     ) : (
-                        props.notifications.map((notification, index) => (
-                            <NotificationListItem
-                                key={notification._id || index}
-                                item={notification.item in props.items ? props.items[notification.item] : notification.data?.item}
-                                notification={notification}
-                                clearNotification={props.clearNotification}
-                            />
-                        ))
+                        props.notifications
+                            .map((notification) => ({
+                                notification,
+                                item: props.items[notification.item] ?? notification.data?.item,
+                            }))
+                            // drop notifications whose item is gone, there is nothing to render for those
+                            .filter((entry): entry is {notification: INotification; item: IArticle} => entry.item != null)
+                            .map(({notification, item}) => (
+                                <NotificationListItem
+                                    key={notification._id}
+                                    item={item}
+                                    notification={notification}
+                                    clearNotification={props.clearNotification}
+                                />
+                            ))
                     )}
                 </div>
             );

--- a/assets/tests/NotificationListItem.spec.tsx
+++ b/assets/tests/NotificationListItem.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import NotificationListItem from '../components/NotificationListItem';
+
+import 'tests/setup';
+
+const notification = {
+    _id: 'user_id_item_id',
+    item: 'item_id',
+    resource: 'wire',
+    action: 'topic_matches',
+    _created: '2024-01-01T10:00:00+0000',
+};
+
+function setup(item: any) {
+    return mount(
+        <NotificationListItem
+            notification={notification}
+            item={item}
+            clearNotification={() => undefined}
+        />
+    );
+}
+
+describe('NotificationListItem', () => {
+    it('renders the notification when the item is there', () => {
+        const wrapper = setup({_id: 'item_id', type: 'text', headline: 'Demo Article'});
+
+        expect(wrapper.find('.notif__list__item').length).toBe(1);
+        expect(wrapper.text()).toContain('Demo Article');
+    });
+
+    it('renders nothing when the item is missing', () => {
+        expect(setup(undefined).isEmptyRender()).toBe(true);
+        expect(setup(null).isEmptyRender()).toBe(true);
+    });
+
+    it('clears the notification by its item id', () => {
+        const clearNotification = jasmine.createSpy('clearNotification');
+        const wrapper = mount(
+            <NotificationListItem
+                notification={notification}
+                item={{_id: 'item_id', type: 'text', headline: 'Demo Article'}}
+                clearNotification={clearNotification}
+            />
+        );
+
+        wrapper.find('button').first().simulate('click');
+
+        expect(clearNotification).toHaveBeenCalledWith('item_id');
+    });
+});

--- a/assets/tests/NotificationListItem.spec.tsx
+++ b/assets/tests/NotificationListItem.spec.tsx
@@ -4,7 +4,7 @@ import NotificationListItem from '../components/NotificationListItem';
 
 import 'tests/setup';
 
-const notification = {
+const notification: any = {
     _id: 'user_id_item_id',
     item: 'item_id',
     resource: 'wire',
@@ -30,17 +30,12 @@ describe('NotificationListItem', () => {
         expect(wrapper.text()).toContain('Demo Article');
     });
 
-    it('renders nothing when the item is missing', () => {
-        expect(setup(undefined).isEmptyRender()).toBe(true);
-        expect(setup(null).isEmptyRender()).toBe(true);
-    });
-
     it('clears the notification by its item id', () => {
         const clearNotification = jasmine.createSpy('clearNotification');
         const wrapper = mount(
             <NotificationListItem
                 notification={notification}
-                item={{_id: 'item_id', type: 'text', headline: 'Demo Article'}}
+                item={{_id: 'item_id', type: 'text', headline: 'Demo Article'} as any}
                 clearNotification={clearNotification}
             />
         );

--- a/assets/tests/NotificationPopup.spec.tsx
+++ b/assets/tests/NotificationPopup.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {NotificationPopup} from '../components/NotificationPopup';
+
+import 'tests/setup';
+
+function notification(id: string, item: string, data?: any) {
+    return {_id: id, item, resource: 'wire', action: 'topic_matches', _created: '2024-01-01T10:00:00+0000', data};
+}
+
+function setup(props: any = {}) {
+    return mount(
+        <NotificationPopup
+            fullUser={{}}
+            items={{}}
+            count={0}
+            notifications={[]}
+            loading={false}
+            clearNotification={() => undefined}
+            clearAll={() => undefined}
+            loadNotifications={() => undefined}
+            resumeNotifications={() => undefined}
+            {...props}
+        />
+    );
+}
+
+describe('NotificationPopup', () => {
+    it('only renders notifications whose item can be resolved', () => {
+        const wrapper = setup({
+            count: 3,
+            items: {resolved: {_id: 'resolved', type: 'text', headline: 'Resolved Article'}},
+            notifications: [
+                notification('n_resolved', 'resolved'),
+                notification('n_embedded', 'gone', {item: {_id: 'gone', type: 'text', headline: 'Embedded Article'}}),
+                notification('n_orphaned', 'missing'),
+            ],
+        });
+
+        expect(wrapper.find('.notif__list__item').length).toBe(2);
+        expect(wrapper.text()).toContain('Resolved Article');
+        expect(wrapper.text()).toContain('Embedded Article');
+    });
+});

--- a/newsroom/notifications/utils.py
+++ b/newsroom/notifications/utils.py
@@ -74,12 +74,15 @@ async def get_notifications_with_items() -> dict[str, Any] | None:
     items = wire_items + agenda_items + topic_items
     found_ids = {item["_id"] for item in items}
 
-    # skip notifications whose item is gone, there is nothing to render for those
-    notifications = [
-        notification
-        for notification in saved_notifications
-        if notification["item"] in found_ids or (notification.get("data") or {}).get("item")
-    ]
+    def has_item(notification: dict[str, Any]) -> bool:
+        return notification["item"] in found_ids or bool((notification.get("data") or {}).get("item"))
+
+    # there is nothing to render for these, so drop them instead of leaving them in the count
+    orphaned_ids = [notification["_id"] for notification in saved_notifications if not has_item(notification)]
+    if orphaned_ids:
+        await NotificationsService().delete_many({"_id": {"$in": orphaned_ids}})
+
+    notifications = [notification for notification in saved_notifications if has_item(notification)]
 
     return {
         "user": str(user_id),

--- a/newsroom/notifications/utils.py
+++ b/newsroom/notifications/utils.py
@@ -71,10 +71,20 @@ async def get_notifications_with_items() -> dict[str, Any] | None:
         TopicService().find_by_ids_raw(item_ids),
     )
 
+    items = wire_items + agenda_items + topic_items
+    found_ids = {item["_id"] for item in items}
+
+    # skip notifications whose item is gone, there is nothing to render for those
+    notifications = [
+        notification
+        for notification in saved_notifications
+        if notification["item"] in found_ids or (notification.get("data") or {}).get("item")
+    ]
+
     return {
         "user": str(user_id),
-        "items": wire_items + agenda_items + topic_items,
-        "notifications": saved_notifications,
+        "items": items,
+        "notifications": notifications,
     }
 
 

--- a/newsroom/push/notifications.py
+++ b/newsroom/push/notifications.py
@@ -42,17 +42,22 @@ class NotificationManager:
 
         item_type = item.get("type")
         users_with_realtime_subscription: set[ObjectId] = set()
+
+        # broadcast first, so the live Wire/Agenda refresh survives a failure below
+        try:
+            if item_type == "agenda":
+                await push_agenda_item_notification("new_item", item=item)
+            else:
+                push_notification("new_item", _items=[item])
+        except Exception:
+            logger.exception(f"Failed to broadcast new {item_type} item", extra={"_id": item["_id"]})
+
         try:
             users = await get_user_dict_async()
             user_ids = list(users.keys())
 
             companies = await get_company_dict_async()
             company_ids = list(companies.keys())
-
-            if item_type == "agenda":
-                await push_agenda_item_notification("new_item", item=item)
-            else:
-                push_notification("new_item", _items=[item])
 
             if check_topics:
                 if item_type == "text":

--- a/newsroom/types/users.py
+++ b/newsroom/types/users.py
@@ -120,7 +120,7 @@ class UserResourceModel(NewshubResourceModel):
     @field_validator("locale", mode="before")
     @classmethod
     def validate_locale(cls, value: str | None) -> str:
-        if value is not None and value not in get_app_config("LANGUAGES", []):
+        if value and value not in get_app_config("LANGUAGES", []):
             raise SuperdeskApiError.badRequestError("Locale is not in configured list of locales.")
         return value or get_app_config("DEFAULT_LANGUAGE", "en")
 

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -19,6 +19,7 @@ from eve.utils import ParsedRequest
 from eve_elastic.elastic import parse_date, ElasticCursor
 from quart_babel import gettext, format_date as _format_date
 
+from superdesk.errors import SuperdeskApiError
 from superdesk.core.types import Request
 from superdesk.core import json, get_current_app, get_app_config, get_current_async_app
 from superdesk.flask import abort, request, g, url_for, Request as FlaskRequest
@@ -325,7 +326,7 @@ async def get_user_dict_async(use_globals: bool = True) -> dict[ObjectId, UserRe
             try:
                 user_dict.pop("_type", None)
                 user = UserResourceModel.from_dict(user_dict)
-            except Exception:
+            except (ValidationError, SuperdeskApiError):
                 logger.warning("Skipping invalid user %s", user_dict.get("_id"), exc_info=True)
                 continue
 

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -321,8 +321,9 @@ async def get_user_dict_async(use_globals: bool = True) -> dict[ObjectId, UserRe
 
         # build users one by one, so an invalid one doesn't fail the whole lookup
         users: dict[ObjectId, UserResourceModel] = {}
-        for user_dict in await users_cursor.to_list_raw():
+        while (user_dict := await users_cursor.next_raw()) is not None:
             try:
+                user_dict.pop("_type", None)
                 user = UserResourceModel.from_dict(user_dict)
             except Exception:
                 logger.warning("Skipping invalid user %s", user_dict.get("_id"), exc_info=True)

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytz
 import regex
 import superdesk
@@ -33,6 +35,8 @@ from newsroom.template_filters import (
     get_client_format,
 )
 
+
+logger = logging.getLogger(__name__)
 
 DAY_IN_MINUTES = 24 * 60 - 1
 MAX_TERMS_SIZE = 1000
@@ -315,11 +319,19 @@ async def get_user_dict_async(use_globals: bool = True) -> dict[ObjectId, UserRe
         users_task = UsersService().search({"is_enabled": True})
         users_cursor, companies = await gather(users_task, get_company_dict_async(use_globals))
 
-        return {
-            user.id: user
-            async for user in users_cursor
-            if _is_user_and_company_enabled(user, companies.get(user.company))
-        }
+        # build users one by one, so an invalid one doesn't fail the whole lookup
+        users: dict[ObjectId, UserResourceModel] = {}
+        for user_dict in await users_cursor.to_list_raw():
+            try:
+                user = UserResourceModel.from_dict(user_dict)
+            except Exception:
+                logger.warning("Skipping invalid user %s", user_dict.get("_id"), exc_info=True)
+                continue
+
+            if _is_user_and_company_enabled(user, companies.get(user.company)):
+                users[user.id] = user
+
+        return users
 
     if not use_globals or not is_from_request():
         return await _get_users()

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -95,7 +95,6 @@ async def test_delete_notification(client, service):
 
     await login_public(client)
     resp = await client.get(USER_NOTIFICATIONS_URL)
-    print(await resp.get_data(as_text=True))
     data = json.loads(await resp.get_data())
     notify_id = data["notifications"][0]["_id"]
 
@@ -157,3 +156,6 @@ async def test_notifications_without_an_item_are_not_returned(client, service):
 
     assert 1 == len(data["notifications"])
     assert WIRE_ITEM_ID == data["notifications"][0]["item"]
+
+    # the orphan is dropped, so it stops inflating the notification count
+    assert 1 == len(await get_user_notifications(PUBLIC_USER_ID))

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -1,18 +1,20 @@
 import datetime
 
 from quart import json
-from bson import ObjectId
 from pytest import fixture
 
 from superdesk.utc import utcnow
 
 from newsroom.notifications import get_user_notifications, NotificationsService
 from ..fixtures import PUBLIC_USER_ID, TEST_USER_ID
+from tests.core.utils import create_entries_for
 from tests.utils import login_public
 
-TEST_ITEM_ID = ObjectId()
+WIRE_ITEM_ID = "urn:newsml:localhost:wire-item"
+SECOND_WIRE_ITEM_ID = "urn:newsml:localhost:second-wire-item"
+DELETED_ITEM_ID = "urn:newsml:localhost:deleted-item"
 TEST_USER = str(PUBLIC_USER_ID)
-TEST_NOTIFICATION = {"item": TEST_ITEM_ID, "user": TEST_USER, "resource": "test-resource", "action": "test-action"}
+TEST_NOTIFICATION = {"item": WIRE_ITEM_ID, "user": TEST_USER, "resource": "test-resource", "action": "test-action"}
 USER_NOTIFICATIONS_URL = f"users/{TEST_USER}/notifications"
 
 
@@ -21,13 +23,29 @@ def service() -> NotificationsService:
     return NotificationsService()
 
 
+async def create_items_for(*item_ids):
+    """Notifications are only returned when their item can be found."""
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": item_id,
+                "type": "text",
+                "headline": "Test item",
+                "versioncreated": utcnow(),
+            }
+            for item_id in item_ids
+        ],
+    )
+
+
 async def test_notification_has_unique_id(service, app):
     app.config["NOTIFICATIONS_TTL"] = 1
     await service.create_or_update([TEST_NOTIFICATION])
 
     notifications = await get_user_notifications(PUBLIC_USER_ID)
     assert len(notifications) == 1
-    assert notifications[0]["_id"] == f"{TEST_USER}_{TEST_ITEM_ID}"
+    assert notifications[0]["_id"] == f"{TEST_USER}_{WIRE_ITEM_ID}"
 
 
 async def test_notification_updates_with_unique_id(app, service):
@@ -35,13 +53,13 @@ async def test_notification_updates_with_unique_id(app, service):
     await service.create_or_update([TEST_NOTIFICATION])
 
     # update the existing notification with an older created date
-    test_notification_id = f"{TEST_USER}_{TEST_ITEM_ID}"
+    test_notification_id = f"{TEST_USER}_{WIRE_ITEM_ID}"
     updates = dict(_created=utcnow() - datetime.timedelta(hours=1))
     await service.update(test_notification_id, updates)
     user_notifications = await get_user_notifications(PUBLIC_USER_ID)
 
     assert len(user_notifications) == 1
-    assert user_notifications[0]["_id"] == f"{TEST_USER}_{TEST_ITEM_ID}"
+    assert user_notifications[0]["_id"] == f"{TEST_USER}_{WIRE_ITEM_ID}"
 
     app.config["NOTIFICATIONS_TTL"] = 1
     old_created = user_notifications[0]["_created"]
@@ -60,7 +78,7 @@ async def test_delete_notification_fails_for_different_user(client, service):
     async with client.session_transaction() as session:
         session["user"] = TEST_USER
 
-    test_notification_id = f"{TEST_USER}_{TEST_ITEM_ID}"
+    test_notification_id = f"{TEST_USER}_{WIRE_ITEM_ID}"
     await service.create_or_update([TEST_NOTIFICATION])
 
     async with client.session_transaction() as session:
@@ -72,6 +90,7 @@ async def test_delete_notification_fails_for_different_user(client, service):
 
 
 async def test_delete_notification(client, service):
+    await create_items_for(WIRE_ITEM_ID)
     await service.create_or_update([TEST_NOTIFICATION])
 
     await login_public(client)
@@ -89,11 +108,12 @@ async def test_delete_notification(client, service):
 
 
 async def test_delete_all_notifications(client, service):
+    await create_items_for(WIRE_ITEM_ID, SECOND_WIRE_ITEM_ID)
     await service.create_or_update(
         [
             TEST_NOTIFICATION,
             {
-                "item": ObjectId(),
+                "item": SECOND_WIRE_ITEM_ID,
                 "user": TEST_USER,
                 "resource": "test-resources",
                 "action": "test-action",
@@ -113,3 +133,27 @@ async def test_delete_all_notifications(client, service):
     resp = await client.get(USER_NOTIFICATIONS_URL)
     data = json.loads(await resp.get_data())
     assert 0 == len(data["notifications"])
+
+
+async def test_notifications_without_an_item_are_not_returned(client, service):
+    await create_items_for(WIRE_ITEM_ID)
+    await service.create_or_update(
+        [
+            TEST_NOTIFICATION,
+            {
+                "item": DELETED_ITEM_ID,
+                "user": TEST_USER,
+                "resource": "wire",
+                "action": "topic_matches",
+            },
+        ]
+    )
+
+    assert 2 == len(await get_user_notifications(PUBLIC_USER_ID))
+
+    await login_public(client)
+    resp = await client.get(USER_NOTIFICATIONS_URL)
+    data = json.loads(await resp.get_data())
+
+    assert 1 == len(data["notifications"])
+    assert WIRE_ITEM_ID == data["notifications"][0]["item"]

--- a/tests/core/test_realtime_notifications.py
+++ b/tests/core/test_realtime_notifications.py
@@ -428,3 +428,63 @@ async def test_pause_notifications(app, mocker, company_products):
         await notify_new_wire_item("item1")
         assert len(outbox) == 0
         push_mock.assert_not_called()
+
+
+@mock.patch("newsroom.email.send_email", mock_send_email)
+async def test_realtime_notifications_with_an_invalid_user(app, mocker, company_products):
+    user = await UsersService().find_by_id(PUBLIC_USER_ID)
+
+    await create_entries_for(
+        "topics",
+        [
+            {
+                "user": user.id,
+                "label": "Cheesy Stuff",
+                "query": "cheese",
+                "topic_type": "wire",
+                "subscribers": [
+                    {
+                        "user_id": user.id,
+                        "notification_type": "real-time",
+                    },
+                ],
+            },
+        ],
+    )
+
+    await create_entries_for(
+        "items",
+        [
+            {
+                "_id": "cheese_item",
+                "type": "text",
+                "slugline": "cheese",
+                "headline": "Demo Article",
+                "body_html": "Story that involves cheese",
+                "versioncreated": utcnow(),
+            },
+        ],
+    )
+
+    # an unrelated user that no longer passes validation, bypassing the service
+    result = await UsersService().mongo_async.update_one(
+        {"_id": ObjectId(ADMIN_USER_ID)}, {"$set": {"locale": "xx_XX"}}
+    )
+    assert result.modified_count == 1
+
+    broadcast_mock = mocker.patch("newsroom.push.notifications.push_notification")
+    count_mock = mocker.patch("newsroom.notifications.utils.push_notification")
+
+    await notify_new_wire_item("cheese_item")
+
+    # the item is still broadcast for the live Wire refresh
+    assert broadcast_mock.call_args_list[0][0][0] == "new_item"
+
+    # and the subscriber is still notified
+    count_mock.assert_called_once()
+    assert count_mock.call_args[0][0] == "new_notifications"
+
+    notification = await NotificationsService().find_one(user=user.id)
+    assert notification is not None
+    assert notification.item == "cheese_item"
+    assert notification.action == "topic_matches"

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,4 +1,6 @@
-from newsroom.utils import short_highlighted_text, get_groups
+from newsroom.users import UsersService
+from newsroom.utils import short_highlighted_text, get_groups, get_user_dict_async
+from newsroom.tests.fixtures import PUBLIC_USER_ID
 
 
 def test_short_highlighted_text():
@@ -113,3 +115,19 @@ def test_filter_groups():
 
     company["restrict_coverage_info"] = False
     assert len(get_groups(agenda_groups, company)) == 2
+
+
+async def test_get_user_dict_async_skips_invalid_user(app):
+    users = await get_user_dict_async(use_globals=False)
+
+    assert PUBLIC_USER_ID in users
+    user_count = len(users)
+    assert user_count > 1
+
+    # bypass the service so the invalid locale is not rejected on the way in
+    await UsersService().mongo_async.update_one({"_id": PUBLIC_USER_ID}, {"$set": {"locale": "xx_XX"}})
+
+    users = await get_user_dict_async(use_globals=False)
+
+    assert PUBLIC_USER_ID not in users
+    assert len(users) == user_count - 1


### PR DESCRIPTION
### Purpose
This PR fixes the in-app notification icon disappearing when clicked, and notifications/live updates not firing at all in some cases. Clicking the icon crashed on a notification whose item could no longer be loaded because React unmounted the whole notification root instead of just that one row. Also, a single user with an invalid `locale` broke `get_user_dict_async`, which `notify_new_item` swallowed and returned early from, causing some items to never be notified and only appear after revisiting Wire/Agenda.

### What has changed
- Notifications without a resolvable item are no longer returned, and `NotificationListItem` guards against a missing one
- New `ErrorBoundary` wraps the notification popup
- Empty `locale` is treated as unset, and users are built one by one so an invalid one is skipped rather than it being fatal
- `new_item` broadcast moved before the user lookup, so live updates survive a failure there
- Added tests

### Steps to test

1. Create a notification whose item does not exist (or delete the item it points at), then click the notification icon. Observe the notification is not listed, and the icon stays on screen
2. Post a matching story from Superdesk and observe:
   - the notification icon shows a count
   - Wire refreshes live, without revisiting the page
   - an invalid user is skipped with a warning log


Resolves: #[STT-1718](https://sofab.atlassian.net/browse/STT-1718)


[STT-1718]: https://sofab.atlassian.net/browse/STT-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ