### PR TITLE
tweak email monitoring config

### DIFF
--- a/newsroom/web/default_settings.py
+++ b/newsroom/web/default_settings.py
@@ -220,6 +220,12 @@ MAIL_DEFAULT_SENDER = _MAIL_FROM or "newsroom@localhost"
 SIGNUP_EMAIL_RECIPIENTS = os.environ.get("SIGNUP_EMAIL_RECIPIENTS")
 # Recipients for the periodic email delivery monitor (single or comma separated)
 EMAIL_DELIVERY_MONITOR_RECIPIENTS = os.environ.get("NEWSROOM_EMAIL_DELIVERY_MONITOR_RECIPIENTS")
+# Runs email delivery monitor every N minutes
+EMAIL_DELIVERY_MONITOR_CRON_MINUTES = max(1, int(os.environ.get("NEWSROOM_EMAIL_DELIVERY_MONITOR_CRON_MINUTES", "15")))
+# If the task runs later than this window (seconds), drop it
+EMAIL_DELIVERY_MONITOR_EXPIRES = int(
+    os.environ.get("NEWSROOM_EMAIL_DELIVERY_MONITOR_EXPIRES") or (EMAIL_DELIVERY_MONITOR_CRON_MINUTES * 60 - 1)
+)
 
 #: public client url - used to create links within emails etc
 CLIENT_URL = os.environ.get("CLIENT_URL", "http://localhost:5050")
@@ -467,11 +473,17 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": timedelta(seconds=60),
         "options": {"expires": 59},  # if the task is not executed within 59 seconds, it will be discarded
     },
-    "newsroom:email_delivery_monitor": {
-        "task": "newsroom.email_delivery_monitor.email_delivery_monitor",
-        "schedule": crontab(minute="*/5"),
-        "options": {"expires": 5 * 60 - 1},
-    },
+    **(
+        {
+            "newsroom:email_delivery_monitor": {
+                "task": "newsroom.email_delivery_monitor.email_delivery_monitor",
+                "schedule": crontab(minute=f"*/{EMAIL_DELIVERY_MONITOR_CRON_MINUTES}"),
+                "options": {"expires": EMAIL_DELIVERY_MONITOR_EXPIRES},
+            }
+        }
+        if EMAIL_DELIVERY_MONITOR_RECIPIENTS
+        else {}
+    ),
     "newsroom:remove_expired_content_api": {
         "task": "content_api.commands.item_expiry",
         "schedule": crontab(hour=local_to_utc_hour(2), minute=0),  # Runs every day at 2am


### PR DESCRIPTION
send it every 15m by default and only register
the cron job when recipients are set.

NHUB-633

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is not adding new forms that use redux
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is replacing `lodash.get` with optional chaining for modified code segments

Resolves: #[issue-number]
