### PR TITLE
[STT-1726] - show/hide indicator for agenda list items works incorrectly

### DIFF
--- a/assets/agenda/components/AgendaListGroupHeader.tsx
+++ b/assets/agenda/components/AgendaListGroupHeader.tsx
@@ -18,36 +18,32 @@ interface IProps {
 
 export function AgendaListGroupHeader({group, itemIds, itemsById, itemsShown, toggleHideItems}: IProps) {
     const coverageTypeCount: {[coverageType: string]: number} = {};
-    let itemCount = 0;
 
-    // Filter out Events/Planning that meet the following criteria
-    // * Events with no planning items
-    // * Events or Planning, no coverages at all
-    // * Events or Planning, coverages fall on `group` date
-    for (let itemIndex = 0; itemIndex < itemIds.length; ++itemIndex) {
-        const item = itemsById[itemIds[itemIndex]];
+    // The coverage summary is only rendered while the group is collapsed, so
+    // skip the scan entirely once the items are shown.
+    if (!itemsShown) {
+        // Filter out Events/Planning that meet the following criteria
+        // * Events with no planning items
+        // * Events or Planning, no coverages at all
+        // * Events or Planning, coverages fall on `group` date
+        for (let itemIndex = 0; itemIndex < itemIds.length; ++itemIndex) {
+            const item = itemsById[itemIds[itemIndex]];
 
-        if (item.coverages == null || item.coverages.length === 0) {
-            itemCount += 1;
-            continue;
-        }
-
-        let coverageAdded = false;
-        for (let coverageIndex = 0; coverageIndex < item.coverages.length; ++coverageIndex) {
-            const coverage = item.coverages[coverageIndex];
-
-            if (formatDate(moment(coverage.scheduled)) !== group) {
+            if (item.coverages == null || item.coverages.length === 0) {
                 continue;
-            } else if (coverageTypeCount[coverage.coverage_type] == null) {
-                coverageTypeCount[coverage.coverage_type] = 0;
-                coverageAdded = true;
             }
 
-            coverageTypeCount[coverage.coverage_type] += 1;
-        }
+            for (let coverageIndex = 0; coverageIndex < item.coverages.length; ++coverageIndex) {
+                const coverage = item.coverages[coverageIndex];
 
-        if (coverageAdded) {
-            itemCount += 1;
+                if (formatDate(moment(coverage.scheduled)) !== group) {
+                    continue;
+                } else if (coverageTypeCount[coverage.coverage_type] == null) {
+                    coverageTypeCount[coverage.coverage_type] = 0;
+                }
+
+                coverageTypeCount[coverage.coverage_type] += 1;
+            }
         }
     }
 

--- a/assets/agenda/components/AgendaListGroupHeader.tsx
+++ b/assets/agenda/components/AgendaListGroupHeader.tsx
@@ -55,28 +55,26 @@ export function AgendaListGroupHeader({group, itemIds, itemsById, itemsShown, to
 
     return (
         <div className="list-group-header">
-            <span className="badge rounded-pill badge--neutral">{itemIds.length}</span>
-            {coverageTypes.length === 0 ? (
-                <div className="list-group-header__title">
-                    {gettext('More hidden')}
-                </div>
-            ) : (
+            {!itemsShown && (
                 <React.Fragment>
+                    <span className="badge rounded-pill badge--neutral">{itemIds.length}</span>
                     <div className="list-group-header__title">
                         {gettext('More hidden')}
                     </div>
-                    <div className="list-group-header__coverage-group">
-                        {coverageTypes.map((coverageType) => (
-                            <div key={coverageType} className="list-group-header__coverage-item">
-                                <span className="wire-articles__item__icon" title="Some title">
-                                    <i className={`icon--coverage-${getCoverageIcon(coverageType)}`} />
-                                </span>
-                                <span className="list-group-header__coverage-number">
-                                    {coverageTypeCount[coverageType]}
-                                </span>
-                            </div>
-                        ))}
-                    </div>
+                    {coverageTypes.length === 0 ? null : (
+                        <div className="list-group-header__coverage-group">
+                            {coverageTypes.map((coverageType) => (
+                                <div key={coverageType} className="list-group-header__coverage-item">
+                                    <span className="wire-articles__item__icon" title="Some title">
+                                        <i className={`icon--coverage-${getCoverageIcon(coverageType)}`} />
+                                    </span>
+                                    <span className="list-group-header__coverage-number">
+                                        {coverageTypeCount[coverageType]}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </React.Fragment>
             )}
             <div className="list-group-header__actions">

--- a/assets/agenda/tests/AgendaListGroupHeader.spec.tsx
+++ b/assets/agenda/tests/AgendaListGroupHeader.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import moment from 'moment';
+import {mount} from 'enzyme';
+
+import {formatDate} from 'utils';
+import {AgendaListGroupHeader} from '../components/AgendaListGroupHeader';
+
+import 'tests/setup';
+
+function setup(props: any) {
+    return mount(
+        <AgendaListGroupHeader
+            group={props.group}
+            itemIds={props.itemIds}
+            itemsById={props.itemsById}
+            itemsShown={props.itemsShown}
+            toggleHideItems={props.toggleHideItems ?? (() => undefined)}
+        />
+    );
+}
+
+describe('AgendaListGroupHeader', () => {
+    const group = '01-08-2026';
+    const itemsById = {a: {_id: 'a'}, b: {_id: 'b'}};
+    const itemIds = ['a', 'b'];
+
+    describe('when the group is collapsed (itemsShown=false)', () => {
+        it('renders the hidden indicator and a "Show all" button', () => {
+            const wrapper = setup({group, itemIds, itemsById, itemsShown: false});
+
+            expect(wrapper.find('span.badge').text()).toBe('2');
+            expect(wrapper.find('.list-group-header__title').text()).toBe('More hidden');
+            expect(wrapper.find('.list-group-header__actions button').text()).toBe('Show all');
+        });
+    });
+
+    describe('when the group is expanded (itemsShown=true)', () => {
+        it('hides the indicator, leaving only the "Hide" button', () => {
+            const wrapper = setup({group, itemIds, itemsById, itemsShown: true});
+
+            // STT-1726: the "N More hidden" indicator must be gone once shown
+            expect(wrapper.find('span.badge').length).toBe(0);
+            expect(wrapper.find('.list-group-header__title').length).toBe(0);
+            expect(wrapper.find('.list-group-header__actions button').text()).toBe('Hide');
+        });
+    });
+
+    describe('with coverages scheduled on the group date', () => {
+        const scheduled = '2026-08-05T12:00:00';
+        const covGroup = formatDate(moment(scheduled));
+        const covItemsById = {
+            e: {_id: 'e', coverages: [{coverage_id: 'c1', coverage_type: 'text', scheduled}]},
+        };
+
+        it('renders coverage icons while collapsed', () => {
+            const wrapper = setup({group: covGroup, itemIds: ['e'], itemsById: covItemsById, itemsShown: false});
+
+            expect(wrapper.find('.list-group-header__coverage-item').length).toBe(1);
+        });
+
+        it('hides coverage icons once expanded', () => {
+            const wrapper = setup({group: covGroup, itemIds: ['e'], itemsById: covItemsById, itemsShown: true});
+
+            expect(wrapper.find('.list-group-header__coverage-item').length).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
### Purpose
When an agenda day-group has hidden (multi-day) items and the user presses **Show all**, the "N More hidden" indicator stays on screen even though the items are now expanded. It should only be present while the items are hidden.

### What has changed
- Gated the whole hidden indicator (count badge, "More hidden" label, and coverage icons) in `AgendaListGroupHeader` on `!itemsShown`, so once a group is expanded only the **Hide** button remains
- Added tests

### Steps to test
1. Have an agenda list with a multi-day event, so a day-group shows the "N More hidden" indicator and a **Show all** button
2. Press **Show all** and observe:
   - the hidden items expand into the list
   - the badge, "More hidden" label and coverage icons disappear, leaving only the **Hide** button
3. Press **Hide** and observe the indicator returns

Resolves: #[STT-1726](https://sofab.atlassian.net/browse/STT-1726)

[STT-1726]: https://sofab.atlassian.net/browse/STT-1726
