### PR TITLE
SDAN-770 Add slugline to the Content Activity Report

### DIFF
--- a/assets/company-reports/components/ContentActivity.tsx
+++ b/assets/company-reports/components/ContentActivity.tsx
@@ -23,6 +23,7 @@ interface IResultItem {
     _id: string;
     versioncreated: string;
     headline: string;
+    slugline: string;
     anpa_take_key: string;
     source: string;
     place: Array<{name: string}>;
@@ -56,6 +57,7 @@ class ContentActivity extends React.Component<IProps, any> {
         const headers = [
             gettext('Published'),
             gettext('Headline'),
+            gettext('Slugline'),
             gettext('Take Key'),
             gettext('Place'),
             gettext('Category'),
@@ -121,6 +123,7 @@ class ContentActivity extends React.Component<IProps, any> {
                     <tr key={item._id}>
                         <td>{formatTime(item?.versioncreated || '')}</td>
                         <td>{item.headline || ''}</td>
+                        <td>{item.slugline || ''}</td>
                         <td>{item.anpa_take_key || ''}</td>
                         <td>{this.renderNamesSorted(item?.place)}</td>
                         <td>{this.renderNamesSorted(item?.service)}</td>

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -336,10 +336,13 @@ label:not(.label--no-spacing) {
 .report-thead {
     position: sticky;
     inset-block-start: 0;
+    z-index: 10;
     th {
         position: sticky;
         inset-block-start: 0;
         border: none;
+        background-color: hsl(0, 0%, 96%);
+        z-index: 10;
     }
 }
 

--- a/newsroom/reports/content_activity.py
+++ b/newsroom/reports/content_activity.py
@@ -25,6 +25,7 @@ CHUNK_SIZE = 100
 
 async def get_query_source(args: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
     search_request = NewshubSearchRequest[BaseSearchRequestArgs](section=SectionEnum(args["section"]))
+    search_request.include_updated = True
     query = search_request.search.query
 
     if args.get("genre"):
@@ -75,6 +76,7 @@ async def get_items(args):
                 "subject",
                 "service",
                 "versioncreated",
+                "slugline",
                 "anpa_take_key",
                 "source",
             ],
@@ -209,6 +211,7 @@ def export_csv(args, results):
         [
             gettext("Published"),
             gettext("Headline"),
+            gettext("Slugline"),
             gettext("Take Key"),
             gettext("Place"),
             gettext("Category"),
@@ -260,6 +263,7 @@ def export_csv(args, results):
         row = [
             utc_to_local("Australia/Sydney", item.get("versioncreated")).strftime("%H:%M"),
             item.get("headline"),
+            item.get("slugline"),
             item.get("anpa_take_key") or "",
             "\r\n".join(sorted([place.get("name") or "" for place in item.get("place") or []])),
             "\r\n".join(sorted([service.get("name") or "" for service in item.get("service") or []])),

--- a/tests/core/test_reports.py
+++ b/tests/core/test_reports.py
@@ -3,7 +3,8 @@ from pytest import fixture
 from bson import ObjectId
 from datetime import datetime, timedelta
 from newsroom.tests.fixtures import COMPANY_1_ID
-from tests.core.utils import create_entries_for
+from tests.core.utils import create_entries_for, update_entries_for
+from ..fixtures import items
 
 
 @fixture(autouse=True)
@@ -210,6 +211,23 @@ async def test_companies(client):
 
 async def test_content_activity_csv(client):
     today = datetime.now().date()
+
+    for item in items:
+        if item.get("_id") == "tag:weather":
+            await update_entries_for(
+                "items",
+                item["_id"],
+                {"versioncreated": datetime.now() + timedelta(minutes=1), "headline": "New weather"},
+                item,
+            )
+        if item.get("_id") == "tag:weather:old":
+            await update_entries_for(
+                "items",
+                item["_id"],
+                {"versioncreated": datetime.now() + timedelta(minutes=2), "headline": "Old weather"},
+                item,
+            )
+
     resp = await client.get(
         "reports/export/content-activity?export=true&date_from={}&date_to={}".format(
             today.isoformat(), today.isoformat()
@@ -227,3 +245,5 @@ async def test_content_activity_csv(client):
     values = lines[1].split(",")
     assert "Amazon Is Opening More Bookstores" == values[1]
     assert "0" == values[-1]
+    assert "New weather" == lines[2].split(",")[1]
+    assert "Old weather" == lines[3].split(",")[1]


### PR DESCRIPTION
### Purpose
Add the "Slugline" to the Content Activity report and include all versions of the stories to enable analysis of which versions of the stories the clients are interacting with.

### What has changed
All versions are included in the report along with the slugline. Also a style change to stop the content overwriting the column headers on scrolling the report.

### Steps to test
Interact with some content and generate a Content Activity report and ensure that the Slugline is visible.

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is not adding new forms that use redux
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: SDAN-770
